### PR TITLE
Added dependencies on delete and restore tests to assure stability

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
@@ -71,7 +71,7 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
   }
 
   @Test(groups = {"DeleteAndRestoreMapTests_005", "DeleteAndRestoreMapTests", "InteractiveMaps"},
-      dependsOnMethods = {"DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner"})
+      dependsOnMethods = {"DeleteAndRestoreMapTests_004_StaffUserCanDeleteMap"})
   public void DeleteAndRestoreMapTests_005_StaffUserCanRestoreMap() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
@@ -21,7 +21,7 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
   Credentials credentials = config.getCredentials();
 
   @Test(groups = {"DeleteAndRestoreMapTests_001", "DeleteAndRestoreMapTests", "InteractiveMaps"})
-  public void DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner() {
+  public void DeleteAndRestoreMapTests_001_DeleteAndRestoreMapAsAMapOwner() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName, credentials.password, wikiURL);
     InteractiveMapPageObject
@@ -31,22 +31,13 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
     InteractiveMapsPageObject specialMap = deleteMapModal.deleteMap();
     selectedMap =
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
-  }
-
-  @Test(groups = {"DeleteAndRestoreMapTests_002", "DeleteAndRestoreMapTests", "InteractiveMaps"},
-      dependsOnMethods = {"DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner"})
-  public void DeleteAndRestoreMapTests_002_RestoreMapAsAMapOwner() {
-    WikiBasePageObject base = new WikiBasePageObject(driver);
-    base.logInCookie(credentials.userName, credentials.password, wikiURL);
-    InteractiveMapPageObject
-        selectedMap =
-        base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
     selectedMap.verifyMapOpenedForDeleteMapTests();
     selectedMap.restoreMap();
+    selectedMap.verifyMapOpenedForDeleteMapTests();
   }
 
-  @Test(groups = {"DeleteAndRestoreMapTests_003", "DeleteAndRestoreMapTests", "InteractiveMaps"})
-  public void DeleteAndRestoreMapTests_003_DeleteMapByNotOwner() {
+  @Test(groups = {"DeleteAndRestoreMapTests_002", "DeleteAndRestoreMapTests", "InteractiveMaps"})
+  public void DeleteAndRestoreMapTests_002_DeleteMapByNotOwner() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName2, credentials.password2, wikiURL);
     InteractiveMapPageObject
@@ -58,8 +49,8 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
         .assertEquals(InteractiveMapsContent.MAP_DELETE_ERROR, deleteMapModal.getDeleteMapError());
   }
 
-  @Test(groups = {"DeleteAndRestoreMapTests_004", "DeleteAndRestoreMapTests", "InteractiveMaps"})
-  public void DeleteAndRestoreMapTests_004_StaffUserCanDeleteMap() {
+  @Test(groups = {"DeleteAndRestoreMapTests_003", "DeleteAndRestoreMapTests", "InteractiveMaps"})
+  public void DeleteAndRestoreMapTests_003_StaffUserCanDeleteMap() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     InteractiveMapPageObject
@@ -68,17 +59,10 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
     selectedMap.verifyMapOpenedForDeleteMapTests();
     DeleteAMapComponentObject deleteMapModal = selectedMap.deleteMap();
     InteractiveMapsPageObject specialMap = deleteMapModal.deleteMap();
-  }
-
-  @Test(groups = {"DeleteAndRestoreMapTests_005", "DeleteAndRestoreMapTests", "InteractiveMaps"},
-      dependsOnMethods = {"DeleteAndRestoreMapTests_004_StaffUserCanDeleteMap"})
-  public void DeleteAndRestoreMapTests_005_StaffUserCanRestoreMap() {
-    WikiBasePageObject base = new WikiBasePageObject(driver);
-    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
-    InteractiveMapPageObject
-        selectedMap =
+    selectedMap =
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[2]);
     selectedMap.verifyMapOpenedForDeleteMapTests();
     selectedMap.restoreMap();
+    selectedMap.verifyMapOpenedForDeleteMapTests();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
@@ -24,13 +24,11 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
   public void DeleteAndRestoreMapTests_001_DeleteAndRestoreMapAsAMapOwner() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName, credentials.password, wikiURL);
-    InteractiveMapPageObject
-        selectedMap =
+    InteractiveMapPageObject selectedMap =
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
     DeleteAMapComponentObject deleteMapModal = selectedMap.deleteMap();
     InteractiveMapsPageObject specialMap = deleteMapModal.deleteMap();
-    selectedMap =
-        base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
+    selectedMap = base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
     selectedMap.verifyMapOpenedForDeleteMapTests();
     selectedMap.restoreMap();
     selectedMap.verifyMapOpenedForDeleteMapTests();
@@ -40,27 +38,23 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
   public void DeleteAndRestoreMapTests_002_DeleteMapByNotOwner() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName2, credentials.password2, wikiURL);
-    InteractiveMapPageObject
-        selectedMap =
+    InteractiveMapPageObject selectedMap =
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[1]);
     DeleteAMapComponentObject deleteMapModal = selectedMap.deleteMap();
     deleteMapModal.clickDeleteMap();
-    Assertion
-        .assertEquals(InteractiveMapsContent.MAP_DELETE_ERROR, deleteMapModal.getDeleteMapError());
+    Assertion.assertEquals(InteractiveMapsContent.MAP_DELETE_ERROR, deleteMapModal.getDeleteMapError());
   }
 
   @Test(groups = {"DeleteAndRestoreMapTests_003", "DeleteAndRestoreMapTests", "InteractiveMaps"})
   public void DeleteAndRestoreMapTests_003_StaffUserCanDeleteMap() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
-    InteractiveMapPageObject
-        selectedMap =
+    InteractiveMapPageObject selectedMap =
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[2]);
     selectedMap.verifyMapOpenedForDeleteMapTests();
     DeleteAMapComponentObject deleteMapModal = selectedMap.deleteMap();
     InteractiveMapsPageObject specialMap = deleteMapModal.deleteMap();
-    selectedMap =
-        base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[2]);
+    selectedMap = base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[2]);
     selectedMap.verifyMapOpenedForDeleteMapTests();
     selectedMap.restoreMap();
     selectedMap.verifyMapOpenedForDeleteMapTests();

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
@@ -33,7 +33,8 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[0]);
   }
 
-  @Test(groups = {"DeleteAndRestoreMapTests_002", "DeleteAndRestoreMapTests", "InteractiveMaps"})
+  @Test(groups = {"DeleteAndRestoreMapTests_002", "DeleteAndRestoreMapTests", "InteractiveMaps"},
+      dependsOnMethods = {"DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner"})
   public void DeleteAndRestoreMapTests_002_RestoreMapAsAMapOwner() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userName, credentials.password, wikiURL);
@@ -69,7 +70,8 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
     InteractiveMapsPageObject specialMap = deleteMapModal.deleteMap();
   }
 
-  @Test(groups = {"DeleteAndRestoreMapTests_005", "DeleteAndRestoreMapTests", "InteractiveMaps"})
+  @Test(groups = {"DeleteAndRestoreMapTests_005", "DeleteAndRestoreMapTests", "InteractiveMaps"},
+      dependsOnMethods = {"DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner"})
   public void DeleteAndRestoreMapTests_005_StaffUserCanRestoreMap() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);


### PR DESCRIPTION
DeleteAndRestoreMapTests_004_StaffUserCanDeleteMap and DeleteAndRestoreMapTests_001_DeleteMapAsAMapOwner are regularly failing because sometimes there is no map to delete since their respective restore tests failed to restore it. 