### PR TITLE
MON-geo

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
@@ -45,6 +45,7 @@ public class URLsContent {
 	public static final String USER_MESSAGE_WALL = "wiki/Message_Wall:";
 	public static final String SPECIAL_MULTI_WIKI_FINDER = "wiki/Special:Multiwikifinder";
 	public static final String LOGOUT = "wiki/Special:UserLogout?noexternals=1";
+	public static final String LOGOUT_RETURNTO = "wiki/Special:UserLogout?returnto=";
 	public static final String SPECIAL_UNDELETE = "wiki/Special:Undelete";
 	public static final String USER_PROFILE = "wiki/User:%userName%";
 	public static final String SPECIAL_CREATE_NEW_WIKI = "Special:CreateNewWiki";

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -47,23 +47,19 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.videohomepage.VideoHome
 import com.wikia.webdriver.pageobjectsfactory.pageobject.visualeditor.VisualEditorPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.wikipage.WikiHistoryPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.wikipage.blog.BlogPageObject;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.ParseException;
+import org.apache.http.*;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultBackoffStrategy;
-import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openqa.selenium.*;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -77,14 +73,8 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -808,7 +798,7 @@ public class WikiBasePageObject extends BasePageObject {
 	public void logOut(WebDriver driver) {
 		try {
 			driver.manage().deleteAllCookies();
-			driver.get(Global.DOMAIN + "wiki/Special:UserLogout?noexternals=1");
+			driver.get(Global.DOMAIN + URLsContent.LOGOUT);
 		} catch (TimeoutException e) {
 			PageObjectLogging.log("logOut",
 				"page loads for more than 30 seconds", true);
@@ -827,6 +817,17 @@ public class WikiBasePageObject extends BasePageObject {
 		}
 		waitForElementPresenceByBy(LOGIN_BUTTON_CSS);
 		PageObjectLogging.log("logOut", "user is logged out", true, driver);
+	}
+
+	public void logOut(String wikiURL, String articleName) {
+		try {
+			getUrl(wikiURL + URLsContent.LOGOUT_RETURNTO + articleName);
+		} catch (TimeoutException e) {
+			PageObjectLogging.log("logOut",
+				"page loads for more than 30 seconds", true);
+		}
+		waitForElementPresenceByBy(LOGIN_BUTTON_CSS);
+		PageObjectLogging.log("logOut", "user is logged out and returned to article", true, driver);
 	}
 
 	public String logInCookie(String userName, String password, String wikiURL) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -62,7 +62,6 @@ import org.openqa.selenium.*;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -803,8 +802,7 @@ public class WikiBasePageObject extends BasePageObject {
 			PageObjectLogging.log("logOut",
 				"page loads for more than 30 seconds", true);
 		}
-		wait.until(ExpectedConditions.visibilityOfElementLocated(By
-			.cssSelector("a[data-id='login']")));
+		waitForElementPresenceByBy(LOGIN_BUTTON_CSS);
 		PageObjectLogging.log("logOut", "user is logged out", true, driver);
 	}
 

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -147,8 +147,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyAdsenseUnitNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		monetizationModule.logOut(wikiURL, TEST_ARTICLE);
 		monetizationModule.verifyAdsenseUnitShown();
 	}
 
@@ -174,8 +173,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyAdsenseUnitNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		monetizationModule.logOut(wikiURL, TEST_ARTICLE);
 		monetizationModule.verifyAdsenseUnitNotShown();
 	}
 
@@ -220,8 +218,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		monetizationModule.logOut(wikiURL, testArticle);
 		monetizationModule.verifyMonetizationModuleNotShown();
 	}
 
@@ -287,8 +284,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		monetizationModule.logOut(wikiURL, testArticle);
 		monetizationModule.verifyMonetizationModuleNotShown();
 	}
 
@@ -333,8 +329,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		monetizationModule.logOut(wikiURL, TEST_TOP_100_ARTICLE);
 		monetizationModule.verifyMonetizationModuleNotShown();
 	}
 

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -216,7 +216,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.refreshPage();
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// logged in user
-		base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+		base.logInCookie(credentials.userName2, credentials.password2, wikiURL);
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
@@ -254,7 +254,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.refreshPage();
 		monetizationModule.verifyMonetizationModuleShown();
 		// logged in user
-		base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+		base.logInCookie(credentials.userName, credentials.password, wikiURL);
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
@@ -330,7 +330,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.refreshPage();
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// logged in user
-		base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+		base.logInCookie(credentials.userName4, credentials.password4, wikiURL);
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -259,7 +259,6 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
 		monetizationModule.logOut(wikiURL, testArticle);
-		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleShown();
 	}
 

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -248,7 +248,6 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		WikiBasePageObject base = new WikiBasePageObject(driver);
 		base.openWikiPage(articleURL);
 		MonetizationModuleComponentObject monetizationModule = new MonetizationModuleComponentObject(driver);
-		monetizationModule.deleteCookieFromSearch();
 		monetizationModule.setCookieFromSearch();
 		monetizationModule.setCookieGeo(TEST_COUNTRY_CODE);
 		// anon user
@@ -259,8 +258,8 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
-		base.logOut(wikiURL);
-		base.openArticleByName(wikiURL, testArticle);
+		monetizationModule.logOut(wikiURL, testArticle);
+		base.openWikiPage(articleURL);
 		monetizationModule.verifyMonetizationModuleShown();
 	}
 

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -248,6 +248,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		WikiBasePageObject base = new WikiBasePageObject(driver);
 		base.openWikiPage(articleURL);
 		MonetizationModuleComponentObject monetizationModule = new MonetizationModuleComponentObject(driver);
+		monetizationModule.deleteCookieFromSearch();
 		monetizationModule.setCookieFromSearch();
 		monetizationModule.setCookieGeo(TEST_COUNTRY_CODE);
 		// anon user

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -259,7 +259,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
 		monetizationModule.verifyMonetizationModuleNotShown();
 		// anon user
 		base.logOut(wikiURL);
-		base.openWikiPage(articleURL);
+		base.openArticleByName(wikiURL, testArticle);
 		monetizationModule.verifyMonetizationModuleShown();
 	}
 


### PR DESCRIPTION
This PR is address two issues are causing MonetizationModuleTest_008-011 to fail.
1) The tests are using the same account, which would cause an early session termination when 1 test is logged in and another test is logging in under the same account.
The solution is to use different accounts for tests that are running in parallel on Jenkins.

2) There is a cached issue with session that even when an user goes to Special:UserLogout page, the session is still logged in when navigate back to the article page. https://wikia-inc.atlassian.net/browse/SOC-233.
The solution is to use Special:UserLogout?returnto=<article> so the test would have a valid anon state on the particular article