### PR TITLE
ADEN-2001 Update to page where we have an ad slot

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -56,7 +56,7 @@ public class AdsDataProvider {
         {"wowwiki", "Portal:Main"},
         {"gameofthrones", "Season_4"},
         {"zh.pad", "Homepage/Mobile"},
-        {"zh.pad", "Special:%E6%90%9C%E7%B4%A2?search=dragon&fulltext=Search&ns0=1&ns14=1"}
+        {"zh.pad", "Special:Video"}
     };
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestKruxIntegration.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestKruxIntegration.java
@@ -46,7 +46,6 @@ public class TestKruxIntegration extends NewTestTemplate {
     ads.refreshPage();
     ads.verifyKruxControlTag(kruxSiteId);
 
-    // Krux.user should be available now
     ads.verifyKruxUserParam();
   }
 }


### PR DESCRIPTION
We use `popularSites` data provider in the different tests. One of them is a test that checks integration with Krux. The test contains verification that we added Krux data to our Ad slot. So, my PR is about changing one URL from the page where we don't have Ad slot (search page on mobile) to the page which contains an Ad slot (video page).