### PR TITLE
QAART-517: Avoided reusing method parameter

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/Assertion.java
+++ b/src/test/java/com/wikia/webdriver/common/core/Assertion.java
@@ -121,11 +121,12 @@ public class Assertion extends Assert {
    * @rerturn String pattern - with characters entities
    */
   private static String encodeSpecialChars(String pattern) {
+    String encodedPattern = null;
     if (pattern.contains("<") || pattern.contains(">")) {
       String tmp = pattern.replaceAll("<", "&lt");
-      pattern = tmp.replaceAll(">", "&gt");
+      encodedPattern = tmp.replaceAll(">", "&gt");
     }
-    return pattern;
+    return encodedPattern;
   }
 
   public static void assertStringNotEmpty(String current) {

--- a/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
+++ b/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
@@ -110,8 +110,9 @@ public class MailFunctions {
     }
   }
 
-  public static String getActivationLinkFromEmailContent(String content) {
-    content = content.replace("=", ""); //mail content contain '=' chars, which has to be removed
+  public static String getActivationLinkFromEmailContent(String mailContent) {
+    //mail content contain '=' chars, which has to be removed
+    String content = mailContent.replace("=", "");
     Pattern
         p =
         Pattern.compile(
@@ -126,8 +127,8 @@ public class MailFunctions {
     }
   }
 
-  public static String getPasswordFromEmailContent(String content) {
-    content = content.replace("\"", "\n");
+  public static String getPasswordFromEmailContent(String mailContent) {
+    String content = mailContent.replace("\"", "\n");
     String[] lines = content.split("\n");
     return lines[1];
   }

--- a/src/test/java/com/wikia/webdriver/common/core/imageutilities/ImageEditor.java
+++ b/src/test/java/com/wikia/webdriver/common/core/imageutilities/ImageEditor.java
@@ -23,11 +23,12 @@ public class ImageEditor {
   public void saveImageFile(File imageFile, String path) {
     Pattern pattern = Pattern.compile("/*.jpg|/*.png|/*.jpeg");
     Matcher matcher = pattern.matcher(path);
+    String newPath = null;
     if (!matcher.matches()) {
-      path += ".png";
+      newPath = path + ".png";
     }
     try {
-      FileUtils.copyFile(imageFile, new File(path));
+      FileUtils.copyFile(imageFile, new File(newPath));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/wikia/webdriver/common/core/urlbuilder/UrlBuilder.java
+++ b/src/test/java/com/wikia/webdriver/common/core/urlbuilder/UrlBuilder.java
@@ -25,9 +25,10 @@ public class UrlBuilder {
     return url;
   }
 
-  public String getUrlForWiki(String wikiName) {
+  public String getUrlForWiki(String inputWikiName) {
     String prefix;
     String suffix;
+    String wikiName = inputWikiName;
     isWikia = wikiName.endsWith("wikia");
     String url = "http://";
 

--- a/src/test/java/com/wikia/webdriver/common/logging/PageObjectLogging.java
+++ b/src/test/java/com/wikia/webdriver/common/logging/PageObjectLogging.java
@@ -70,17 +70,17 @@ public class PageObjectLogging extends AbstractWebDriverEventListener implements
 
   private static void log(String command, String description, boolean success,
                           boolean ifLowLevel) {
-    description = escapeHtml(description);
+    String escapedDescription = escapeHtml(description);
 
     String className = success ? "success" : "error";
     StringBuilder builder = new StringBuilder();
     if (ifLowLevel) {
       builder.append("<tr class=\"" + className + " lowLevelAction"
-                     + "\"><td>" + command + "</td><td>" + description
+                     + "\"><td>" + command + "</td><td>" + escapedDescription
                      + "</td><td> <br/> &nbsp;</td></tr>");
     } else {
       builder.append("<tr class=\"" + className + "\"><td>" + command
-                     + "</td><td>" + description
+                     + "</td><td>" + escapedDescription
                      + "</td><td> <br/> &nbsp;</td></tr>");
     }
     CommonUtils.appendTextToFile(logPath, builder.toString());

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/InteractiveMapsMercuryComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/InteractiveMapsMercuryComponentObject.java
@@ -57,10 +57,9 @@ public class InteractiveMapsMercuryComponentObject extends MercuryBasePageObject
   }
 
   public void clickZoomIn(int amountOfClicks) {
-    while (amountOfClicks != 0) {
+    for (int i = amountOfClicks; i != 0; i--) {
       waitForElementClickableByElement(zoomInButton);
       tapOnElement(zoomInButton);
-      amountOfClicks--;
     }
     PageObjectLogging.log("clickZoomIn", "Zoom in button was clicked", true);
   }
@@ -73,10 +72,9 @@ public class InteractiveMapsMercuryComponentObject extends MercuryBasePageObject
 
 
   public void clickZoomOut(int amountOfClicks) {
-    while (amountOfClicks != 0) {
+    for (int i = amountOfClicks; i != 0; i--) {
       waitForElementClickableByElement(zoomOutButton);
       tapOnElement(zoomOutButton);
-      amountOfClicks--;
     }
     PageObjectLogging.log("clickZoomOut", "Zoom out button was clicked", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/LightBoxMercuryComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/LightBoxMercuryComponentObject.java
@@ -101,6 +101,7 @@ public class LightBoxMercuryComponentObject extends MercuryBasePageObject {
 
   public void verifySwiping(PerformTouchAction touchAction, String direction, int attempts) {
     String currentImageSrc = getCurrentImagePath();
+    String swipeDirection = direction;
     String nextImageSrc;
     boolean imageChanged = false;
     int startX = 70;
@@ -108,12 +109,13 @@ public class LightBoxMercuryComponentObject extends MercuryBasePageObject {
     int duration = 300;
     int waitAfter = 5000;
     int centerY = 50;
-    if ("right".equals(direction)) {
+
+    if ("right".equals(swipeDirection)) {
       int temp = startX;
       startX = endX;
       endX = temp;
     } else {
-      direction = "left";
+      swipeDirection = "left";
     }
     for (int i = 0; i < attempts; ++i) {
       touchAction.swipeFromPointToPoint(startX, centerY, endX, centerY, duration, waitAfter);
@@ -124,9 +126,10 @@ public class LightBoxMercuryComponentObject extends MercuryBasePageObject {
       }
     }
     if (imageChanged) {
-      PageObjectLogging.log("verifySwiping", "Swiping to " + direction + " works", true);
+      PageObjectLogging.log("verifySwiping", "Swiping to " + swipeDirection + " works", true);
     } else {
-      PageObjectLogging.log("verifySwiping", "Swiping to " + direction + " doesn't work", false);
+      PageObjectLogging
+          .log("verifySwiping", "Swiping to " + swipeDirection + " doesn't work", false);
     }
   }
 
@@ -182,22 +185,24 @@ public class LightBoxMercuryComponentObject extends MercuryBasePageObject {
 
   public void verifyTappingOnImageEdge(PerformTouchAction touchAction, String edge) {
     String currentImageSrc = getCurrentImagePath();
+    String imgEdge = edge;
     String nextImageSrc;
     int pointX = 25;
     int duration = 500;
     int waitAfter = 5000;
-    if ("right".equals(edge)) {
+    if ("right".equals(imgEdge)) {
       pointX = 75;
     } else {
-      edge = "left";
+      imgEdge = "left";
     }
     touchAction.tapOnPointXY(pointX, 50, duration, waitAfter);
     nextImageSrc = getCurrentImagePath();
     if (!nextImageSrc.contains(currentImageSrc)) {
-      PageObjectLogging.log("verifyTappingOnImageEdge", "Tapping on " + edge + " edge works", true);
+      PageObjectLogging
+          .log("verifyTappingOnImageEdge", "Tapping on " + imgEdge + " edge works", true);
     } else {
       PageObjectLogging
-          .log("verifyTappingOnImageEdge", "Tapping on " + edge + " edge doesn't work", false);
+          .log("verifyTappingOnImageEdge", "Tapping on " + imgEdge + " edge doesn't work", false);
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -386,11 +386,11 @@ public class AdsBaseObject extends WikiBasePageObject {
   }
 
   protected boolean isScriptPresentInElement(WebElement element, String scriptText) {
-    scriptText = scriptText.replaceAll("\\s", "");
+    String formattedScriptText = scriptText.replaceAll("\\s", "");
 
     for (WebElement scriptNode : element.findElements(By.tagName("script"))) {
       String result = scriptNode.getAttribute("innerHTML");
-      if (result.replaceAll("\\s", "").contains(scriptText)) {
+      if (result.replaceAll("\\s", "").contains(formattedScriptText)) {
         return true;
       }
     }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumPageObject.java
@@ -87,20 +87,20 @@ public class ForumPageObject extends WikiArticlePageObject {
   public ForumBoardPageObject openForumBoard(String forumBoardTitle) {
     int forumNumber = 0;
     List<String> forumNames = getForumNamesList();
-    forumBoardTitle = forumBoardTitle.replace("_", " ");
+    String formattedForumBoardTitle = forumBoardTitle.replace("_", " ");
     for (int i = 0; i < forumNames.size(); i++) {
-      if (forumNames.get(i).contains(forumBoardTitle)) {
+      if (forumNames.get(i).contains(formattedForumBoardTitle)) {
         forumNumber = i + 1;
       }
     }
     if (forumNumber == 0) {
       PageObjectLogging.log("openForumBoard",
-                            "didn't find forum Board with title " + forumBoardTitle,
+                            "didn't find forum Board with title " + formattedForumBoardTitle,
                             true, driver);
       return null;
     } else {
       PageObjectLogging.log("openForumBoard",
-                            "click on the forum Board with title " + forumBoardTitle,
+                            "click on the forum Board with title " + formattedForumBoardTitle,
                             true, driver);
       return openForumBoard();
     }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mercury/PerformTouchAction.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mercury/PerformTouchAction.java
@@ -223,12 +223,12 @@ public class PerformTouchAction {
   public void swipeFromPointToPoint(int startX, int startY, int endX, int endY, int duration,
                                     int waitAfter) {
     String methodName = "swipeFromPointToPoint";
-    startX = (int) ((startX / 100f) * appNativeWidth);
-    startY = (int) (((startY / 100f) * appNativeHeight) + taskbarNativeHeight);
-    endX = (int) ((endX / 100f) * appNativeWidth);
-    endY = (int) (((endY / 100f) * appNativeHeight) + taskbarNativeHeight);
+    int appStartX = (int) ((startX / 100f) * appNativeWidth);
+    int appStartY = (int) (((startY / 100f) * appNativeHeight) + taskbarNativeHeight);
+    int appEndX = (int) ((endX / 100f) * appNativeWidth);
+    int appEndY = (int) (((endY / 100f) * appNativeHeight) + taskbarNativeHeight);
     switchToContext(CONTEXT_NATIVE_APP, methodName);
-    mobileDriver.swipe(startX, startY, endX, endY, duration);
+    mobileDriver.swipe(appStartX, appStartY, appEndX, appEndY, duration);
     waitForFinish(waitAfter, methodName);
     switchToContext(CONTEXT_WEBVIEW_1, methodName);
   }
@@ -248,8 +248,8 @@ public class PerformTouchAction {
   public void zoomInOutPointXY(int pointX, int pointY, int fingersSpace, int pixelPath,
                                String zoomWay, int waitAfter) {
     String methodName = "zoomInOutPointXY";
-    pointX = (int) ((pointX / 100f) * appNativeWidth);
-    pointY = (int) (((pointY / 100f) * appNativeHeight) + taskbarNativeHeight);
+    int appPointX = (int) ((pointX / 100f) * appNativeWidth);
+    int appPointY = (int) (((pointY / 100f) * appNativeHeight) + taskbarNativeHeight);
     TouchAction touchOne = new TouchAction(mobileDriver);
     TouchAction touchTwo = new TouchAction(mobileDriver);
     MultiTouchAction multiTouch = new MultiTouchAction(mobileDriver);
@@ -259,21 +259,22 @@ public class PerformTouchAction {
     int offSet = 0;
     int startXOne = 0;
     int startXTwo = 0;
+    int appFingersSpace = 0;
     if (fingersSpace >= pixelPath) {
-      fingersSpace = pixelPath - 2;
+      appFingersSpace = pixelPath - 2;
     }
-    fingersSpace /= 2;
+    appFingersSpace = fingersSpace / 2;
     if (pixelPath < appNativeWidth) {
       halfPath = pixelPath / 2;
     } else {
       halfPath = (appNativeWidth - 2) / 2;
     }
-    endXOne = pointX - halfPath;
+    endXOne = appPointX - halfPath;
     if (endXOne < 0) {
       offSet = -endXOne;
       endXOne = 0;
     }
-    endXTwo = pointX + halfPath;
+    endXTwo = appPointX + halfPath;
     if (endXTwo > (appNativeWidth - 2)) {
       offSet = (appNativeWidth - 2) - endXTwo;
       endXTwo = (appNativeWidth - 2);
@@ -284,11 +285,11 @@ public class PerformTouchAction {
     if (offSet < 0) {
       endXOne += offSet;
     }
-    startXOne = pointX - fingersSpace;
+    startXOne = appPointX - appFingersSpace;
     if (startXOne <= 0) {
       startXOne = 1;
     }
-    startXTwo = pointX + fingersSpace;
+    startXTwo = appPointX + appFingersSpace;
     if (startXTwo >= (appNativeWidth - 2)) {
       startXTwo = appNativeWidth - 3;
     }
@@ -302,8 +303,8 @@ public class PerformTouchAction {
       endXTwo = temp;
     }
     switchToContext(CONTEXT_NATIVE_APP, methodName);
-    touchOne.press(startXOne, pointY).moveTo(endXOne - startXOne, 0).release();
-    touchTwo.press(startXTwo, pointY).moveTo(endXTwo - startXTwo, 0).release();
+    touchOne.press(startXOne, appPointY).moveTo(endXOne - startXOne, 0).release();
+    touchTwo.press(startXTwo, appPointY).moveTo(endXTwo - startXTwo, 0).release();
     multiTouch.add(touchOne);
     multiTouch.add(touchTwo);
     multiTouch.perform();
@@ -319,10 +320,10 @@ public class PerformTouchAction {
    */
   public void tapOnPointXY(int pointX, int pointY, int duration, int waitAfter) {
     String methodName = "tapOnPointXY";
-    pointX = (int) ((pointX / 100f) * appNativeWidth);
-    pointY = (int) (((pointY / 100f) * appNativeHeight) + taskbarNativeHeight);
+    int appPointX = (int) ((pointX / 100f) * appNativeWidth);
+    int appPointY = (int) (((pointY / 100f) * appNativeHeight) + taskbarNativeHeight);
     switchToContext(CONTEXT_NATIVE_APP, methodName);
-    mobileDriver.tap(1, pointX, pointY, duration);
+    mobileDriver.tap(1, appPointX, appPointY, duration);
     waitForFinish(waitAfter, methodName);
     switchToContext(CONTEXT_WEBVIEW_1, methodName);
   }

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleCRUDAnonTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleCRUDAnonTests.java
@@ -71,14 +71,14 @@ public class ArticleCRUDAnonTests extends NewTestTemplate {
   public void ArticleCRUDAnon_004_differentTitles(String articleTitle) {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     String articleContent = PageContent.ARTICLE_TEXT;
-    articleTitle = articleTitle + base.getTimeStamp();
+    String randomArticleTitle = articleTitle + base.getTimeStamp();
     VisualEditModePageObject
         visualEditMode =
-        base.navigateToArticleEditPageCK(wikiURL, articleTitle);
+        base.navigateToArticleEditPageCK(wikiURL, randomArticleTitle);
     visualEditMode.addContent(articleContent);
     ArticlePageObject article = visualEditMode.submitArticle();
     article.verifyContent(articleContent);
-    article.verifyArticleTitle(articleTitle);
+    article.verifyArticleTitle(randomArticleTitle);
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleCRUDUserTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleCRUDUserTests.java
@@ -76,14 +76,14 @@ public class ArticleCRUDUserTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName, credentials.password, wikiURL);
     String articleContent = PageContent.ARTICLE_TEXT;
-    articleTitle = articleTitle + base.getTimeStamp();
+    String randomArticleTitle = articleTitle + base.getTimeStamp();
     VisualEditModePageObject
         visualEditMode =
-        base.navigateToArticleEditPageCK(wikiURL, articleTitle);
+        base.navigateToArticleEditPageCK(wikiURL, randomArticleTitle);
     visualEditMode.addContent(articleContent);
     ArticlePageObject article = visualEditMode.submitArticle();
     article.verifyContent(articleContent);
-    article.verifyArticleTitle(articleTitle);
+    article.verifyArticleTitle(randomArticleTitle);
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/blogtests/BlogTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/blogtests/BlogTests.java
@@ -49,12 +49,12 @@ public class BlogTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName, credentials.password, wikiURL);
     String blogContent = PageContent.BLOG_CONTENT + base.getTimeStamp();
-    blogTitle += blogTitle + base.getTimeStamp();
+    String randomBlogTitle = blogTitle + base.getTimeStamp();
     SpecialCreatePagePageObject createBlogPage = base.openSpecialCreateBlogPage(wikiURL);
-    VisualEditModePageObject visualEditMode = createBlogPage.populateTitleField(blogTitle);
+    VisualEditModePageObject visualEditMode = createBlogPage.populateTitleField(randomBlogTitle);
     visualEditMode.addContent(blogContent);
     BlogPageObject blogPage = visualEditMode.submitBlog();
-    blogPage.verifyBlogTitle(blogTitle);
+    blogPage.verifyBlogTitle(randomBlogTitle);
     blogPage.verifyContent(blogContent);
   }
 


### PR DESCRIPTION
Method parameters, caught exceptions and foreach variables should not be reassigned

While it is technically correct to assign to parameters from within method bodies, it is better to use temporary variables to store intermediate results. This rule will typically detect cases where a constructor parameter is assigned to itself instead of a field of the same name, i.e. when this was forgotten. Allowing parameters to be assigned to also reduces the code readability as developers will not be able to know whether the original parameter or some temporary variable is being accessed without going through the whole method. Moreover, some developers might also expect assignments of method parameters to be visible from callers, which is not the case and can confuse them. All parameters should be treated as final.