### PR TITLE
ADEN-1989 Test ads on consecutive page views

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -117,7 +117,9 @@ public class MobileAdsDataProvider {
   public static Object[][] mercuryConsecutivePageViews() {
       return new Object[][]{
         {
-            "adtest", "SyntheticTests/Slots/leaderboard+prefooter",
+            "adtest", "SyntheticTests/Slots/MercuryOnConsecutivePageViews1",
+            "SyntheticTests/Slots/MercuryOnConsecutivePageViews2",
+            "SyntheticTests/Slots/MercuryOnConsecutivePageViews3",
             "wka.ent/_adtest//article",
         }
       };

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -9,119 +9,119 @@ import java.util.Arrays;
  */
 public class MobileAdsDataProvider {
 
-  private MobileAdsDataProvider() {
+    private MobileAdsDataProvider() {
 
-  }
+    }
 
-  @DataProvider
-  public static Object[][] leaderboardAndPrefooterSlots() {
-    return new Object[][]{
-        {
-            "adtest", "SyntheticTests/Slots/leaderboard+prefooter",
-            "wka.ent/_adtest//article",
-            "googlesyndication.com/simgad/8216620376696319112",
-            "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
-        }
-    };
-  }
+    @DataProvider
+    public static Object[][] leaderboardAndPrefooterSlots() {
+        return new Object[][]{
+                {
+                        "adtest", "SyntheticTests/Slots/leaderboard+prefooter",
+                        "wka.ent/_adtest//article",
+                        "googlesyndication.com/simgad/8216620376696319112",
+                        "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
+                }
+        };
+    }
 
-  @DataProvider
-  public static Object[][] leaderboardAndInContentSlots() {
-    return new Object[][]{
-        {
-            "adtest", "SyntheticTests/Slots/leaderboard+in_content",
-            "wka.ent/_adtest//article",
-            "googlesyndication.com/simgad/8216620376696319112",
-            "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
-        }
-    };
-  }
+    @DataProvider
+    public static Object[][] leaderboardAndInContentSlots() {
+        return new Object[][]{
+                {
+                        "adtest", "SyntheticTests/Slots/leaderboard+in_content",
+                        "wka.ent/_adtest//article",
+                        "googlesyndication.com/simgad/8216620376696319112",
+                        "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
+                }
+        };
+    }
 
-  @DataProvider
-  public static Object[][] allSlots() {
-    return new Object[][]{
-        {
-            "adtest", "SyntheticTests/Slots/leaderboard+in content+prefooter",
-            "wka.ent/_adtest//article",
-            "googlesyndication.com/simgad/8216620376696319112",
-            "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
-        }
-    };
-  }
+    @DataProvider
+    public static Object[][] allSlots() {
+        return new Object[][]{
+                {
+                        "adtest", "SyntheticTests/Slots/leaderboard+in content+prefooter",
+                        "wka.ent/_adtest//article",
+                        "googlesyndication.com/simgad/8216620376696319112",
+                        "googlesyndication.com/pagead/imgad?id=CICAgKCNj62dEhCsAhj6ASgBMgjBw3U0lR5Thg"
+                }
+        };
+    }
 
-  @DataProvider
-  public static Object[][] articlesWithTopLeaderboard() {
-    return new Object[][]{
-        {"elderscrolls", "Skyrim"},
-        {"it.creepypasta", "Slenderman"},
-        {"ja.gundam", "%E3%82%AC%E3%83%B3%E3%83%80%E3%83%9A%E3%83%87%E3%82%A3%E3%82%A2"},
-        {"wowwiki", "Portal:Main"},
-        {"muppet", "Kermit"},
-        {"warframe", "WARFRAME_Wiki"},
-        {"gameofthrones", "Season_4"},
-        {"dragon-story", "Battle_Arena"},
-        {"zh.chain-chronicle", "Chain_Chronicle_维基"},
-        {"zh.pad", "Homepage/Mobile"}
-    };
-  }
+    @DataProvider
+    public static Object[][] articlesWithTopLeaderboard() {
+        return new Object[][]{
+                {"elderscrolls", "Skyrim"},
+                {"it.creepypasta", "Slenderman"},
+                {"ja.gundam", "%E3%82%AC%E3%83%B3%E3%83%80%E3%83%9A%E3%83%87%E3%82%A3%E3%82%A2"},
+                {"wowwiki", "Portal:Main"},
+                {"muppet", "Kermit"},
+                {"warframe", "WARFRAME_Wiki"},
+                {"gameofthrones", "Season_4"},
+                {"dragon-story", "Battle_Arena"},
+                {"zh.chain-chronicle", "Chain_Chronicle_维基"},
+                {"zh.pad", "Homepage/Mobile"}
+        };
+    }
 
-  @DataProvider
-  public static Object[][] dfpParams() {
-    return new Object[][]{
-        {
-            "adtest",
-            "SyntheticTests/DfpParams",
-            "wka.ent/_adtest//article",
-            "MOBILE_TOP_LEADERBOARD",
-            "115974612",
-            "50006703732",
-            Arrays.asList(
-                "\"s0\":\"ent\"",
-                "\"s1\":\"_adtest\"",
-                "\"s2\":\"article\"",
-                "\"dmn\":\"wikiacom\"",
-                "\"hostpre\":\"",
-                "\"wpage\":\"synthetictests/dfpparams\"",
-                "\"ref\":\"direct\"",
-                "\"lang\":\"en\"",
-                "\"esrb\":\"teen\""
-            ),
-            Arrays.asList(
-                "\"pos\":\"MOBILE_TOP_LEADERBOARD\"",
-                "\"src\":\"mobile\""
-            )
-        }
-    };
-  }
+    @DataProvider
+    public static Object[][] dfpParams() {
+        return new Object[][]{
+                {
+                        "adtest",
+                        "SyntheticTests/DfpParams",
+                        "wka.ent/_adtest//article",
+                        "MOBILE_TOP_LEADERBOARD",
+                        "115974612",
+                        "50006703732",
+                        Arrays.asList(
+                                "\"s0\":\"ent\"",
+                                "\"s1\":\"_adtest\"",
+                                "\"s2\":\"article\"",
+                                "\"dmn\":\"wikiacom\"",
+                                "\"hostpre\":\"",
+                                "\"wpage\":\"synthetictests/dfpparams\"",
+                                "\"ref\":\"direct\"",
+                                "\"lang\":\"en\"",
+                                "\"esrb\":\"teen\""
+                        ),
+                        Arrays.asList(
+                                "\"pos\":\"MOBILE_TOP_LEADERBOARD\"",
+                                "\"src\":\"mobile\""
+                        )
+                }
+        };
+    }
 
-  @DataProvider
-  public static Object[][] testSynthetic() {
-    return new Object[][]{
-        {"adtest", "SyntheticTests/MobileLeaderboard", "MOBILE_TOP_LEADERBOARD", 320, 100,
-         136987812,
-         "mobile", "src/test/resources/adsResources/mobiletl320x100"}
-    };
-  }
+    @DataProvider
+    public static Object[][] testSynthetic() {
+        return new Object[][]{
+                {"adtest", "SyntheticTests/MobileLeaderboard", "MOBILE_TOP_LEADERBOARD", 320, 100,
+                        136987812,
+                        "mobile", "src/test/resources/adsResources/mobiletl320x100"}
+        };
+    }
 
-  @DataProvider
-  public static Object[][] testDisableGptAds() {
-    return new Object[][]{
-        {
-            "adtest", "SyntheticTests/ProvidersChain", "InstantGlobals.wgSitewideDisableGpt=1",
-            "MOBILE_TOP_LEADERBOARD", "mobile; mobile_remnant", ""
-        },
-    };
-  }
+    @DataProvider
+    public static Object[][] testDisableGptAds() {
+        return new Object[][]{
+                {
+                        "adtest", "SyntheticTests/ProvidersChain", "InstantGlobals.wgSitewideDisableGpt=1",
+                        "MOBILE_TOP_LEADERBOARD", "mobile; mobile_remnant", ""
+                },
+        };
+    }
 
-  @DataProvider
-  public static Object[][] mercuryConsecutivePageViews() {
-      return new Object[][]{
-        {
-            "adtest", "SyntheticTests/Slots/MercuryOnConsecutivePageViews1",
-            "SyntheticTests/Slots/MercuryOnConsecutivePageViews2",
-            "SyntheticTests/Slots/MercuryOnConsecutivePageViews3",
-            "wka.ent/_adtest//article",
-        }
-      };
-  }
+    @DataProvider
+    public static Object[][] mercuryConsecutivePageViews() {
+        return new Object[][]{
+                {
+                        "adtest", "SyntheticTests/Slots/MercuryOnConsecutivePageViews1",
+                        "SyntheticTests/Slots/MercuryOnConsecutivePageViews2",
+                        "SyntheticTests/Slots/MercuryOnConsecutivePageViews3",
+                        "wka.ent/_adtest//article",
+                }
+        };
+    }
 }

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -112,4 +112,14 @@ public class MobileAdsDataProvider {
         },
     };
   }
