### PR TITLE
Facebook tests - fix for QAART-559

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -310,6 +310,11 @@ public class WikiBasePageObject extends BasePageObject {
     return new SignUpPageObject(driver);
   }
 
+  public SignUpPageObject navigateToSpecialSignUpPage(String wikiURL) {
+    getUrl(wikiURL + URLsContent.SPECIAL_USER_SIGNUP);
+    return new SignUpPageObject(driver);
+  }
+
   public PreferencesPageObject openSpecialPreferencesPage(String wikiURL) {
     getUrl(wikiURL + URLsContent.SPECIAL_PREFERENCES);
     PageObjectLogging.log("openSpecialPreferencesPage", "Special:Prefereces page opened", true);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/FacebookSettingsPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/FacebookSettingsPageObject.java
@@ -1,18 +1,15 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.facebook;
 
-import com.wikia.webdriver.common.contentpatterns.URLsContent;
-import com.wikia.webdriver.common.logging.PageObjectLogging;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
-
-import junit.framework.Assert;
+import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.How;
 
-import java.util.List;
+import com.wikia.webdriver.common.contentpatterns.URLsContent;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
 /**
  * @author Michal 'justnpT' Nowierski
@@ -33,6 +30,10 @@ public class FacebookSettingsPageObject extends WikiBasePageObject {
   private WebElement settings;
   @FindBy(css = "#SettingsPage_Content")
   private WebElement settingsContent;
+  @FindBy(css = "#userNavigationLabel")
+  private WebElement fbDropDown;
+  @FindBy(css = "#uiLinkButtonInput")
+  private WebElement fbLogOut;
 
   public FacebookSettingsPageObject(WebDriver driver) {
     super(driver);
@@ -57,7 +58,8 @@ public class FacebookSettingsPageObject extends WikiBasePageObject {
         if (element.getText().toString().matches("^Wikia.*\n?.*")) {
           waitForElementByElement(element);
           element.click();
-          WebElement AppRemoveButton = element.findElement(By.xpath("//a[contains(text(), 'Remove')]"));
+          WebElement AppRemoveButton =
+              element.findElement(By.xpath("//a[contains(text(), 'Remove')]"));
           if (AppRemoveButton != null) {
             waitForElementByElement(AppRemoveButton);
             AppRemoveButton.click();
@@ -89,5 +91,12 @@ public class FacebookSettingsPageObject extends WikiBasePageObject {
       }
     }
     return isPresent;
+  }
+
+  public void logOutFB() {
+    waitForElementByElement(fbDropDown);
+    fbDropDown.click();
+    waitForElementByElement(fbLogOut);
+    fbLogOut.click();
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/RemoveFacebookPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/RemoveFacebookPageObject.java
@@ -1,0 +1,27 @@
+package com.wikia.webdriver.pageobjectsfactory.pageobject.facebook;
+
+import org.openqa.selenium.WebDriver;
+
+import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
+
+/**
+ * Created by rcunningham on 4/2/15.
+ */
+public class RemoveFacebookPageObject extends FacebookMainPageObject {
+
+  public RemoveFacebookPageObject(WebDriver driver) {
+    super(driver);
+  }
+
+  public void removeWikiaApps(String email, String password) {
+    WikiBasePageObject base = new WikiBasePageObject(driver);
+    FacebookMainPageObject fbLogin = base.openFacebookMainPage();
+    FacebookUserPageObject userFB;
+    userFB = fbLogin.login(email, password);
+    userFB.verifyPageLogo();
+    FacebookSettingsPageObject settingsFB = userFB.fbOpenSettings();
+    settingsFB.openApps();
+    settingsFB.removeAppIfPresent();
+  }
+
+}

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/RemoveFacebookPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/facebook/RemoveFacebookPageObject.java
@@ -22,6 +22,8 @@ public class RemoveFacebookPageObject extends FacebookMainPageObject {
     FacebookSettingsPageObject settingsFB = userFB.fbOpenSettings();
     settingsFB.openApps();
     settingsFB.removeAppIfPresent();
+    settingsFB.openApps();
+    settingsFB.logOutFB();
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
@@ -9,7 +9,6 @@ import com.wikia.webdriver.pageobjectsfactory.componentobject.dropdowncomponento
 import com.wikia.webdriver.pageobjectsfactory.componentobject.modalwindows.FacebookSignupModalComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookMainPageObject;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookSettingsPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookUserPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.RemoveFacebookPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.AlmostTherePageObject;
@@ -36,7 +35,7 @@ public class FacebookTests extends NewTestTemplate {
   @UseUnstablePageLoadStrategy
   public void Facebook_002_noEmailPerms() {
     new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
-                                                         credentials.passwordFB);
+        credentials.passwordFB);
     WikiBasePageObject base = new WikiBasePageObject(driver);
     FacebookMainPageObject fbLogin = base.openFacebookMainPage();
     FacebookUserPageObject userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);
@@ -73,7 +72,7 @@ public class FacebookTests extends NewTestTemplate {
   @UseUnstablePageLoadStrategy
   public void Facebook_003_linkFBwithWikia() {
     new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
-                                                         credentials.passwordFB);
+        credentials.passwordFB);
     String winHandleBefore = driver.getWindowHandle();
 
     DropDownComponentObject dropDown = new DropDownComponentObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/facebooktests/FacebookTests.java
@@ -11,6 +11,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookMainPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookSettingsPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookUserPageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.RemoveFacebookPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.AlmostTherePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.SignUpPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
@@ -23,18 +24,7 @@ public class FacebookTests extends NewTestTemplate {
    * dependent method: Signup_007_signUpWithFacebook and Facebook_002_noEmailPerms Steps: 1. Log in
    * to facebook 2. Open Facebook settings 3. Remove Wikia and Wikia Development App
    */
-  @Test(groups = {"Facebook_001", "Facebook", "SignUp_007", "SignUp", "Modals"})
-  @UseUnstablePageLoadStrategy
-  public void Facebook_001_removeWikiaApps() {
-    WikiBasePageObject base = new WikiBasePageObject(driver);
-    FacebookMainPageObject fbLogin = base.openFacebookMainPage();
-    FacebookUserPageObject userFB;
-    userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);
-    userFB.verifyPageLogo();
-    FacebookSettingsPageObject settingsFB = userFB.fbOpenSettings();
-    settingsFB.openApps();
-    settingsFB.removeAppIfPresent();
-  }
+
 
   /**
    * depends on method Facebook_001_removeWikiaApps Steps: 1. Log in to facebook 2. Click facebook
@@ -42,9 +32,11 @@ public class FacebookTests extends NewTestTemplate {
    * email address and create account 5. confirm account and login, 6. Verify user can login via
    * facebook
    */
-  @Test(groups = {"Facebook_002", "Facebook"}, dependsOnMethods = {"Facebook_001_removeWikiaApps"})
+  @Test(groups = {"Facebook_002", "Facebook"})
   @UseUnstablePageLoadStrategy
   public void Facebook_002_noEmailPerms() {
+    new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
+                                                         credentials.passwordFB);
     WikiBasePageObject base = new WikiBasePageObject(driver);
     FacebookMainPageObject fbLogin = base.openFacebookMainPage();
     FacebookUserPageObject userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);
