### PR TITLE
removig deleted reintroduces search 14 test, changing result string

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/templates/search/IntraWiki.java
+++ b/src/test/java/com/wikia/webdriver/common/templates/search/IntraWiki.java
@@ -20,7 +20,7 @@ public class IntraWiki extends NewTestTemplate {
     }
 
     protected static final int RESULTS_PER_PAGE = 25;
-    protected static final String SEARCH_PHRASE_RESULTS = "a";
+    protected static final String SEARCH_PHRASE_RESULTS = "A";
     protected static final String SEARCH_PAGINATION_RESULTS = "what";
     protected static final String SEARCH_RESULT_WITH_EXTENSION = "betweenlions";
     protected static final String SEARCH_PHRASE_NO_RESULTS = "qazwsxedcrfvtgb";

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
@@ -1,9 +1,8 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.search.intrawikisearch;
 
-import com.wikia.webdriver.common.contentpatterns.URLsContent;
-import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.logging.PageObjectLogging;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.SearchPageObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -15,9 +14,10 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import com.wikia.webdriver.common.contentpatterns.URLsContent;
+import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.SearchPageObject;
 
 public class IntraWikiSearchPageObject extends SearchPageObject {
 

--- a/src/test/java/com/wikia/webdriver/testcases/searchtests/intrawiki/BasicActions.java
+++ b/src/test/java/com/wikia/webdriver/testcases/searchtests/intrawiki/BasicActions.java
@@ -1,19 +1,16 @@
 package com.wikia.webdriver.testcases.searchtests.intrawiki;
 
-import com.wikia.webdriver.common.core.urlbuilder.UrlBuilder;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
 import com.wikia.webdriver.common.dataprovider.IntraWikiSearchProvider;
-import com.wikia.webdriver.common.properties.Credentials;
-import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.common.templates.search.IntraWiki;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.global_navitagtion.NavigationBar;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.SearchPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.search.intrawikisearch.IntraWikiSearchPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.search.intrawikisearch.IntraWikiSearchPageObject.sortOptions;
-
-import org.testng.annotations.Test;
-
-import java.util.List;
 
 /*
  *  anonSearch: As anon basic search action and verify you are on search result page. This also prevents goSearch being active by default.
@@ -34,9 +31,8 @@ import java.util.List;
  *  11. Verify if there are correct advanced option set as a default
  *  12. Search for some image without typing extension (.jpg) and verify photo is found
  *  13. Search for different phrases and verify there are correct namespaces in result titles
- *  14. Search for empty field and verify if search page is opened
- *  15. Verify top module
- *  16. Verify push to top is working in community.wikia.com
+ *  14. Verify top module
+ *  15. Verify push to top is working in community.wikia.com
  */
 
 public class BasicActions extends IntraWiki {
@@ -198,14 +194,6 @@ public class BasicActions extends IntraWiki {
     }
 
     @Test(groups = { "IntraWikiSearch_014", "IntraWikiSearch", "Search" })
-    public void searchPageOpened() {
-        IntraWikiSearchPageObject search = new IntraWikiSearchPageObject(driver);
-        search.openWikiPage(testedWiki);
-        search.searchFor("");
-        search.verifySearchPageOpened();
-    }
-
-    @Test(groups = { "IntraWikiSearch_015", "IntraWikiSearch", "Search" })
     public void topModule() {
         IntraWikiSearchPageObject search = new IntraWikiSearchPageObject(driver);
         search.openWikiPage(testedWiki);
@@ -213,7 +201,7 @@ public class BasicActions extends IntraWiki {
         search.verifyTopModule();
     }
 
-    @Test(groups = { "IntraWikiSearch_016", "IntraWikiSearch", "Search" })
+    @Test(groups = { "IntraWikiSearch_015", "IntraWikiSearch", "Search" })
     public void communityPushToTopWikiResult() {
         IntraWikiSearchPageObject search = new IntraWikiSearchPageObject(driver);
         search.openWikiPage(communityWiki);


### PR DESCRIPTION
1 . searchPageOpened  was deleted earlier this week, but a merge reintroduced it. 
2. anonSearch and userSearch tests are searching were searching for lowerCase letter a, when result was upperCase letter A

PR provides fix for both
1. removes searchPageOpened test
2. changes search query from lower-case to upper-case