### PR TITLE
QAART-568: Adding a parameter to disable Adobe flash (for FF)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
 						<mobile-config>/selenium-config/mobile-config.xml</mobile-config>
 						<config>/selenium-config/config.xml</config>
 						<captcha>/selenium-config/captcha.txt</captcha>
+						<disable-flash>${disable-flash}</disable-flash>
 					</systemPropertyVariables>
 					<suiteXmlFiles>
 						<suiteXmlFile>${testSuite}</suiteXmlFile>

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ The following are valid test parameters:
 * `-Dwiki-name` - The wiki where the test(s) should be run on, for example "mediawiki119", "muppet"
 * `-Dgroups` - (Optional) Which test groups to run, for example "Chat". Optional. Uses all tests if omitted
 * `-Dlive-domain` - (Optional) The base URL to run in the browser, for example "http://www.wikia.com/". Only required for Hubs tests
+* `-Ddisable-flash` - (Optional) Disable Flash plugin, any String value = true
 
 ### Browsers
 

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/AbstractConfiguration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/AbstractConfiguration.java
@@ -33,6 +33,8 @@ public abstract class AbstractConfiguration {
 
   public abstract String getCredentialsFilePath();
 
+  public abstract String getDisableFlash();
+
   public Credentials getCredentials() {
     return new Credentials(new File(this.getCredentialsFilePath()));
   }

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/ManualConfiguration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/ManualConfiguration.java
@@ -90,4 +90,9 @@ public class ManualConfiguration extends AbstractConfiguration {
   public String getDeviceName() {
     return config.get("device-name");
   }
+
+  @Override
+  public String getDisableFlash() {
+    return config.get("disable-flash");
+  }
 }

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/ManualConfiguration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/ManualConfiguration.java
@@ -93,6 +93,6 @@ public class ManualConfiguration extends AbstractConfiguration {
 
   @Override
   public String getDisableFlash() {
-    return config.get("disable-flash");
+    return String.valueOf(config.get("disable-flash"));
   }
 }

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/POMConfiguration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/POMConfiguration.java
@@ -93,4 +93,9 @@ public class POMConfiguration extends AbstractConfiguration {
   public String getDeviceName() {
     return System.getProperty("device-name");
   }
+
+  @Override
+  public String getDisableFlash() {
+    return System.getProperty("disable-flash");
+  }
 }

--- a/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
@@ -199,6 +199,10 @@ public class NewDriverProvider {
       firefoxProfile.setPreference("webdriver.load.strategy", "unstable");
     }
 
+    if (StringUtils.isNotBlank(ConfigurationFactory.getConfig().getDisableFlash().toString())) {
+      firefoxProfile.setPreference("plugin.state.flash", 0);
+    }
+
     caps.setCapability(FirefoxDriver.PROFILE, firefoxProfile);
 
     //Adding console logging for FF browser

--- a/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/driverprovider/NewDriverProvider.java
@@ -199,7 +199,7 @@ public class NewDriverProvider {
       firefoxProfile.setPreference("webdriver.load.strategy", "unstable");
     }
 
-    if (StringUtils.isNotBlank(ConfigurationFactory.getConfig().getDisableFlash().toString())) {
+    if (StringUtils.isNotBlank(ConfigurationFactory.getConfig().getDisableFlash())) {
       firefoxProfile.setPreference("plugin.state.flash", 0);
     }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/QAART-568
Disabling Adobe Flash to ensure that FF would exit all of the plugins before the driver exits.
This would make the FF run time to be normal again as org.openqa.selenium.os.UnixProcess$SeleniumWatchDog destroyHarder should no longer happen on Jenkins