+
+  @DataProvider
+  public static Object[][] mercuryConsecutivePageViews() {
+      return new Object[][]{
+        {
+            "adtest", "SyntheticTests/Slots/leaderboard+prefooter",
+            "wka.ent/_adtest//article",
+        }
+      };
+  }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -12,8 +12,10 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Bogna 'bognix' Knychala
@@ -24,6 +26,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
   private static final String FLITE_MASK_SELECTOR = ".flite-mask";
   private static final String MERCURY_WIKI_TITLE_SELECTOR = ".wiki-title a";
   private static final String WIKI_LINK_SELECTOR = "a[href^='/wiki/']";
+  private static final String MERCURY_LOADING_OVERLAY = "loading-overlay";
 
   private AdsComparison adsComparison;
 
@@ -169,6 +172,18 @@ public class MobileAdsBaseObject extends AdsBaseObject {
       }
     } else {
       PageObjectLogging.logWarning("mercuryNavigateToAnArticle()", "No links on main page!");
+    }
+  }
+
+  public void mercuryWaitForPageToLoad() {
+    driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
+    try {
+      PageObjectLogging.log("mercuryWaitForPageToLoad", "Waiting till loaded...", true, driver);
+      wait.until(
+        ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY))
+      );
+    } finally {
+      restoreDeaultImplicitWait();
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -75,7 +75,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
 
   public void verifyNoSlotPresent(String slotName) {
     if (checkIfElementOnPage("#" + slotName)) {
-      throw new NoSuchElementException("No slot found as expected");
+      throw new NoSuchElementException("No slot found as expected (" + slotName + ")");
     }
     PageObjectLogging.log("AdInSlot", "Slot is added to the page", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -26,7 +26,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
   private static final String FLITE_MASK_SELECTOR = ".flite-mask";
   private static final String MERCURY_WIKI_TITLE_SELECTOR = ".wiki-title a";
   private static final String WIKI_LINK_SELECTOR = "a[href^='/wiki/']";
-  private static final String MERCURY_LOADING_OVERLAY = "loading-overlay";
+  private static final String MERCURY_LOADING_OVERLAY_SELECTOR = ".loading-overlay";
 
   private AdsComparison adsComparison;
 
@@ -180,7 +180,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
     try {
       PageObjectLogging.log("mercuryWaitForPageToLoad", "Waiting till loaded...", true, driver);
       wait.until(
-        ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY))
+        ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY_SELECTOR))
       );
     } finally {
       restoreDeaultImplicitWait();

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -14,7 +14,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,8 +23,6 @@ public class MobileAdsBaseObject extends AdsBaseObject {
 
   private static final String SMART_BANNER_SELECTOR = ".smartbanner.android";
   private static final String FLITE_MASK_SELECTOR = ".flite-mask";
-  private static final String MERCURY_WIKI_TITLE_SELECTOR = ".wiki-title a";
-  private static final String WIKI_LINK_SELECTOR = "a[href^='/wiki/']";
   private static final String MERCURY_LOADING_OVERLAY_SELECTOR = ".loading-overlay";
 
   private AdsComparison adsComparison;
@@ -111,67 +108,33 @@ public class MobileAdsBaseObject extends AdsBaseObject {
   }
 
   /**
-   * Scrolls to the main page link (to hide top bars) and clicks the link
+   * Checks if link to /wiki/articleName exists on the page and clicks it
+   *
+   * @param articleLinkName part of link to another wiki article
    */
-  public void mercuryNavigateToMainPage() {
-    if (checkIfElementOnPage(MERCURY_WIKI_TITLE_SELECTOR)) {
-      WebElement mainPageLink = driver.findElement(By.cssSelector(MERCURY_WIKI_TITLE_SELECTOR));
-      scrollToElement(mainPageLink);
+  public void mercuryNavigateToAnArticle(String articleLinkName) {
+    String articleLinkSelector = String.format("a[href^='/wiki/%s']", articleLinkName);
+    if (checkIfElementOnPage(articleLinkSelector)) {
+      WebElement link = driver.findElement(By.cssSelector(articleLinkSelector));
 
       PageObjectLogging.log(
-        "mercuryNavigateToMainPage()",
+        "mercuryNavigateToAnArticle()",
         String.format(
-          "Clicking main page link: %s (%s)",
-          mainPageLink.getText(),
-          mainPageLink.getAttribute("href")
+          "Clicking: %s (%s)",
+          link.getText(),
+          link.getAttribute("href")
         ),
         true,
         driver
       );
 
-      mainPageLink.click();
-    }
-  }
-
-  /**
-   * Gets list of /wiki/* links on page and clicks the first valid
-   */
-  public void mercuryNavigateToAnArticle() {
-    if (checkIfElementOnPage(WIKI_LINK_SELECTOR)) {
-      String notArticlePattern = ".*\\/wiki\\/.*\\:.*";
-      List<WebElement> links = driver.findElements(By.cssSelector(WIKI_LINK_SELECTOR));
-
-      PageObjectLogging.log(
-        "mercuryNavigateToAnArticle()",
-        "Found " + links.size() + " internal links",
-        true,
-        driver
-      );
-
-      for(WebElement link : links) {
-        String href = link.getAttribute("href");
-        Boolean isArticle = !href.matches(notArticlePattern);
-        Boolean isMainPage = href.equals(getMercuryMainPageHref());
-
-        if (isArticle && !isMainPage) {
-          PageObjectLogging.log(
-            "mercuryNavigateToAnArticle()",
-            String.format(
-              "Link found, clicking: %s (%s)",
-              link.getText(),
-              link.getAttribute("href")
-            ),
-            true,
-            driver
-          );
-
-          scrollToElement(link);
-          link.click();
-          return;
-        }
-      }
+      scrollToElement(link);
+      link.click();
     } else {
-      PageObjectLogging.logWarning("mercuryNavigateToAnArticle()", "No links on main page!");
+      PageObjectLogging.logWarning(
+        "mercuryNavigateToAnArticle()",
+        "Could not find the link to: /wiki/" + articleLinkName
+      );
     }
   }
 
@@ -185,15 +148,6 @@ public class MobileAdsBaseObject extends AdsBaseObject {
     } finally {
       restoreDeaultImplicitWait();
     }
-  }
-
-  private String getMercuryMainPageHref() {
-    if (checkIfElementOnPage(MERCURY_WIKI_TITLE_SELECTOR)) {
-      WebElement mainPageLink = driver.findElement(By.cssSelector(MERCURY_WIKI_TITLE_SELECTOR));
-      return mainPageLink.getAttribute("href");
-    }
-
-    return "";
   }
 
   private void removeSmartBanner() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -75,9 +75,9 @@ public class MobileAdsBaseObject extends AdsBaseObject {
 
   public void verifyNoSlotPresent(String slotName) {
     if (checkIfElementOnPage("#" + slotName)) {
-      throw new NoSuchElementException("Slot is added to the page");
+      throw new NoSuchElementException("No slot found as expected");
     }
-    PageObjectLogging.log("AdInSlot", "No slot found as expected", true);
+    PageObjectLogging.log("AdInSlot", "Slot is added to the page", true);
   }
 
   public void verifySlotExpanded(String slotName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -83,9 +83,9 @@ public class MobileAdsBaseObject extends AdsBaseObject {
 
   public void verifyNoSlotPresent(String slotName) {
     if (checkIfElementOnPage("#" + slotName)) {
-      throw new NoSuchElementException("No slot found as expected (" + slotName + ")");
+      throw new NoSuchElementException("Slot is added to the page");
     }
-    PageObjectLogging.log("AdInSlot", "Slot is added to the page", true);
+    PageObjectLogging.log("AdInSlot", "No slot found as expected", true);
   }
 
   public void verifySlotExpanded(String slotName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -138,10 +138,19 @@ public class MobileAdsBaseObject extends AdsBaseObject {
     }
   }
 
-  public void mercuryWaitForPageToLoad() {
+  /**
+   * Mercury is a single page application (SPA) and if you want to test navigating between different
+   * pages in the application you might want to use this method before clicking anything
+   * which is not on the first page.
+   *
+   * First page in Mercury loads just as a regular web page but next articles in Mercury just change
+   * part of loaded DOM and between them the preloader layer is displayed. This layer is on the very
+   * top and may block driver from clicking elements.
+   */
+  public void mercuryWaitForPreloaderToHide() {
     driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
     try {
-      PageObjectLogging.log("mercuryWaitForPageToLoad", "Waiting till loaded...", true, driver);
+      PageObjectLogging.log("mercuryWaitForPreloaderToHide", "Waiting till loaded...", true, driver);
       wait.until(
         ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY_SELECTOR))
       );

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -148,7 +148,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
       for(WebElement link : links) {
         String href = link.getAttribute("href");
         Boolean isArticle = !href.matches(notArticlePattern);
-        Boolean isMainPage = !href.equals(getMercuryMainPageHref());
+        Boolean isMainPage = href.equals(getMercuryMainPageHref());
 
         if (isArticle && !isMainPage) {
           PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -21,160 +21,160 @@ import java.util.concurrent.TimeUnit;
  */
 public class MobileAdsBaseObject extends AdsBaseObject {
 
-  private static final String SMART_BANNER_SELECTOR = ".smartbanner.android";
-  private static final String FLITE_MASK_SELECTOR = ".flite-mask";
-  private static final String MERCURY_LOADING_OVERLAY_SELECTOR = ".loading-overlay";
+    private static final String SMART_BANNER_SELECTOR = ".smartbanner.android";
+    private static final String FLITE_MASK_SELECTOR = ".flite-mask";
+    private static final String MERCURY_LOADING_OVERLAY_SELECTOR = ".loading-overlay";
 
-  private AdsComparison adsComparison;
+    private AdsComparison adsComparison;
 
-  public MobileAdsBaseObject(WebDriver driver, String page) {
-    super(driver, page);
-    adsComparison = new AdsComparison();
-    PageObjectLogging.log("", "Page screenshot", true, driver);
-  }
-
-  @Override
-  protected void setWindowSizeAndroid() {
-    try {
-      driver.manage().window().setSize(new Dimension(360, 640));
-    } catch (WebDriverException ex) {
-      PageObjectLogging.log(
-          "ResizeWindowForMobile",
-          "Resize window method not available - possibly running on real device",
-          true
-      );
+    public MobileAdsBaseObject(WebDriver driver, String page) {
+        super(driver, page);
+        adsComparison = new AdsComparison();
+        PageObjectLogging.log("", "Page screenshot", true, driver);
     }
-  }
 
-  public void verifyMobileTopLeaderboard() {
-    PageObjectLogging.log("GeoEdge", getCountry(), true);
-    extractGptInfo(presentLeaderboardSelector);
-    removeSmartBanner();
-    if (checkIfElementOnPage(FLITE_MASK_SELECTOR)) {
-      PageObjectLogging.log(
-          "FliteAd", "Page contains the flite ad", true, driver
-      );
-      return;
+    @Override
+    protected void setWindowSizeAndroid() {
+        try {
+            driver.manage().window().setSize(new Dimension(360, 640));
+        } catch (WebDriverException ex) {
+            PageObjectLogging.log(
+                    "ResizeWindowForMobile",
+                    "Resize window method not available - possibly running on real device",
+                    true
+            );
+        }
     }
-    if (!checkIfSlotExpanded(presentLeaderboard)) {
-      throw new NoSuchElementException(
-          String.format("Slot is not expanded - ad is not there; CSS selector: %s",
-                        presentLeaderboardSelector)
-      );
+
+    public void verifyMobileTopLeaderboard() {
+        PageObjectLogging.log("GeoEdge", getCountry(), true);
+        extractGptInfo(presentLeaderboardSelector);
+        removeSmartBanner();
+        if (checkIfElementOnPage(FLITE_MASK_SELECTOR)) {
+            PageObjectLogging.log(
+                    "FliteAd", "Page contains the flite ad", true, driver
+            );
+            return;
+        }
+        if (!checkIfSlotExpanded(presentLeaderboard)) {
+            throw new NoSuchElementException(
+                    String.format("Slot is not expanded - ad is not there; CSS selector: %s",
+                            presentLeaderboardSelector)
+            );
+        }
+        if (!adsComparison.isAdVisible(presentLeaderboard, presentLeaderboardSelector, driver)) {
+            throw new NoSuchElementException(
+                    "Screenshots of element on/off look the same."
+                            + "Most probable ad is not present; CSS "
+                            + presentLeaderboardSelector
+            );
+        }
     }
-    if (!adsComparison.isAdVisible(presentLeaderboard, presentLeaderboardSelector, driver)) {
-      throw new NoSuchElementException(
-          "Screenshots of element on/off look the same."
-          + "Most probable ad is not present; CSS "
-          + presentLeaderboardSelector
-      );
+
+    public void verifyNoAdInSlot(String slotName) {
+        scrollToSlotOnMobile(slotName);
+        WebElement slot = driver.findElement(By.id(slotName));
+        waitForSlotCollapsed(slot);
+        PageObjectLogging.log("AdInSlot", "Ad is not found in slot as expected.", true);
     }
-  }
 
-  public void verifyNoAdInSlot(String slotName) {
-    scrollToSlotOnMobile(slotName);
-    WebElement slot = driver.findElement(By.id(slotName));
-    waitForSlotCollapsed(slot);
-    PageObjectLogging.log("AdInSlot", "Ad is not found in slot as expected.", true);
-  }
-
-  public void verifyNoSlotPresent(String slotName) {
-    if (checkIfElementOnPage("#" + slotName)) {
-      throw new NoSuchElementException("Slot is added to the page");
+    public void verifyNoSlotPresent(String slotName) {
+        if (checkIfElementOnPage("#" + slotName)) {
+            throw new NoSuchElementException("Slot is added to the page");
+        }
+        PageObjectLogging.log("AdInSlot", "No slot found as expected", true);
     }
-    PageObjectLogging.log("AdInSlot", "No slot found as expected", true);
-  }
 
-  public void verifySlotExpanded(String slotName) {
-    scrollToSlotOnMobile(slotName);
-    WebElement slot = driver.findElement(By.id(slotName));
-    if (checkIfSlotExpanded(slot)) {
-      PageObjectLogging.log("AdInSlot", "Slot expanded as expecting", true);
-    } else {
-      throw new NoSuchElementException("Slot is collapsed - should be expanded");
+    public void verifySlotExpanded(String slotName) {
+        scrollToSlotOnMobile(slotName);
+        WebElement slot = driver.findElement(By.id(slotName));
+        if (checkIfSlotExpanded(slot)) {
+            PageObjectLogging.log("AdInSlot", "Slot expanded as expecting", true);
+        } else {
+            throw new NoSuchElementException("Slot is collapsed - should be expanded");
+        }
     }
-  }
 
-  public void verifyImgAdLoadedInSlot(String slotName, String expectedImg) {
-    scrollToSlotOnMobile(slotName);
-    WebElement slot = driver.findElement(By.id(slotName));
-    if (checkIfSlotExpanded(slot)) {
-      String foundImg = getSlotImageAd(slot);
-      Assertion.assertStringContains(expectedImg, foundImg);
-    } else {
-      throw new NoSuchElementException("Slot is collapsed - should be expanded");
+    public void verifyImgAdLoadedInSlot(String slotName, String expectedImg) {
+        scrollToSlotOnMobile(slotName);
+        WebElement slot = driver.findElement(By.id(slotName));
+        if (checkIfSlotExpanded(slot)) {
+            String foundImg = getSlotImageAd(slot);
+            Assertion.assertStringContains(expectedImg, foundImg);
+        } else {
+            throw new NoSuchElementException("Slot is collapsed - should be expanded");
+        }
+        PageObjectLogging.log("AdInSlot", "Ad found in slot", true, driver);
     }
-    PageObjectLogging.log("AdInSlot", "Ad found in slot", true, driver);
-  }
 
-  /**
-   * Checks if link to /wiki/articleName exists on the page and clicks it
-   *
-   * @param articleLinkName part of link to another wiki article
-   */
-  public void mercuryNavigateToAnArticle(String articleLinkName) {
-    String articleLinkSelector = String.format("a[href^='/wiki/%s']", articleLinkName);
-    if (checkIfElementOnPage(articleLinkSelector)) {
-      WebElement link = driver.findElement(By.cssSelector(articleLinkSelector));
+    /**
+     * Checks if link to /wiki/articleName exists on the page and clicks it
+     *
+     * @param articleLinkName part of link to another wiki article
+     */
+    public void mercuryNavigateToAnArticle(String articleLinkName) {
+        String articleLinkSelector = String.format("a[href^='/wiki/%s']", articleLinkName);
+        if (checkIfElementOnPage(articleLinkSelector)) {
+            WebElement link = driver.findElement(By.cssSelector(articleLinkSelector));
 
-      PageObjectLogging.log(
-        "mercuryNavigateToAnArticle()",
-        String.format(
-          "Clicking: %s (%s)",
-          link.getText(),
-          link.getAttribute("href")
-        ),
-        true,
-        driver
-      );
+            PageObjectLogging.log(
+                    "mercuryNavigateToAnArticle()",
+                    String.format(
+                            "Clicking: %s (%s)",
+                            link.getText(),
+                            link.getAttribute("href")
+                    ),
+                    true,
+                    driver
+            );
 
-      scrollToElement(link);
-      link.click();
-    } else {
-      PageObjectLogging.logWarning(
-        "mercuryNavigateToAnArticle()",
-        "Could not find the link to: /wiki/" + articleLinkName
-      );
+            scrollToElement(link);
+            link.click();
+        } else {
+            PageObjectLogging.logWarning(
+                    "mercuryNavigateToAnArticle()",
+                    "Could not find the link to: /wiki/" + articleLinkName
+            );
+        }
     }
-  }
 
-  /**
-   * Mercury is a single page application (SPA) and if you want to test navigating between different
-   * pages in the application you might want to use this method before clicking anything
-   * which is not on the first page.
-   *
-   * First page in Mercury loads just as a regular web page but next articles in Mercury just change
-   * part of loaded DOM and between them the preloader layer is displayed. This layer is on the very
-   * top and may block driver from clicking elements.
-   */
-  public void mercuryWaitForPreloaderToHide() {
-    driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
-    try {
-      PageObjectLogging.log("mercuryWaitForPreloaderToHide", "Waiting till loaded...", true, driver);
-      wait.until(
-        ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY_SELECTOR))
-      );
-    } finally {
-      restoreDeaultImplicitWait();
+    /**
+     * Mercury is a single page application (SPA) and if you want to test navigating between
+     * different pages in the application you might want to use this method before clicking anything
+     * which is not on the first page.
+     *
+     * First page in Mercury loads just as a regular web page but next articles in Mercury just
+     * change part of loaded DOM and between them the preloader layer is displayed. This layer is on
+     * the very top and may block driver from clicking elements.
+     */
+    public void mercuryWaitForPreloaderToHide() {
+        driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
+        try {
+            PageObjectLogging.log("mercuryWaitForPreloaderToHide", "Waiting till loaded...", true, driver);
+            wait.until(
+                    ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(MERCURY_LOADING_OVERLAY_SELECTOR))
+            );
+        } finally {
+            restoreDeaultImplicitWait();
+        }
     }
-  }
 
-  private void removeSmartBanner() {
-    if (checkIfElementOnPage(SMART_BANNER_SELECTOR)) {
-      WebElement smartBanner = driver.findElement(By.cssSelector(SMART_BANNER_SELECTOR));
-      JavascriptExecutor js = (JavascriptExecutor) driver;
-      js.executeScript("$(arguments[0]).css('display', 'none')", smartBanner);
-      waitForElementNotVisibleByElement(smartBanner);
+    private void removeSmartBanner() {
+        if (checkIfElementOnPage(SMART_BANNER_SELECTOR)) {
+            WebElement smartBanner = driver.findElement(By.cssSelector(SMART_BANNER_SELECTOR));
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            js.executeScript("$(arguments[0]).css('display', 'none')", smartBanner);
+            waitForElementNotVisibleByElement(smartBanner);
+        }
     }
-  }
 
-  private void scrollToSlotOnMobile(String slotName) {
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    js.executeScript(
-        "var elementY = document.getElementById(arguments[0]).offsetTop;" +
-        "window.scrollTo(0, elementY);",
-        slotName
-    );
-  }
+    private void scrollToSlotOnMobile(String slotName) {
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        js.executeScript(
+                "var elementY = document.getElementById(arguments[0]).offsetTop;" +
+                        "window.scrollTo(0, elementY);",
+                slotName
+        );
+    }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestAdTypeMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestAdTypeMobile.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 public class TestAdTypeMobile extends MobileTestTemplate {
 
   @Test(
-      groups = {"TestAdTypeAsync_001", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_001", "TestAdType", "MobileAds"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncSuccessWithAd"
   )
@@ -30,7 +30,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeAsync_002", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_002", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncHopNoAd"
   )
@@ -47,7 +47,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeAsync_003", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_003", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncSuccessNoAd"
   )
@@ -61,7 +61,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeAsync_004", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_004", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncHopWithAd"
   )
@@ -75,7 +75,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeAsync_005", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_005", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncHopWithSpecialProvider"
   )
@@ -89,7 +89,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeAsync_006", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeAsync_006", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "asyncHopAndAsyncSuccess"
   )
@@ -108,7 +108,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeForcedSuccess_001", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeForcedSuccess_001", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "forcedSuccessNoAd"
   )
@@ -122,7 +122,7 @@ public class TestAdTypeMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdTypeInspectIframe_001", "TestAdType"},
+      groups = {"MobileAds", "TestAdTypeInspectIframe_001", "TestAdType"},
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "inspectIframeImg"
   )

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestDfpParamsPresentMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestDfpParamsPresentMobile.java
@@ -18,7 +18,7 @@ public class TestDfpParamsPresentMobile extends NewTestTemplate {
   @Test(
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "dfpParams",
-      groups = {"TestDfpParamsPresentMobile_GeoEdgeFree", "MobileAds"}
+      groups = {"MobileAds", "TestDfpParamsPresentMobile_GeoEdgeFree"}
   )
   public void TestDfpParamsPresentMobile_GeoEdgeFree(
       String wikiName, String article, String adUnit, String slot, String lineItemId,

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -23,7 +23,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
 
   @Test(
-      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "allSlots"
   )
@@ -42,7 +42,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndPrefooterSlots"
   )
@@ -60,7 +60,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndInContentSlots"
   )

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -18,64 +18,64 @@ import org.testng.annotations.Test;
  */
 public class TestSlotsMobile extends MobileTestTemplate {
 
-  private static final String MOBILE_TOP_LEADERBOARD = "MOBILE_TOP_LEADERBOARD";
-  private static final String MOBILE_IN_CONTENT = "MOBILE_IN_CONTENT";
-  private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
+    private static final String MOBILE_TOP_LEADERBOARD = "MOBILE_TOP_LEADERBOARD";
+    private static final String MOBILE_IN_CONTENT = "MOBILE_IN_CONTENT";
+    private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
 
-  @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
-      dataProviderClass = MobileAdsDataProvider.class,
-      dataProvider = "allSlots"
-  )
-  public void TestAllSlotsOnPage(
-      String wikiName, String article,
-      String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
+    @Test(
+            groups = {"MobileAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
+            dataProviderClass = MobileAdsDataProvider.class,
+            dataProvider = "allSlots"
+    )
+    public void TestAllSlotsOnPage(
+            String wikiName, String article,
+            String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
 
-    String testedPage = urlBuilder.getUrlForPath(wikiName, article);
-    MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
-    ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
-    ads.verifyGptIframe(adUnit, MOBILE_IN_CONTENT, "mobile");
-    ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
-    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-    ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, medrecImgUrl);
-    ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
-  }
+        String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+        MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_IN_CONTENT, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, medrecImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
+    }
 
-  @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
-      dataProviderClass = MobileAdsDataProvider.class,
-      dataProvider = "leaderboardAndPrefooterSlots"
-  )
-  public void TestLeaderboardAndPrefooterOnPage(
-      String wikiName, String article,
-      String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
+    @Test(
+            groups = {"MobileAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
+            dataProviderClass = MobileAdsDataProvider.class,
+            dataProvider = "leaderboardAndPrefooterSlots"
+    )
+    public void TestLeaderboardAndPrefooterOnPage(
+            String wikiName, String article,
+            String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
 
-    String testedPage = urlBuilder.getUrlForPath(wikiName, article);
-    MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
-    ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
-    ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
-    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-    ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
-    ads.verifyNoSlotPresent(MOBILE_IN_CONTENT);
-  }
+        String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+        MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
+        ads.verifyNoSlotPresent(MOBILE_IN_CONTENT);
+    }
 
-  @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
-      dataProviderClass = MobileAdsDataProvider.class,
-      dataProvider = "leaderboardAndInContentSlots"
-  )
-  public void TestLeaderboardAndInContentOnPage(
-      String wikiName, String article,
-      String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
+    @Test(
+            groups = {"MobileAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
+            dataProviderClass = MobileAdsDataProvider.class,
+            dataProvider = "leaderboardAndInContentSlots"
+    )
+    public void TestLeaderboardAndInContentOnPage(
+            String wikiName, String article,
+            String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
 
-    String testedPage = urlBuilder.getUrlForPath(wikiName, article);
-    MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
-    ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
-    ads.verifyGptIframe(adUnit, MOBILE_IN_CONTENT, "mobile");
-    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-    ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, medrecImgUrl);
-    ads.verifyNoSlotPresent(MOBILE_PREFOOTER);
-  }
+        String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+        MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_IN_CONTENT, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, medrecImgUrl);
+        ads.verifyNoSlotPresent(MOBILE_PREFOOTER);
+    }
 
     @Test(
             groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_004", "TestAdSlotsMobile"},
@@ -83,11 +83,11 @@ public class TestSlotsMobile extends MobileTestTemplate {
             dataProvider = "mercuryConsecutivePageViews"
     )
     public void TestLeaderboardAndPrefooterOnConsecutivePageViews(
-        String wikiName,
-        String firstArticle,
-        String secondArticle,
-        String thirdArticle,
-        String adUnit
+            String wikiName,
+            String firstArticle,
+            String secondArticle,
+            String thirdArticle,
+            String adUnit
     ) {
         String testedPage = urlBuilder.getUrlForPath(wikiName, firstArticle);
         MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -93,10 +93,12 @@ public class TestSlotsMobile extends MobileTestTemplate {
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
         ads.mercuryNavigateToMainPage();
+        ads.mercuryWaitForPageToLoad();
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
         ads.mercuryNavigateToAnArticle();
+        ads.mercuryWaitForPageToLoad();
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
     }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -80,32 +80,24 @@ public class TestSlotsMobile extends MobileTestTemplate {
     @Test(
             groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_004", "TestAdSlotsMobile"},
             dataProviderClass = MobileAdsDataProvider.class,
-            dataProvider = "leaderboardAndPrefooterSlots"
+            dataProvider = "mercuryConsecutivePageViews"
     )
     public void TestLeaderboardAndPrefooterOnConsecutivePageViews(
-            String wikiName, String article,
-            String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
-
+        String wikiName,
+        String article,
+        String adUnit
+    ) {
         String testedPage = urlBuilder.getUrlForPath(wikiName, article);
         MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
-
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
-        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
 
         ads.mercuryNavigateToMainPage();
-
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
-        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
 
         ads.mercuryNavigateToAnArticle();
-
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
-        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
-        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
     }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -84,21 +84,23 @@ public class TestSlotsMobile extends MobileTestTemplate {
     )
     public void TestLeaderboardAndPrefooterOnConsecutivePageViews(
         String wikiName,
-        String article,
+        String firstArticle,
+        String secondArticle,
+        String thirdArticle,
         String adUnit
     ) {
-        String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+        String testedPage = urlBuilder.getUrlForPath(wikiName, firstArticle);
         MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryNavigateToMainPage();
         ads.mercuryWaitForPageToLoad();
+        ads.mercuryNavigateToAnArticle(secondArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryNavigateToAnArticle();
         ads.mercuryWaitForPageToLoad();
+        ads.mercuryNavigateToAnArticle(thirdArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
     }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -23,7 +23,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
 
   @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "allSlots"
   )
@@ -42,7 +42,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndPrefooterSlots"
   )
@@ -60,7 +60,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"MobileAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndInContentSlots"
   )

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -23,7 +23,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
 
   @Test(
-      groups = {"TestAdSlotsMobile_001", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_001", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "allSlots"
   )
@@ -42,7 +42,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdSlotsMobile_002", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_002", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndPrefooterSlots"
   )
@@ -60,7 +60,7 @@ public class TestSlotsMobile extends MobileTestTemplate {
   }
 
   @Test(
-      groups = {"TestAdSlotsMobile_003", "TestAdSlotsMobile"},
+      groups = {"MobileAds", "TestAdSlotsMobile_003", "TestAdSlotsMobile"},
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardAndInContentSlots"
   )

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -94,12 +94,12 @@ public class TestSlotsMobile extends MobileTestTemplate {
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryWaitForPageToLoad();
+        ads.mercuryWaitForPreloaderToHide();
         ads.mercuryNavigateToAnArticle(secondArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryWaitForPageToLoad();
+        ads.mercuryWaitForPreloaderToHide();
         ads.mercuryNavigateToAnArticle(thirdArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -76,4 +76,36 @@ public class TestSlotsMobile extends MobileTestTemplate {
     ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, medrecImgUrl);
     ads.verifyNoSlotPresent(MOBILE_PREFOOTER);
   }
+
+    @Test(
+            groups = {"MobileAds", "MercuryAds", "TestAdSlotsMobile_004", "TestAdSlotsMobile"},
+            dataProviderClass = MobileAdsDataProvider.class,
+            dataProvider = "leaderboardAndPrefooterSlots"
+    )
+    public void TestLeaderboardAndPrefooterOnConsecutivePageViews(
+            String wikiName, String article,
+            String adUnit, String topleaderboardImgUrl, String medrecImgUrl) {
+
+        String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+        MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
+
+        ads.mercuryNavigateToMainPage();
+
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
+
+        ads.mercuryNavigateToAnArticle();
+
+        ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
+        ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
+        ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, topleaderboardImgUrl);
+        ads.verifyImgAdLoadedInSlot(MOBILE_PREFOOTER, medrecImgUrl);
+    }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSynthetic.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSynthetic.java
@@ -15,7 +15,7 @@ public class TestSynthetic extends NewTestTemplate {
   @Test(
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "testSynthetic",
-      groups = {"TestSynthetic"}
+      groups = {"MobileAds", "TestSynthetic"}
   )
   public void testSynthetic(String wikiPage, String article,
                             String slotName, int slotWidth, int slotHeight,


### PR DESCRIPTION
Mercury is a single page application and it does not behave like regular web page. Therefore we need couple of changes in our mobile tests (`MobileAdsBaseObject::mercuryWaitForPageToLoad()`). There are also some issues with filling ads slots on consecutive pageviews. So, the changes below include new test which is checking ad slots for a synthetic test page, main page and an article page which links can be found on the main page.

The test is failing now but once we find the cause and fix the issue it should start passing :japanese_ogre: 