### PR TITLE
ADEN-1743 Change functionality for hiding slot to changing opacity property of the web element.

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/helpers/AdsComparison.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/helpers/AdsComparison.java
@@ -43,17 +43,17 @@ public class AdsComparison {
   }
 
   public void hideSlot(String selector, WebDriver driver) {
-    changeVisibility(selector, "hidden", driver);
+    changeOpacity(selector, 0, driver);
   }
 
   public void showSlot(String selector, WebDriver driver) {
-    changeVisibility(selector, "visible", driver);
+    changeOpacity(selector, 100, driver);
   }
 
-  private void changeVisibility(String selector, String visibility, WebDriver driver) {
+  private void changeOpacity(String selector, int value, WebDriver driver) {
     ((JavascriptExecutor) driver).executeScript(
-        "$(arguments[0]).css('visibility', arguments[1]);",
-        selector, visibility
+        "$(arguments[0]).css('opacity', arguments[1]);",
+        selector, Integer.toString(value)
     );
   }
 


### PR DESCRIPTION
We moving 'hide/show slot' functionality from changing visibility to changing opacity because we found one case when changing visibility of slot doesn't hide the ad (if between slot and ad we have items with visibility equals show).