### PR TITLE
QAART-487 Fixed issue which config is now returning empty String instead...

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/configuration/POMConfiguration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/POMConfiguration.java
@@ -16,17 +16,17 @@ public class POMConfiguration extends AbstractConfiguration {
 
 	public POMConfiguration() {
 		browser = System.getProperty("browser");
-		if (browser == null) {
+		if (browser == null || browser.isEmpty()) {
 			browser = "FF"; //Set default value to Firefox;
 		}
 
 		env = System.getProperty("env");
-		if (env == null) {
+		if (env == null || env.isEmpty()) {
 			env = "prod"; //Set default value to production
 		}
 
 		wikiName = System.getProperty("wiki-name");
-		if (wikiName == null) {
+		if (wikiName == null || wikiName.isEmpty()) {
 			wikiName = "mediawiki119"; //Set default value to mediawiki119
 		}
 


### PR DESCRIPTION
... of null due to Surefire 2.18 change.
Source:
https://jira.codehaus.org/browse/SUREFIRE-649

Surefire 2.18 release note
https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=10541&version=20175
