### PR TITLE
QAART-418 Disabling auto scroll to frame in Firefox

### DIFF
--- a/src/test/java/com/wikia/webdriver/Common/DriverProvider/NewDriverProvider.java
+++ b/src/test/java/com/wikia/webdriver/Common/DriverProvider/NewDriverProvider.java
@@ -157,6 +157,8 @@ public class NewDriverProvider {
 		}
 
 		caps.setCapability(FirefoxDriver.PROFILE, firefoxProfile);
+		//Disable auto-scroll to frames
+		caps.setCapability("elementScrollBehavior", 1);
 		return new EventFiringWebDriver(new FirefoxDriver(caps));
 	}
 


### PR DESCRIPTION
Auto-scroll to frame is causing Web driver + OS specific fail on Jenkins.
https://wikia-inc.atlassian.net/browse/QAART-418
Known issue for Selenium:
https://code.google.com/p/selenium/issues/detail?id=6458