@@ -77,9 +69,11 @@ public class FacebookTests extends NewTestTemplate {
    * 2. Enter existing wikia credentials to link facebook and wikia accounts 3. login 4. Verify user
    * can login via wikia username/pwd 5. Disconnect facebook via prefs for cleanup
    */
-  @Test(groups = {"Facebook_003", "Facebook"}, dependsOnMethods = {"Facebook_001_removeWikiaApps"})
+  @Test(groups = {"Facebook_003", "Facebook", "Facebook_004"})
   @UseUnstablePageLoadStrategy
   public void Facebook_003_linkFBwithWikia() {
+    new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
+                                                         credentials.passwordFB);
     String winHandleBefore = driver.getWindowHandle();
 
     DropDownComponentObject dropDown = new DropDownComponentObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -1,11 +1,16 @@
 package com.wikia.webdriver.testcases.signuptests;
 
+import java.io.File;
+import java.util.Calendar;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.Test;
+
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.modalwindows.FacebookSignupModalComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.toolbars.CustomizedToolbarComponentObject;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.BasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.createnewwiki.CreateNewWikiLogInSignUpPageObject;
@@ -20,28 +25,18 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.UserProfilePageO
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.login.SpecialUserLoginPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject.tabNames;
-import com.wikia.webdriver.testcases.facebooktests.FacebookTests;
-
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.Test;
-
-import java.io.File;
-import java.util.Calendar;
 
 /*
- * 1. Attempt to sign up wrong blurry word,
- * 2. Attempt to sign up of too young user,
- * 3. Attempt to sign up with existing user name,
- * 4. Sign up,
- * 5. Sign up during CNW process,
- * 6. Login in using not verified user
+ * 1. Attempt to sign up wrong blurry word, 2. Attempt to sign up of too young user, 3. Attempt to
+ * sign up with existing user name, 4. Sign up, 5. Sign up during CNW process, 6. Login in using not
+ * verified user
  */
 public class SignUpTests extends NewTestTemplate {
 
-  Credentials credentials = config.getCredentials();
-  File captchaFile = config.getCaptchaFile();
   private static String userName;
   private static String password;
+  Credentials credentials = config.getCredentials();
+  File captchaFile = config.getCaptchaFile();
 
   @Test(groups = {"SignUp_001", "SignUp"})
   public void SignUp_001_captchaNotChecked() {
@@ -50,11 +45,8 @@ public class SignUpTests extends NewTestTemplate {
     signUp.typeUserName(signUp.getTimeStamp());
     signUp.typeEmail(credentials.emailQaart1);
     signUp.typePassword(signUp.getTimeStamp());
-    signUp.enterBirthDate(
-        PageContent.WIKI_SIGN_UP_BIRTHMONTH,
-        PageContent.WIKI_SIGN_UP_BIRTHDAY,
-        PageContent.WIKI_SIGN_UP_BIRTHYEAR
-    );
+    signUp.enterBirthDate(PageContent.WIKI_SIGN_UP_BIRTHMONTH, PageContent.WIKI_SIGN_UP_BIRTHDAY,
+        PageContent.WIKI_SIGN_UP_BIRTHYEAR);
     signUp.submit();
     signUp.verifyCaptchaInvalidMessage();
   }
@@ -71,8 +63,7 @@ public class SignUpTests extends NewTestTemplate {
         // +1 because months are numerated from 0
         Integer.toString(currentDate.get(Calendar.MONTH) + 1),
         Integer.toString(currentDate.get(Calendar.DAY_OF_MONTH)),
-        Integer.toString(currentDate.get(Calendar.YEAR) - PageContent.MIN_AGE)
-    );
+        Integer.toString(currentDate.get(Calendar.YEAR) - PageContent.MIN_AGE));
     signUp.verifyTooYoungMessage();
   }
 
@@ -97,20 +88,15 @@ public class SignUpTests extends NewTestTemplate {
     signUp.typeEmail(email);
     signUp.typeUserName(userName);
     signUp.typePassword(password);
-    signUp.enterBirthDate(
-        PageContent.WIKI_SIGN_UP_BIRTHMONTH,
-        PageContent.WIKI_SIGN_UP_BIRTHDAY,
-        PageContent.WIKI_SIGN_UP_BIRTHYEAR
-    );
+    signUp.enterBirthDate(PageContent.WIKI_SIGN_UP_BIRTHMONTH, PageContent.WIKI_SIGN_UP_BIRTHDAY,
+        PageContent.WIKI_SIGN_UP_BIRTHYEAR);
     AlmostTherePageObject almostTherePage = signUp.submit(email, emailPassword);
     almostTherePage.verifyAlmostTherePage();
-    ConfirmationPageObject
-        confirmPageAlmostThere =
+    ConfirmationPageObject confirmPageAlmostThere =
         almostTherePage.enterActivationLink(email, emailPassword, wikiURL);
     confirmPageAlmostThere.typeInUserName(userName);
     confirmPageAlmostThere.typeInPassword(password);
-    UserProfilePageObject
-        userProfile =
+    UserProfilePageObject userProfile =
         confirmPageAlmostThere.clickSubmitButton(email, emailPassword);
     userProfile.verifyUserLoggedIn(userName);
     CustomizedToolbarComponentObject toolbar = new CustomizedToolbarComponentObject(driver);
@@ -139,15 +125,11 @@ public class SignUpTests extends NewTestTemplate {
     signUp.typeEmail(email);
     signUp.typeUserName(userName);
     signUp.typePassword(password);
-    signUp.enterBirthDate(
-        PageContent.WIKI_SIGN_UP_BIRTHMONTH,
-        PageContent.WIKI_SIGN_UP_BIRTHDAY,
-        PageContent.WIKI_SIGN_UP_BIRTHYEAR
-    );
+    signUp.enterBirthDate(PageContent.WIKI_SIGN_UP_BIRTHMONTH, PageContent.WIKI_SIGN_UP_BIRTHDAY,
+        PageContent.WIKI_SIGN_UP_BIRTHYEAR);
     AlmostTherePageObject almostTherePage = signUp.submit(email, emailPassword);
     almostTherePage.verifyAlmostTherePage();
-    ConfirmationPageObject
-        confirmPageAlmostThere =
+    ConfirmationPageObject confirmPageAlmostThere =
         almostTherePage.enterActivationLink(email, emailPassword, wikiCorporateURL);
     confirmPageAlmostThere.typeInUserName(userName);
     confirmPageAlmostThere.typeInPassword(password);
@@ -168,11 +150,8 @@ public class SignUpTests extends NewTestTemplate {
     signUp.typeEmail(email);
     signUp.typeUserName(userName);
     signUp.typePassword(password);
-    signUp.enterBirthDate(
-        PageContent.WIKI_SIGN_UP_BIRTHMONTH,
-        PageContent.WIKI_SIGN_UP_BIRTHDAY,
-        PageContent.WIKI_SIGN_UP_BIRTHYEAR
-    );
+    signUp.enterBirthDate(PageContent.WIKI_SIGN_UP_BIRTHMONTH, PageContent.WIKI_SIGN_UP_BIRTHDAY,
+        PageContent.WIKI_SIGN_UP_BIRTHYEAR);
     AlmostTherePageObject almostTherePage = signUp.submit(email, emailPassword);
     almostTherePage.verifyAlmostTherePage();
 
@@ -182,15 +161,12 @@ public class SignUpTests extends NewTestTemplate {
   }
 
   /**
-   * pre-conditions: Facebook_001 test removes Wikia and Wikia Development
-   * App from Facebook Facebook_001 test stored in TestCases/FacebookTests/FacebookTests.java path
-   * Steps: 1. Log in to Facebook 2. Open finish signup with facebook modal 3. create and
-   * verify account 4. disconnect created account from facebook
+   * pre-conditions: Facebook_001 test removes Wikia and Wikia Development App from Facebook
+   * Facebook_001 test stored in TestCases/FacebookTests/FacebookTests.java path Steps: 1. Log in to
+   * Facebook 2. Open finish signup with facebook modal 3. create and verify account 4. disconnect
+   * created account from facebook
    */
-  @Test(
-      groups = {"SignUp_007", "SignUp", "Modals"},
-      invocationCount = 1
-  )
+  @Test(groups = {"SignUp_007", "SignUp", "Modals"}, invocationCount = 25)
   public void SignUp_007_signUpWithFacebook() {
     new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
         credentials.passwordFB);
@@ -215,14 +191,18 @@ public class SignUpTests extends NewTestTemplate {
   }
 
   @AfterGroups(groups = {"SignUp_007"}, alwaysRun = true)
-  public void dissconnectFromFB(){
+  public void disconnectFromFB() {
     startBrowser();
-    WikiBasePageObject base = new WikiBasePageObject(driver);
-    base.openWikiPage(wikiURL);
-    base.logInCookie(userName, password, wikiURL);
-    base.verifyUserLoggedIn(userName);
-    PreferencesPageObject preferences = base.openSpecialPreferencesPage(wikiURL);
-    preferences.selectTab(tabNames.FACEBOOK);
-    preferences.disconnectFromFacebook();
+    if (userName != null) {
+      WikiBasePageObject base = new WikiBasePageObject(driver);
+      base.openWikiPage(wikiURL);
+      base.logInCookie(userName, password, wikiURL);
+      base.verifyUserLoggedIn(userName);
+      PreferencesPageObject preferences = base.openSpecialPreferencesPage(wikiURL);
+      preferences.selectTab(tabNames.FACEBOOK);
+      preferences.disconnectFromFacebook();
+    } else {
+      stopBrowser();
+    }
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -186,8 +186,10 @@ public class SignUpTests extends NewTestTemplate {
     fbModal.typeUserName(userName);
     fbModal.typePassword(password);
     fbModal.createAccount();
-    fbModal.verifyUserLoggedIn(userName);
-    fbModal.logOut(wikiURL);
+    base.openWikiPage(wikiURL);
+    base.appendToUrl("noads=1");
+    base.verifyUserLoggedIn(userName);
+    base.logOut(wikiURL);
   }
 
   @AfterGroups(groups = {"SignUp_007"}, alwaysRun = true)

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -11,6 +11,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.createnewwiki.CreateNew
 import com.wikia.webdriver.pageobjectsfactory.pageobject.createnewwiki.CreateNewWikiPageObjectStep1;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookMainPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.FacebookUserPageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.facebook.RemoveFacebookPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.AlmostTherePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.ConfirmationPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.SignUpPageObject;
@@ -18,6 +19,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.UserProfilePageO
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.login.SpecialUserLoginPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject.tabNames;
+import com.wikia.webdriver.testcases.facebooktests.FacebookTests;
 
 import org.testng.annotations.Test;
 
@@ -183,11 +185,15 @@ public class SignUpTests extends NewTestTemplate {
    */
   @Test(
       groups = {"SignUp_007", "SignUp", "Modals"},
-      dependsOnGroups = "Facebook_001",
       invocationCount = 25
   )
   public void SignUp_007_signUpWithFacebook() {
+    new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
+                                                         credentials.passwordFB);
+    stopBrowser();
+    startBrowser();
     WikiBasePageObject base = new WikiBasePageObject(driver);
+    base.openWikiPage(wikiURL);
     FacebookMainPageObject fbLogin = base.openFacebookMainPage();
     FacebookUserPageObject userFB;
     userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -186,8 +186,8 @@ public class SignUpTests extends NewTestTemplate {
     fbModal.typeUserName(userName);
     fbModal.typePassword(password);
     fbModal.createAccount();
-    signUp.verifyUserLoggedIn(userName);
-    signUp.logOut(wikiURL);
+    fbModal.verifyUserLoggedIn(userName);
+    fbModal.logOut(wikiURL);
   }
 
   @AfterGroups(groups = {"SignUp_007"}, alwaysRun = true)
@@ -204,5 +204,6 @@ public class SignUpTests extends NewTestTemplate {
     } else {
       stopBrowser();
     }
+    driver.quit();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -184,7 +184,7 @@ public class SignUpTests extends NewTestTemplate {
   @Test(
       groups = {"SignUp_007", "SignUp", "Modals"},
       dependsOnGroups = "Facebook_001",
-      enabled = true
+      invocationCount = 25
   )
   public void SignUp_007_signUpWithFacebook() {
     WikiBasePageObject base = new WikiBasePageObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -5,6 +5,7 @@ import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.modalwindows.FacebookSignupModalComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.toolbars.CustomizedToolbarComponentObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.BasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.createnewwiki.CreateNewWikiLogInSignUpPageObject;
@@ -21,6 +22,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.Pre
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject.tabNames;
 import com.wikia.webdriver.testcases.facebooktests.FacebookTests;
 
+import org.testng.annotations.AfterGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -38,6 +40,8 @@ public class SignUpTests extends NewTestTemplate {
 
   Credentials credentials = config.getCredentials();
   File captchaFile = config.getCaptchaFile();
+  private static String userName;
+  private static String password;
 
   @Test(groups = {"SignUp_001", "SignUp"})
   public void SignUp_001_captchaNotChecked() {
@@ -185,11 +189,11 @@ public class SignUpTests extends NewTestTemplate {
    */
   @Test(
       groups = {"SignUp_007", "SignUp", "Modals"},
-      invocationCount = 25
+      invocationCount = 1
   )
   public void SignUp_007_signUpWithFacebook() {
     new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
-                                                         credentials.passwordFB);
+        credentials.passwordFB);
     stopBrowser();
     startBrowser();
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -198,20 +202,26 @@ public class SignUpTests extends NewTestTemplate {
     FacebookUserPageObject userFB;
     userFB = fbLogin.login(credentials.emailFB, credentials.passwordFB);
     userFB.verifyPageLogo();
-    SignUpPageObject signUp = userFB.openSpecialSignUpPage(wikiURL);
+    SignUpPageObject signUp = userFB.navigateToSpecialSignUpPage(wikiURL);
     FacebookSignupModalComponentObject fbModal = signUp.clickFacebookSignUp();
     fbModal.acceptWikiaAppPolicy();
-    String userName = "QA" + signUp.getTimeStamp();
-    String password = "Pass" + signUp.getTimeStamp();
+    userName = "QA" + signUp.getTimeStamp();
+    password = "Pass" + signUp.getTimeStamp();
     fbModal.typeUserName(userName);
     fbModal.typePassword(password);
     fbModal.createAccount();
     signUp.verifyUserLoggedIn(userName);
     signUp.logOut(wikiURL);
-    signUp.openWikiPage(wikiURL);
-    signUp.logInCookie(userName, password, wikiURL);
-    signUp.verifyUserLoggedIn(userName);
-    PreferencesPageObject preferences = signUp.openSpecialPreferencesPage(wikiURL);
+  }
+
+  @AfterGroups(groups = {"SignUp_007"}, alwaysRun = true)
+  public void dissconnectFromFB(){
+    startBrowser();
+    WikiBasePageObject base = new WikiBasePageObject(driver);
+    base.openWikiPage(wikiURL);
+    base.logInCookie(userName, password, wikiURL);
+    base.verifyUserLoggedIn(userName);
+    PreferencesPageObject preferences = base.openSpecialPreferencesPage(wikiURL);
     preferences.selectTab(tabNames.FACEBOOK);
     preferences.disconnectFromFacebook();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/signuptests/SignUpTests.java
@@ -166,12 +166,10 @@ public class SignUpTests extends NewTestTemplate {
    * Facebook 2. Open finish signup with facebook modal 3. create and verify account 4. disconnect
    * created account from facebook
    */
-  @Test(groups = {"SignUp_007", "SignUp", "Modals"}, invocationCount = 25)
+  @Test(groups = {"SignUp_007", "SignUp", "Modals"})
   public void SignUp_007_signUpWithFacebook() {
     new RemoveFacebookPageObject(driver).removeWikiaApps(credentials.emailFB,
         credentials.passwordFB);
-    stopBrowser();
-    startBrowser();
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.openWikiPage(wikiURL);
     FacebookMainPageObject fbLogin = base.openFacebookMainPage();


### PR DESCRIPTION
moved the remove facebook function to it's own page object and added an after method to clean up prefs when test is finished running.