### PR TITLE
Fixed facebook_003 test

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
@@ -4,7 +4,6 @@ import com.wikia.webdriver.common.contentpatterns.ApiActions;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
-import com.wikia.webdriver.common.properties.Properties;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.SignUpPageObject;
 
@@ -72,11 +71,11 @@ public class DropDownComponentObject extends WikiBasePageObject {
         }
       });
     } finally {
-        restoreDeaultImplicitWait();
+      restoreDeaultImplicitWait();
     }
 
-      PageObjectLogging.log(
-          "DropdownVisible",
+    PageObjectLogging.log(
+        "DropdownVisible",
         "Login dropdown is visible",
         true, driver
     );
@@ -133,7 +132,10 @@ public class DropDownComponentObject extends WikiBasePageObject {
   }
 
   public void logInViaFacebook(String email, String password) {
-    scrollAndClick(formConnectWithFbButton);
+    JavascriptExecutor js = (JavascriptExecutor) driver;
+    waitForElementVisibleByElement(formConnectWithFbButton);
+    //When clicking via selenium dropdown disappears
+    js.executeScript("$('.wikia-button-facebook.sso-login-facebook').trigger('click')");
     PageObjectLogging.log(
         "logInDropDownFB",
         "facebook button clicked",

--- a/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
@@ -12,6 +12,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookUserPa
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.AlmostTherePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.SignUpPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
+
 import org.testng.annotations.Test;
 
 public class FacebookTests extends NewTestTemplate {
@@ -19,10 +20,8 @@ public class FacebookTests extends NewTestTemplate {
   Credentials credentials = config.getCredentials();
 
   /**
-   * dependent method: Signup_007_signUpWithFacebook and Facebook_002_noEmailPerms
-   * Steps: 1. Log in to facebook
-   * 2. Open Facebook settings
-   * 3. Remove Wikia and Wikia Development App
+   * dependent method: Signup_007_signUpWithFacebook and Facebook_002_noEmailPerms Steps: 1. Log in
+   * to facebook 2. Open Facebook settings 3. Remove Wikia and Wikia Development App
    */
   @Test(groups = {"Facebook_001", "Facebook"})
   @UseUnstablePageLoadStrategy
@@ -38,22 +37,17 @@ public class FacebookTests extends NewTestTemplate {
   }
 
   /**
-   * depends on method Facebook_001_removeWikiaApps
-   * Steps:
-   * 1. Log in to facebook
-   * 2. Click facebook login on signup page
-   * 3. Deny permission to user's facebook email address
-   * 4. manually enter email address and create account
-   * 5. confirm account and login,
-   * 6. Verify user can login via facebook
+   * depends on method Facebook_001_removeWikiaApps Steps: 1. Log in to facebook 2. Click facebook
+   * login on signup page 3. Deny permission to user's facebook email address 4. manually enter
+   * email address and create account 5. confirm account and login, 6. Verify user can login via
+   * facebook
    */
   @Test(
-          groups = {"Facebook_002", "Facebook"},
-          dependsOnMethods = {"Facebook_001_removeWikiaApps"}
+      groups = {"Facebook_002", "Facebook"},
+      dependsOnMethods = {"Facebook_001_removeWikiaApps"}
   )
   @UseUnstablePageLoadStrategy
   public void Facebook_002_noEmailPerms() {
-
     WikiBasePageObject base = new WikiBasePageObject(driver);
     FacebookMainPageObject fbLogin = base.openFacebookMainPage();
     FacebookUserPageObject userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);
@@ -79,21 +73,16 @@ public class FacebookTests extends NewTestTemplate {
   }
 
   /**
-   * depends on method Facebook_001_removeWikiaApps
-   * Steps:
-   * 1. Click facebook login in dropdown menu
-   * 2. Enter existing wikia credentials to link facebook and wikia accounts
-   * 3. login
-   * 4. Verify user can login via wikia username/pwd
-   * 5. Disconnect facebook via prefs for cleanup
+   * depends on method Facebook_001_removeWikiaApps Steps: 1. Click facebook login in dropdown menu
+   * 2. Enter existing wikia credentials to link facebook and wikia accounts 3. login 4. Verify user
+   * can login via wikia username/pwd 5. Disconnect facebook via prefs for cleanup
    */
   @Test(
-          groups = {"Facebook_003", "Facebook"},
-          dependsOnMethods = {"Facebook_001_removeWikiaApps"}
+      groups = {"Facebook_003", "Facebook"},
+      dependsOnMethods = {"Facebook_001_removeWikiaApps"}
   )
   @UseUnstablePageLoadStrategy
   public void Facebook_003_linkFBwithWikia() {
-    Facebook_001_removeWikiaApps();
     String winHandleBefore = driver.getWindowHandle();
 
     DropDownComponentObject dropDown = new DropDownComponentObject(driver);
@@ -102,7 +91,9 @@ public class FacebookTests extends NewTestTemplate {
 
     Object[] windows = driver.getWindowHandles().toArray();
     driver.switchTo().window(windows[0].toString());
-    FacebookSignupModalComponentObject fbModal = new FacebookSignupModalComponentObject(driver, windows[0].toString());
+    FacebookSignupModalComponentObject
+        fbModal =
+        new FacebookSignupModalComponentObject(driver, windows[0].toString());
     fbModal.acceptWikiaAppPolicy();
     fbModal.loginExistingAccount(credentials.userName, credentials.password);
 


### PR DESCRIPTION
Problems:
- When clicking on facebook button via selenium dropdown disappears --> changed to js click (Bogna's idea)
- Double call method Facebook_001_removeWikiaApps --> removed from Facebook_003_linkFBwithWikia

Applied code format for DropDownComponentObject.java and FacebookTests.java