### PR TITLE
ADEN 2001 Set highest priority for ph3uhzc41 segment

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -117,10 +117,8 @@ public class AdsKruxObject extends AdsBaseObject {
       if (segments.contains(specialSegment) && !slicedSegs.contains(specialSegment)) {
         slicedSegs = new LinkedList<>(Arrays.asList(segs).subList(0, MAX_SEGS_NUMBER_GPT - 1));
         slicedSegs.add(0, specialSegment);
-        return slicedSegs;
-      } else {
-        return slicedSegs;
       }
+      return slicedSegs;
     }
     return Arrays.asList(segs);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -10,6 +10,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -93,15 +95,35 @@ public class AdsKruxObject extends AdsBaseObject {
 
   public String getKsgmntPattern(String segmentsLocalStorage) {
     String ksgmnt = "\"ksgmnt\":[";
-    String[] segments = segmentsLocalStorage.split(",");
-    if (segments.length > MAX_SEGS_NUMBER_GPT) {
-      segments = Arrays.copyOfRange(segmentsLocalStorage.split(","), 0, MAX_SEGS_NUMBER_GPT);
-    }
+    List<String> segments = sliceSegsForGpt(segmentsLocalStorage);
     for (String segment : segments) {
       ksgmnt += String.format("\"%s\",", segment);
     }
     ksgmnt = ksgmnt.substring(0, ksgmnt.length() - 1) + "]";
     return ksgmnt;
+  }
+
+  /**
+   * Slice the krux segments to MAX_SEGS_NUMBER_GPT number for gpt call and set highest priority to
+   * "ph3uhzc41" segment
+   *
+   * @param segments Krux segments
+   */
+  private List<String> sliceSegsForGpt(String segments) {
+    String specialSegment = "ph3uhzc41";
+    String[] segs = segments.split(",");
+    if (segs.length > MAX_SEGS_NUMBER_GPT) {
+      if (segments.contains(specialSegment) &&
+          !Arrays.asList(segs).subList(0, MAX_SEGS_NUMBER_GPT).contains(specialSegment)) {
+        List<String> slicedSegs = new LinkedList<>(Arrays.asList(Arrays.copyOfRange(
+            segs, 0, MAX_SEGS_NUMBER_GPT - 1)));
+        slicedSegs.add(0, specialSegment);
+        return slicedSegs;
+      } else {
+        return Arrays.asList(Arrays.copyOfRange(segs, 0, MAX_SEGS_NUMBER_GPT));
+      }
+    }
+    return Arrays.asList(segs);
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -105,7 +105,7 @@ public class AdsKruxObject extends AdsBaseObject {
 
   /**
    * Slice the krux segments to MAX_SEGS_NUMBER_GPT number for gpt call and set highest priority to
-   * "ph3uhzc41" segment
+   * special segment
    *
    * @param segments Krux segments
    */

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -113,14 +113,13 @@ public class AdsKruxObject extends AdsBaseObject {
     String specialSegment = "ph3uhzc41";
     String[] segs = segments.split(",");
     if (segs.length > MAX_SEGS_NUMBER_GPT) {
-      if (segments.contains(specialSegment) &&
-          !Arrays.asList(segs).subList(0, MAX_SEGS_NUMBER_GPT).contains(specialSegment)) {
-        List<String> slicedSegs = new LinkedList<>(Arrays.asList(Arrays.copyOfRange(
-            segs, 0, MAX_SEGS_NUMBER_GPT - 1)));
+      List<String> slicedSegs = Arrays.asList(segs).subList(0, MAX_SEGS_NUMBER_GPT);
+      if (segments.contains(specialSegment) && !slicedSegs.contains(specialSegment)) {
+        slicedSegs = new LinkedList<>(Arrays.asList(segs).subList(0, MAX_SEGS_NUMBER_GPT - 1));
         slicedSegs.add(0, specialSegment);
         return slicedSegs;
       } else {
-        return Arrays.asList(Arrays.copyOfRange(segs, 0, MAX_SEGS_NUMBER_GPT));
+        return slicedSegs;
       }
     }
     return Arrays.asList(segs);


### PR DESCRIPTION
Krux writes segments for a user to localStorage. We get these segments and pass them to DFP (we send only first 27 segments). Recently due to business reasons we set highest priority for  `ph3uhzc4` segment (It means if a user has 40 segments and `ph3uhzc41` segment is 38th we still send the segment to DFP. This PR stabilises the test due to code changes.