### PR TITLE
VID-1988 Replaced bad metacafe video with good one

### DIFF
--- a/src/test/java/com/wikia/webdriver/Common/DataProvider/VideoUrlProvider.java
+++ b/src/test/java/com/wikia/webdriver/Common/DataProvider/VideoUrlProvider.java
@@ -43,8 +43,8 @@ public class VideoUrlProvider {
 				"http://www.hulu.com/watch/489169",
 				"The Unnatural (Bob's Burgers)"
 			}, {
-				"http://www.metacafe.com/watch/10534054/fast_furious_6_favourite_stunts/",
-				"Fast Furious 6 Favourite Stunts"
+				"http://www.metacafe.com/watch/10859228/epic_tetris_algorithm_savor_meets_alien_love_on_tagged_node/",
+				"Epic Tetris Algorithm Savor Meets Alien Love on Tagged - NODE"
 			}, {
 				"http://www.myvideo.de/watch/9112478/Snowblind",
 				"Snowblind"


### PR DESCRIPTION
Old metacafe video URL was for a video that no longer exists on metacafe.  Swapped in a new one.

https://wikia-inc.atlassian.net/browse/VID-1988
