### PR TITLE
QAART-568: Create new annotation to disable flash plugin

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/driverprovider/DisableFlash.java
+++ b/src/test/java/com/wikia/webdriver/common/driverprovider/DisableFlash.java
@@ -1,0 +1,18 @@
+package com.wikia.webdriver.common.driverprovider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by Ludwik Kaźmierczak on 2015-04-09. <p/> Annotate test method if you want to disable
+ * Flash plugin for webdriver. This would eliminate the problem which the driver quits before
+ * the plugin quits during tear down.
+ * If the driver quits first, then it would causes a long delay in run time.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface DisableFlash {
+
+}

--- a/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
@@ -47,6 +47,7 @@ public class NewDriverProvider {
   private static UserAgentsRegistry userAgentRegistry = new UserAgentsRegistry();
   private static boolean unstablePageLoadStrategy = false;
   private static AndroidDriver mobileDriver;
+  private static boolean disableFlash = false;
 
   private NewDriverProvider() {
 
@@ -199,6 +200,10 @@ public class NewDriverProvider {
       firefoxProfile.setPreference("webdriver.load.strategy", "unstable");
     }
 
+    if (disableFlash) {
+      firefoxProfile.setPreference("plugin.state.flash", 0);
+    }
+
     caps.setCapability(FirefoxDriver.PROFILE, firefoxProfile);
 
     //Adding console logging for FF browser
@@ -320,6 +325,10 @@ public class NewDriverProvider {
 
   public static void setUnstablePageLoadStrategy(boolean value) {
     unstablePageLoadStrategy = value;
+  }
+
+  public static void setDisableFlash(boolean value) {
+    disableFlash = value;
   }
 
   public static AndroidDriver getMobileDriver() {

--- a/src/test/java/com/wikia/webdriver/common/templates/NewTestTemplate.java
+++ b/src/test/java/com/wikia/webdriver/common/templates/NewTestTemplate.java
@@ -1,6 +1,7 @@
 package com.wikia.webdriver.common.templates;
 
 import com.wikia.webdriver.common.core.annotations.UserAgent;
+import com.wikia.webdriver.common.driverprovider.DisableFlash;
 import com.wikia.webdriver.common.driverprovider.NewDriverProvider;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
 
@@ -28,6 +29,10 @@ public class NewTestTemplate extends NewTestTemplateCore {
 
     if (method.isAnnotationPresent(UseUnstablePageLoadStrategy.class)) {
       NewDriverProvider.setUnstablePageLoadStrategy(true);
+    }
+
+    if (method.isAnnotationPresent(DisableFlash.class)) {
+      NewDriverProvider.setDisableFlash(true);
     }
 
     startBrowser();

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.testcases.monetizationtests.monetizationmodule;
 
+import com.wikia.webdriver.common.driverprovider.DisableFlash;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.monetizationmodule.MonetizationModuleComponentObject;
@@ -31,7 +32,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
   private static final String TEST_ECOMMERCE_SINGLE_DARK_WIKI = "masseffect";
   private static final String TEST_ECOMMERCE_SINGLE_DARK_ARTICLE = "Combat";
   private static final String TEST_ECOMMERCE_SINGLE_LIGHT_WIKI = "fallout";
-  private static final String TEST_ECOMMERCE_SINGLE_LIGHT_ARTICLE = "Crocket";
+  private static final String TEST_ECOMMERCE_SINGLE_LIGHT_ARTICLE = "Fallout_2_characters";
   private static final String TEST_ECOMMERCE_MULTI_DARK_WIKI = "elderscrolls";
   private static final String TEST_ECOMMERCE_MULTI_DARK_ARTICLE = "Skyrim";
   private static final String TEST_ECOMMERCE_MULTI_LIGHT_WIKI = "es.pokemon";
@@ -236,6 +237,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_008",
       groups = {"MonetizationModule", "MonetizationModuleTest_008", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_008(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle) {
     wikiURL = urlBuilder.getUrlForWiki(testWiki);
@@ -281,6 +283,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleGeoTestWikis",
       groups = {"MonetizationModule", "MonetizationModuleTest_009", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_009(String testWiki, String testArticle) {
     wikiURL = urlBuilder.getUrlForWiki(testWiki);
     String articleURL = urlBuilder.getUrlForPath(testWiki, testArticle);
@@ -357,6 +360,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_011",
       groups = {"MonetizationModule", "MonetizationModuleTest_011", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_011(String countryCode, Boolean isFromsearch) {
     wikiURL = urlBuilder.getUrlForWiki(TEST_TOP_100_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_TOP_100_WIKI, TEST_TOP_100_ARTICLE);
@@ -402,6 +406,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_012",
       groups = {"MonetizationModule", "MonetizationModuleTest_012", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_012(String testWiki, String testArticle) {
     wikiURL = urlBuilder.getUrlForWiki(testWiki);
     String articleURL = urlBuilder.getUrlForPath(testWiki, testArticle);
@@ -443,6 +448,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_013",
       groups = {"MonetizationModule", "MonetizationModuleTest_013", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_013(String countryCode) {
     wikiURL = urlBuilder.getUrlForWiki(TEST_TOP_700_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_TOP_700_WIKI, TEST_TOP_700_ARTICLE);
@@ -484,6 +490,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_014",
       groups = {"MonetizationModule", "MonetizationModuleTest_014", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_014(String testWiki, String testArticle, String countryCode) {
     wikiURL = urlBuilder.getUrlForWiki(testWiki);
     String articleURL = urlBuilder.getUrlForPath(testWiki, testArticle);
@@ -525,6 +532,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_015",
       groups = {"MonetizationModule", "MonetizationModuleTest_015", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_015(String countryCode) {
     wikiURL = urlBuilder.getUrlForWiki(TEST_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -589,6 +597,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_017",
       groups = {"MonetizationModule", "MonetizationModuleTest_017", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_017(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle) {
 
@@ -637,6 +646,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_018",
       groups = {"MonetizationModule", "MonetizationModuleTest_018", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_018(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle) {
 
@@ -708,6 +718,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_020",
       groups = {"MonetizationModule", "MonetizationModuleTest_020", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_020(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle) {
 
@@ -765,6 +776,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_021",
       groups = {"MonetizationModule", "MonetizationModuleTest_021", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_021(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle, int isMulti) {
 
@@ -819,6 +831,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleTest_022",
       groups = {"MonetizationModule", "DataMonetizationModuleTest_022", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_022(String countryCode, Boolean isFromsearch, String testWiki,
                                          String testArticle, int isMulti) {
 

--- a/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/monetizationtests/monetizationmodule/MonetizationModuleTests.java
@@ -47,6 +47,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_001", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_001() {
     wikiURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -66,6 +67,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_002", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_002() {
     wikiURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -85,6 +87,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_003", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_003() {
     wikiURL = urlBuilder.getUrlForWiki(TEST_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -106,6 +109,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_004", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_004() {
     wikiURL = urlBuilder.getUrlForWiki(TEST_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -141,6 +145,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModule_005",
       groups = {"MonetizationModule", "MonetizationModuleTest_005", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_005(int width, int height, int expectedInContent,
                                          int expectedOthers) {
     wikiURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -165,6 +170,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_006", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_006() {
     wikiURL = urlBuilder.getUrlForWiki(TEST_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -193,6 +199,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_007", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_007() {
     wikiURL = urlBuilder.getUrlForWiki(TEST_WIKI);
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
@@ -316,6 +323,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModuleGeoTestWikis",
       groups = {"MonetizationModule", "MonetizationModuleTest_010", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_010(String testWiki, String testArticle) {
     wikiURL = urlBuilder.getUrlForWiki(testWiki);
     String articleURL = urlBuilder.getUrlForPath(testWiki, testArticle);
@@ -562,6 +570,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
    * @author Saipetch Kongkatong
    */
   @Test(groups = {"MonetizationModule", "MonetizationModuleTest_016", "Monetization"})
+  @DisableFlash
   public void MonetizationModuleTest_016() {
     String articleURL = urlBuilder.getUrlForPath(TEST_WIKI, TEST_ARTICLE);
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -682,6 +691,7 @@ public class MonetizationModuleTests extends NewTestTemplate {
       dataProvider = "DataMonetizationModule_005",
       groups = {"MonetizationModule", "MonetizationModuleTest_019", "Monetization"}
   )
+  @DisableFlash
   public void MonetizationModuleTest_019(int width, int height, int expectedInContent,
                                          int expectedOthers) {
     wikiURL = urlBuilder.getUrlForPath(TEST_AMAZON_WIKI, TEST_AMAZON_ARTICLE);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/QAART-568
Address issue which FF browser is not tearing down properly due to plugin such as Flash.
Attempt to upgrade to the latest supported FF version 33.1.1 did not address the issue, hence the reason of this annotation.