### PR TITLE
QAART-368 Fixing the issue that switching frame causing a run time error

### DIFF
--- a/src/test/java/com/wikia/webdriver/PageObjectsFactory/ComponentObject/MiniEditor/MiniEditorComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/PageObjectsFactory/ComponentObject/MiniEditor/MiniEditorComponentObject.java
@@ -53,6 +53,8 @@ public class MiniEditorComponentObject extends WikiBasePageObject{
 	private WebElement linkExistsIcon;
 	@FindBy (css="[id*='_uiElement'] .external")
 	private WebElement linkExternalIcon;
+	@FindBy (css=".MiniEditorWrapper.active.editor-open")
+	private WebElement miniEditorWrapper;
 
 	public void writeMiniEditor(String text){
 		waitForElementByElement(messageBodyField);
@@ -167,9 +169,12 @@ public class MiniEditorComponentObject extends WikiBasePageObject{
 	}
 
 	public void switchAndQuoteMessageWall(String reply) {
+		waitForElementByElement(miniEditorWrapper);
+		quoteMessageWallFrame = miniEditorWrapper.findElement(By.cssSelector(".cke_contents iframe"));
 		driver.switchTo().frame(quoteMessageWallFrame);
-		driver.findElement(By.cssSelector("body#bodyContent")).clear();
-		driver.findElement(By.cssSelector("body#bodyContent")).sendKeys(reply);
+		WebElement quoteMessageTextArea = driver.findElement(By.cssSelector("body#bodyContent"));
+		quoteMessageTextArea.clear();
+		quoteMessageTextArea.sendKeys(reply);
 		PageObjectLogging.log("switchAndQuoteMessageWall", "quote typed", true);
 	}
 }


### PR DESCRIPTION
The test was switching an iFrame before it is ready. The solution is to wait for the wrapper to appear first before  locating and switching to the iFrame which is the child of the wrapper.

https://wikia-inc.atlassian.net/browse/QAART-368
