### PR TITLE
QAART-521: Fixing the ImageStorage001 test

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialNewFilesPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialNewFilesPageObject.java
@@ -34,7 +34,7 @@ public class SpecialNewFilesPageObject extends SpecialPageObject {
   private WebElement ignoreAnyWarnings;
   @FindBy(css = "div.wikia-gallery div.wikia-gallery-item img")
   private WebElement wikiaPreviewImg;
-  @FindBy(css = "div.wikia-gallery div.wikia-gallery-item img:first")
+  @FindBy(css = "div.wikia-gallery div.wikia-gallery-item:first-child img")
   private WebElement latestWikiaPreviewImg;
   @FindBys(@FindBy(css = "#mw-content-text img"))
   private List<WebElement> imagesNewFiles;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialNewFilesPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialNewFilesPageObject.java
@@ -34,6 +34,8 @@ public class SpecialNewFilesPageObject extends SpecialPageObject {
   private WebElement ignoreAnyWarnings;
   @FindBy(css = "div.wikia-gallery div.wikia-gallery-item img")
   private WebElement wikiaPreviewImg;
+  @FindBy(css = "div.wikia-gallery div.wikia-gallery-item img:first")
+  private WebElement latestWikiaPreviewImg;
   @FindBys(@FindBy(css = "#mw-content-text img"))
   private List<WebElement> imagesNewFiles;
   @FindBy(css = ".wikia-gallery div.wikia-gallery-item a.image")
@@ -101,7 +103,7 @@ public class SpecialNewFilesPageObject extends SpecialPageObject {
   public void verifyFileUploaded(String fileName) {
     driver.navigate().refresh();
     waitForValueToBePresentInElementsAttributeByElement(
-        wikiaPreviewImg,
+        latestWikiaPreviewImg,
         "src",
         fileName);
     PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
@@ -3,9 +3,6 @@
  */
 package com.wikia.webdriver.testcases.imageservingtests;
 
-import org.joda.time.DateTime;
-import org.testng.annotations.Test;
-
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
 import com.wikia.webdriver.common.properties.Credentials;
@@ -16,6 +13,9 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.actions.RenamePageObjec
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialNewFilesPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialRestorePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.filepage.FilePagePageObject;
+
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
 
 /**
  * @author Karol 'kkarolk' Kujawiak
@@ -34,7 +34,7 @@ public class ImageStorageTests extends NewTestTemplate {
   @UseUnstablePageLoadStrategy
   public void ImageStorage_001_deleteImage_QAART_521() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
-    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+    base.logInCookie(credentials.userNameStaff2, credentials.passwordStaff2, wikiURL);
 
     SpecialNewFilesPageObject filesPage = base.openSpecialNewFiles(wikiURL);
     filesPage.addPhoto();

--- a/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
@@ -32,7 +32,7 @@ public class ImageStorageTests extends NewTestTemplate {
 
   @Test(groups = {"ImageStorageTests", "ImageStorage_001"})
   @UseUnstablePageLoadStrategy
-  public void ImageStorage_001_deleteImage_QAART_521() {
+  public void ImageStorage_001_deleteImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff2, credentials.passwordStaff2, wikiURL);
 


### PR DESCRIPTION
The issue with the test failing is because the selector is not targeting the latest file that was uploaded. Since each individual uploaded file has a unique random filename, sometimes when it would select a different file that the value of 'src' would not match.