### PR TITLE
VE-1878: Updating test for adding and editing templates

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/VisualEditorDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/VisualEditorDataProvider.java
@@ -92,6 +92,21 @@ public class VisualEditorDataProvider {
     ADVANCED
   }
 
+  public enum Transclusion {
+    INLINE("span[typeof='mw:Transclusion']"),
+    BLOCKED("div[typeof='mw:Transclusion']");
+
+    private String cssSelector;
+
+    private Transclusion(String cssSelector) {
+      this.cssSelector = cssSelector;
+    }
+
+    public String getCssSelector() {
+      return cssSelector;
+    }
+  }
+
   /**
    * Data provider with text formatting
    */

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorEditTemplateDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorEditTemplateDialog.java
@@ -19,12 +19,14 @@ public class VisualEditorEditTemplateDialog extends VisualEditorDialog {
   private WebElement getInfoLink;
   @FindBy(css = ".ve-ui-mwParameterPage")
   private List<WebElement> templateParams;
-  @FindBy(css = ".oo-ui-flaggableElement-primary a")
+  @FindBy(css = ".oo-ui-processDialog-actions-primary a")
   private WebElement doneButton;
   @FindBy(css = ".ve-ui-wikiaTransclusionDialog-cancelButton a")
   private WebElement cancelButton;
   @FindBy(css = ".ve-ui-mwTemplateDialog-ready")
   private WebElement templateDialog;
+  @FindBy(css = ".ve-ui-wikiaFocusWidget-node")
+  private WebElement templateFocusedMode;
 
   private static final By PARAM_LABEL_BY = By.cssSelector(".ve-ui-mwParameterPage-label");
   private static final By PARAM_INPUT_BY = By.cssSelector(".ve-ui-mwParameterPage-field textarea");
@@ -35,31 +37,31 @@ public class VisualEditorEditTemplateDialog extends VisualEditorDialog {
   }
 
   @Override
-  public void switchToIFrame() {
-    waitForElementVisibleByElement(templateDialog);
-    super.switchToIFrame();
+  public void waitForDialogVisible() {
+    super.waitForDialogVisible();
+    waitForElementVisibleByElement(templateFocusedMode);
   }
 
   @Override
-  public void switchOutOfIFrame() {
-    waitForElementNotVisibleByElement(templateDialog);
-    super.switchOutOfIFrame();
+  public void waitForDialogNotVisible() {
+    super.waitForDialogNotVisible();
+    waitForElementNotVisibleByElement(templateFocusedMode);
   }
 
   public ArticlePageObject clickGetInfoLink() {
-    switchToIFrame();
+    waitForDialogVisible();
     try {
       waitForElementByElement(getInfoLink);
       //Opens new tab to Template namespace
       getInfoLink.click();
       return new ArticlePageObject(driver);
     } finally {
-      switchOutOfIFrame();
+      waitForDialogNotVisible();
     }
   }
 
   public void typeInParam(String paramName, String text) {
-    switchToIFrame();
+    waitForDialogVisible();
     if (checkIfElementOnPage(TEMPLATE_PARAMS_BY)) {
       WebElement targetParam = getElementByChildText(templateParams, PARAM_LABEL_BY, paramName);
       WebElement targetParamInput = targetParam.findElement(PARAM_INPUT_BY);
@@ -70,11 +72,10 @@ public class VisualEditorEditTemplateDialog extends VisualEditorDialog {
     }
     PageObjectLogging
         .log("typeInParam", "Type " + text + " in the " + paramName + " field.", true, driver);
-    switchOutOfIFrame();
   }
 
   public VisualEditorPageObject clickDone() {
-    switchToIFrame();
+    waitForDialogVisible();
     try {
       if (checkIfElementOnPage(TEMPLATE_PARAMS_BY)) {
         waitForElementClickableByElement(doneButton);
@@ -84,12 +85,12 @@ public class VisualEditorEditTemplateDialog extends VisualEditorDialog {
       }
       return new VisualEditorPageObject(driver);
     } finally {
-      switchOutOfIFrame();
+      waitForDialogNotVisible();
     }
   }
 
   public VisualEditorPageObject clickCancel() {
-    switchToIFrame();
+    waitForDialogVisible();
     try {
       if (checkIfElementOnPage(TEMPLATE_PARAMS_BY)) {
         waitForElementClickableByElement(cancelButton);
@@ -99,7 +100,7 @@ public class VisualEditorEditTemplateDialog extends VisualEditorDialog {
       }
       return new VisualEditorPageObject(driver);
     } finally {
-      switchOutOfIFrame();
+      waitForDialogNotVisible();
     }
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
@@ -18,24 +18,29 @@ public class VisualEditorInsertTemplateDialog extends VisualEditorDialog {
   private WebElement searchClearButton;
   @FindBy(css = ".ve-ui-wikiaTemplateSearchWidget-suggestions")
   private WebElement suggestedWidget;
-  @FindBy(css = ".ve-ui-wikiaTemplateSearchWidget-suggestions ul li")
+  @FindBy(css = ".ve-ui-wikiaTemplateSearchWidget-suggestions .ve-ui-wikiaTemplateOptionWidget")
   private List<WebElement> suggestedTemplates;
   @FindBy(css = ".oo-ui-searchWidget-results:not(.ve-ui-wikiaTemplateSearchWidget-suggestions)")
   private WebElement resultWidget;
-  @FindBy(css = ".oo-ui-searchWidget-results:not(.ve-ui-wikiaTemplateSearchWidget-suggestions) ul li")
+  @FindBy(
+      css = ".oo-ui-searchWidget-results:not(.ve-ui-wikiaTemplateSearchWidget-suggestions) " +
+            ".ve-ui-wikiaTemplateOptionWidget")
   private List<WebElement> resultTemplates;
 
-  private By labelBy = By.cssSelector(".oo-ui-labeledElement-label");
+  private By labelBy = By.cssSelector(".oo-ui-labelElement-label");
   private By
       suggestedTemplatesBy =
-      By.cssSelector(".ve-ui-wikiaTemplateSearchWidget-suggestions ul li");
+      By.cssSelector(".ve-ui-wikiaTemplateSearchWidget-suggestions div");
+  private By resulteTemplateBy =
+      By.cssSelector(".oo-ui-searchWidget-results:not(.ve-ui-wikiaTemplateSearchWidget-suggestions)"
+                   + " .ve-ui-wikiaTemplateOptionWidget");
 
   public VisualEditorInsertTemplateDialog(WebDriver driver) {
     super(driver);
   }
 
   public void typeInSearchInput(String searchString) {
-    switchToIFrame();
+    waitForDialogVisible();
     waitForElementByElement(searchInput);
     searchInput.sendKeys(searchString);
     waitForValueToBePresentInElementsAttributeByElement(searchInput, "value", searchString);
@@ -44,68 +49,42 @@ public class VisualEditorInsertTemplateDialog extends VisualEditorDialog {
         "Typed '" + searchString + "' into the template search textfield",
         true
     );
-    switchOutOfIFrame();
   }
 
   public void clearSearchInput() {
-    switchToIFrame();
-    waitForElementVisibleByElement(searchClearButton);
-    searchClearButton.click();
+    searchInput.clear();
     PageObjectLogging.log("clearSearchInput", "Cleared the template search input field", true);
-    switchOutOfIFrame();
   }
 
   public VisualEditorEditTemplateDialog selectSuggestedTemplate(int index) {
-    switchToIFrame();
-    try {
-      waitForElementVisibleByElement(suggestedWidget);
-      WebElement selected = suggestedTemplates.get(index).findElement(labelBy);
-      selected.click();
-      PageObjectLogging.log(
-          "selectSuggestedTemplate",
-          "Suggested template selected: " + selected.getText(),
-          true
-      );
-      return new VisualEditorEditTemplateDialog(driver);
-    } finally {
-      switchOutOfIFrame();
-    }
+    waitForDialogVisible();
+    waitForElementVisibleByElement(suggestedWidget);
+    WebElement selected = suggestedTemplates.get(index).findElement(labelBy);
+    selected.click();
+    PageObjectLogging.log(
+        "selectSuggestedTemplate",
+        "Suggested template selected: " + selected.getText(),
+        true
+    );
+    return new VisualEditorEditTemplateDialog(driver);
   }
 
   public VisualEditorEditTemplateDialog selectResultTemplate(String searchString, int index) {
     typeInSearchInput(searchString);
-    switchToIFrame();
-    try {
-      waitForElementVisibleByElement(resultWidget);
-      WebElement selected = resultTemplates.get(index).findElement(labelBy);
-      selected.click();
-      PageObjectLogging.log(
-          "selectResultTemplate",
-          "Search result template selected: " + selected.getText(),
-          true
-      );
-      return new VisualEditorEditTemplateDialog(driver);
-    } finally {
-      switchOutOfIFrame();
-    }
+    waitForDialogVisible();
+    waitForElementVisibleByElement(resultWidget);
+    WebElement selected = resultTemplates.get(index).findElement(labelBy);
+    selected.click();
+    PageObjectLogging.log(
+        "selectResultTemplate",
+        "Search result template selected: " + selected.getText(),
+        true
+    );
+    return new VisualEditorEditTemplateDialog(driver);
   }
 
   public int getNumberOfResultTemplates() {
-    switchToIFrame();
-    try {
-      if (resultTemplates.isEmpty()) {
-        return 0;
-      } else {
-        return resultTemplates.size();
-      }
-    } finally {
-      PageObjectLogging.log(
-          "getNumberOfResultTemplates",
-          "Number of result templates found: " + resultTemplates.size(),
-          true
-      );
-      switchOutOfIFrame();
-    }
+    return getNumOfElementOnPage(resulteTemplateBy);
   }
 
   public void verifyIsResultTemplate() {
@@ -119,10 +98,8 @@ public class VisualEditorInsertTemplateDialog extends VisualEditorDialog {
   }
 
   public void verifyIsSuggestedTemplate() {
-    switchToIFrame();
     Assertion
         .assertTrue(checkIfElementOnPage(suggestedTemplatesBy), "No suggested template shown.");
     PageObjectLogging.log("verifyIsSuggestedTemplate", "Suggested templates found", true);
-    switchOutOfIFrame();
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
@@ -84,11 +84,11 @@ public class VisualEditorInsertTemplateDialog extends VisualEditorDialog {
   }
 
   public int getNumberOfResultTemplates() {
-    waitForElementVisibleByElement(resultWidget);
     return getNumOfElementOnPage(resulteTemplateBy);
   }
 
   public void verifyIsResultTemplate() {
+    waitForElementVisibleByElement(resultWidget);
     Assertion.assertTrue(getNumberOfResultTemplates() > 0, "No result template shown.");
     PageObjectLogging.log("verifyIsResultTemplate", "Result templates found", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertTemplateDialog.java
@@ -84,6 +84,7 @@ public class VisualEditorInsertTemplateDialog extends VisualEditorDialog {
   }
 
   public int getNumberOfResultTemplates() {
+    waitForElementVisibleByElement(resultWidget);
     return getNumOfElementOnPage(resulteTemplateBy);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
@@ -7,6 +7,7 @@ import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.Indentat
 import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.InsertDialog;
 import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.InsertList;
 import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.Style;
+import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.Transclusion;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.media.VideoComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.visualeditordialogs.VisualEditorEditTemplateDialog;
@@ -67,9 +68,9 @@ public class VisualEditorPageObject extends VisualEditorMenu {
   private WebElement mediaCaption;
   @FindBy(css = ".ve-ce-resizableNode-swHandle")
   private WebElement swResizeHandle;
-  @FindBy(css = ".ve-ui-desktopContext .oo-ui-popupWidget")
+  @FindBy(css = ".ve-ui-desktopContext .oo-ui-popupWidget-popup")
   private WebElement contextMenu;
-  @FindBy(css = ".ve-ce-node-focused")
+  @FindBy(css = ".ve-ui-wikiaFocusWidget")
   private WebElement focusedNode;
   @FindBy(css = ".mw-body-content")
   private WebElement mainContent;
@@ -80,17 +81,15 @@ public class VisualEditorPageObject extends VisualEditorMenu {
   @FindBy(css = ".media-gallery-wrapper.ve-ce-branchNode .toggler")
   private WebElement toggler;
 
-  private By contextMenuBy = By.cssSelector(".ve-ui-contextWidget");
-  private By contextEditBy = By.cssSelector(".oo-ui-icon-edit");
-  private By blockTransclusionBy = By.cssSelector(".ve-ce-mwTransclusionBlockNode");
-  private By inlineTransclusionBy = By.cssSelector(".ve-ce-mwTransclusionInlineNode");
-
-  private String blockTransclusionString = ".ve-ce-mwTransclusionBlockNode";
+  private By contextMenuBy = By.cssSelector(".ve-ui-contextSelectWidget");
+  private By contextEditBy = By.cssSelector(".oo-ui-labelElement");
+  private By blockTransclusionBy = By.cssSelector("div[typeof='mw:Transclusion']");
+  private By inlineTransclusionBy = By.cssSelector("span[typeof='mw:Transclusion']");
 
   public void selectMediaAndDelete() {
-    waitForElementByElement(editArea);
+    waitForElementVisibleByElement(editArea);
     editArea.click();
-    waitForElementByElement(mediaNode);
+    waitForElementVisibleByElement(mediaNode);
     mediaNode.click();
     Actions actions2 = new Actions(driver);
     actions2.sendKeys(Keys.DELETE).build().perform();
@@ -402,14 +401,14 @@ public class VisualEditorPageObject extends VisualEditorMenu {
     actions2.sendKeys(Keys.DELETE).build().perform();
   }
 
-  public void deleteBlockTransclusion(int index) {
-    clickBlockTransclusion(index);
+  public void deleteTransclusion(int index, Transclusion transclusion) {
+    clickTransclusion(index, transclusion);
     Actions actions2 = new Actions(driver);
     actions2.sendKeys(Keys.DELETE).build().perform();
   }
 
-  public void clickBlockTransclusion(int index) {
-    Point tempLocation = getBlockTransclusionLocation(index);
+  public void clickTransclusion(int index, Transclusion transclusion) {
+    Point tempLocation = getTransclusionLocation(index, transclusion);
     int xOffset = 10;
     int yOffset = 10;
     int tempLeft = tempLocation.x + xOffset;
@@ -421,15 +420,15 @@ public class VisualEditorPageObject extends VisualEditorMenu {
     WebElement contextEdit = contextMenu.findElement(contextMenuBy).findElement(contextEditBy);
     waitForElementVisibleByElement(contextEdit);
     PageObjectLogging
-        .log("clickBlockTransclusion", "Clicked at X: " + tempLeft + ", Y: " + tempTop, true,
+        .log("clickTransclusion", "Clicked at X: " + tempLeft + ", Y: " + tempTop, true,
              driver);
   }
 
-  private Point getBlockTransclusionLocation(int index) {
+  private Point getTransclusionLocation(int index, Transclusion transclusion) {
     JavascriptExecutor js = (JavascriptExecutor) driver;
     Object
         templateBounding =
-        js.executeScript(VEContent.BOUNDING_SCRIPT, blockTransclusionString, index);
+        js.executeScript(VEContent.BOUNDING_SCRIPT, transclusion.getCssSelector(), index);
     Map<String, String> mapBounding = (Map) templateBounding;
     int tempLeft = getMapValueAsInt(String.valueOf(mapBounding.get("left")));
     int tempTop = getMapValueAsInt(String.valueOf(mapBounding.get("top")));
@@ -441,8 +440,8 @@ public class VisualEditorPageObject extends VisualEditorMenu {
   }
 
   public VisualEditorEditTemplateDialog openEditTemplateDialog() {
-    waitForElementByElement(editArea);
-    waitForElementByElement(focusedNode);
+    waitForElementVisibleByElement(editArea);
+    waitForElementVisibleByElement(focusedNode);
     clickContextMenu();
     return new VisualEditorEditTemplateDialog(driver);
   }

--- a/src/test/java/com/wikia/webdriver/testcases/visualeditor/VETemplateTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/visualeditor/VETemplateTests.java
@@ -2,7 +2,7 @@ package com.wikia.webdriver.testcases.visualeditor;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.contentpatterns.VEContent;
-import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.InsertDialog;
+import com.wikia.webdriver.common.dataprovider.VisualEditorDataProvider.*;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.visualeditordialogs.VisualEditorEditTemplateDialog;
@@ -67,6 +67,7 @@ public class VETemplateTests extends NewTestTemplate {
     templateDialog.clearSearchInput();
     templateDialog.typeInSearchInput(VEContent.TEMPLATE_SEARCH_MATCH_ARTICLE);
     templateDialog.verifyIsResultTemplate();
+    templateDialog.logOut(wikiURL);
   }
 
   //AT02
@@ -82,6 +83,7 @@ public class VETemplateTests extends NewTestTemplate {
         (VisualEditorInsertTemplateDialog) ve.openDialogFromMenu(InsertDialog.TEMPLATE);
     templateDialog.verifyNoResultTemplate();
     templateDialog.verifyIsSuggestedTemplate();
+    templateDialog.logOut(wikiURL);
   }
 
   //AT03
@@ -134,21 +136,22 @@ public class VETemplateTests extends NewTestTemplate {
     VisualEditorEditTemplateDialog editTemplateDialog =
         templateDialog.selectResultTemplate(VEContent.TEMPLATE_SEARCH_EXACTMATCH, 0);
     ve = editTemplateDialog.clickDone();
-    ve.verifyNumberOfBlockTransclusion(++numBlockTransclusion);
-    ve.verifyNumberOfInlineTransclusion(numInlineTransclusion);
+    ve.verifyNumberOfBlockTransclusion(numBlockTransclusion);
+    ve.verifyNumberOfInlineTransclusion(++numInlineTransclusion);
     templateDialog =
         (VisualEditorInsertTemplateDialog) ve.openDialogFromMenu(InsertDialog.TEMPLATE);
     editTemplateDialog =
         templateDialog.selectResultTemplate(VEContent.TEMPLATE_SEARCH_EXACTMATCH, 0);
     ve = editTemplateDialog.clickDone();
-    ve.verifyNumberOfBlockTransclusion(++numBlockTransclusion);
-    ve.verifyNumberOfInlineTransclusion(numInlineTransclusion);
+    ve.verifyNumberOfBlockTransclusion(numBlockTransclusion);
+    ve.verifyNumberOfInlineTransclusion(++numInlineTransclusion);
     VisualEditorSaveChangesDialog saveDialog = ve.clickPublishButton();
     ArticlePageObject article = saveDialog.savePage();
     article.verifyVEPublishComplete();
     article.logOut(wikiURL);
   }
 
+  //ES05
   @Test(
       groups = {"VETemplate", "VETemplateTests_005", "VEDeleteTemplate"},
       dependsOnGroups = "VETemplateTests_004"
@@ -159,12 +162,13 @@ public class VETemplateTests extends NewTestTemplate {
     ve.verifyEditorSurfacePresent();
     int numBlockTransclusion = ve.getNumberOfBlockTransclusion();
     int numInlineTransclusion = ve.getNumberOfInlineTransclusion();
-    ve.deleteBlockTransclusion(1);
-    ve.verifyNumberOfBlockTransclusion(--numBlockTransclusion);
-    ve.verifyNumberOfInlineTransclusion(numInlineTransclusion);
+    ve.deleteTransclusion(1, Transclusion.INLINE);
+    ve.verifyNumberOfBlockTransclusion(numBlockTransclusion);
+    ve.verifyNumberOfInlineTransclusion(--numInlineTransclusion);
     VisualEditorSaveChangesDialog saveDialog = ve.clickPublishButton();
     ArticlePageObject article = saveDialog.savePage();
     article.verifyVEPublishComplete();
+    article.logOut(wikiURL);
   }
 
   //ET01
@@ -178,7 +182,7 @@ public class VETemplateTests extends NewTestTemplate {
     VisualEditorPageObject ve = base.openVEOnArticle(wikiURL, articleName);
     ve.verifyVEToolBarPresent();
     ve.verifyEditorSurfacePresent();
-    ve.clickBlockTransclusion(0);
+    ve.clickTransclusion(0, Transclusion.INLINE);
     VisualEditorEditTemplateDialog editTemplateDialog = ve.openEditTemplateDialog();
     editTemplateDialog
         .typeInParam(VEContent.TEMPLATE_PARAM_LABEL1, VEContent.TEMPLATE_PARAM_VALUE1);
@@ -191,5 +195,6 @@ public class VETemplateTests extends NewTestTemplate {
     saveDialog = reviewDialog.clickReturnToSaveFormButton();
     ArticlePageObject article = saveDialog.savePage();
     article.verifyVEPublishComplete();
+    article.logOut(wikiURL);
   }
 }


### PR DESCRIPTION
Added wait for edit template's focus mode for a better transition.
Refactored the method for transclusion to be generic.
Removed the unnecessary try and catch since the test no longer needs to switch back to default content.