### PR TITLE
QAART-537 Fix for RTE_019_MoreSympolsTools

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -68,6 +68,8 @@ public class SourceEditModePageObject extends EditMode {
   private WebElement sourceModeLoadingIndicator;
   @FindBy(css = ".editpage-editarea")
   private WebElement sourceOnlyModeTextArea;
+  @FindBy(css = "body.modalShown")
+  private WebElement editorModal;
 
   @FindBy(css = ".cke_source")
   private WebElement sourceModeTextArea;
@@ -287,6 +289,7 @@ public class SourceEditModePageObject extends EditMode {
       driver.findElement(
           By.xpath("//section[@class='modalContent']//span[@id='edittools_symbols']/a[" + i + "]"))
           .click();
+      waitForElementNotVisibleByElement(editorModal);
       checkSourceContent(content);
     }
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -68,8 +68,10 @@ public class SourceEditModePageObject extends EditMode {
   private WebElement sourceModeLoadingIndicator;
   @FindBy(css = ".editpage-editarea")
   private WebElement sourceOnlyModeTextArea;
-  @FindBy(css = "body.modalShown")
+  @FindBy(css = ".modalWrapper")
   private WebElement editorModal;
+  @FindBy(css = ".blackout")
+  private WebElement focusedMode;
 
   @FindBy(css = ".cke_source")
   private WebElement sourceModeTextArea;
@@ -290,6 +292,7 @@ public class SourceEditModePageObject extends EditMode {
           By.xpath("//section[@class='modalContent']//span[@id='edittools_symbols']/a[" + i + "]"))
           .click();
       waitForElementNotVisibleByElement(editorModal);
+      waitForElementNotVisibleByElement(focusedMode);
       checkSourceContent(content);
     }
   }

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
@@ -276,7 +276,7 @@ public class ArticleSourceModeTests extends NewTestTemplate {
   }
 
   @Test(groups = {"RTE_extended", "RTE_extended_019"})
-  public void RTE_019_MoreSympolsTools_QAART_537() {
+  public void RTE_019_MoreSympolsTools() {
     String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
     ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
     SourceEditModePageObject source = article.openCurrectArticleSourceMode();


### PR DESCRIPTION
The test would fail sometimes if the test tries to click on the submit button when the modal is up. When the modal is up, is when there is a white overlay that is blocking the button. Adding wait for those items to be gone after clicking the button to close the modal.