### PR TITLE
removing timestamp from asserted video name

### DIFF
--- a/src/test/java/com/wikia/webdriver/Common/DataProvider/VideoUrlProvider.java
+++ b/src/test/java/com/wikia/webdriver/Common/DataProvider/VideoUrlProvider.java
@@ -32,7 +32,7 @@ public class VideoUrlProvider {
 			// Non-Premium Provider Links
 			{
 				"http://blip.tv/q-tv/ken-jeong-in-studio-q-6609739",
-				"Q on CBC - Ken Jeong in Studio Q-1414748287"
+				"Q on CBC - Ken Jeong in Studio Q-"
 			}, {
 				"http://www.dailymotion.com/video/x101vdw_robert-pattison-y-kristen-stewart-se-dan-un-tiempo_people#.UZovsrWnqXw",
 				"Robert Pattison y Kristen Stewart se dan un tiempo"


### PR DESCRIPTION
VetProvidersTest for blip.tv always failed because it contained a timestamp in the assertion video name. After this quick fix it won't fail anymore
