### PR TITLE
QAART-574 Fix for RTE_017_MoreMainTools

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -261,6 +261,8 @@ public class SourceEditModePageObject extends EditMode {
       driver.findElement(
           By.xpath("//section[@class='modalContent']//span[@id='edittools_main']/a[" + i + "]"))
           .click();
+      waitForElementNotVisibleByElement(editorModal);
+      waitForElementNotVisibleByElement(focusedMode);
       checkSourceContent(content);
     }
   }
@@ -275,6 +277,8 @@ public class SourceEditModePageObject extends EditMode {
       driver.findElement(By.xpath(
           "//section[@class='modalContent']//span[@id='edittools_wikimarkup']/a[" + i + "]"))
           .click();
+      waitForElementNotVisibleByElement(editorModal);
+      waitForElementNotVisibleByElement(focusedMode);
       checkSourceContent(content);
     }
   }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/QAART-574
One of the issues to cause a fail is that if the tool modal is still opened, the focus mode layer would block the interaction of the clicking on the submit button.
Adding wait for the modal and the focus mode to disappear before proceeding of next action.
This should alleviate issues for RTE_017, RTE_018, and RTE_019