### PR TITLE
Deleting openWikiPage method

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/heromoduletests/HeroModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/heromoduletests/HeroModuleTests.java
@@ -28,6 +28,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_001"})
   public void HeroModuleTests_001_VerifyImageVisibilityAfterRefresh() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String prevMoMSrc = mom.getMoMSrc();
     mom.selectFileToUpload(PageContent.FILE);
@@ -42,6 +43,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_002"})
   public void HeroModuleTests_002_VerifyImmediateImageVisibility() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.selectFileToUpload(PageContent.FILE);
     mom.verifyDragToRepositionText();
@@ -52,6 +54,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_003"})
   public void HeroModuleTests_003_VerifyImmediateChangesForDescription() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     String momDescription = mom.getTimeStamp();
@@ -63,6 +66,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_004"})
   public void HeroModuleTests_004_OnlyAdminsAndStaffCanModify() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.verifyAdminStaffButtons();
     mom.logOut();
@@ -75,6 +79,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_005"})
   public void HeroModuleTests_005_VerifyImageDiscardDisplaysPreviousState() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String imgSrc = mom.getMoMSrc();
     mom.selectFileToUpload(PageContent.FILE);
@@ -87,6 +92,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_006"})
   public void HeroModuleTests_006_VerifyDraggingToRepositionFunctionality() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.selectFileToUpload(PageContent.FILE);
     mom.verifyDragToRepositionText();
@@ -99,6 +105,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_007"})
   public void HeroModuleTests_007_DeleteDescriptionAndCheckPublishButtonAvailability() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     mom.deleteDescriptionEditorContent();
@@ -109,6 +116,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_008"})
   public void HeroModuleTests_008_DescriptionFieldDiscardChanges() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String publishedText = mom.getDescriptionText();
     mom.clickEditDescriptionLink();
@@ -121,6 +129,7 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_009"})
   public void HeroModuleTests_009_AddDescriptionAndCheckPublishButtonAvailability() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
+    mom.openWikiPage(wikiURL);
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     mom.deleteDescriptionEditorContent();

--- a/src/test/java/com/wikia/webdriver/testcases/heromoduletests/HeroModuleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/heromoduletests/HeroModuleTests.java
@@ -25,12 +25,9 @@ public class HeroModuleTests extends NewTestTemplate {
 
   Credentials credentials = config.getCredentials();
 
-  private final static String WIKI_NAME = "momrod2";
-
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_001"})
   public void HeroModuleTests_001_VerifyImageVisibilityAfterRefresh() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String prevMoMSrc = mom.getMoMSrc();
     mom.selectFileToUpload(PageContent.FILE);
@@ -45,7 +42,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_002"})
   public void HeroModuleTests_002_VerifyImmediateImageVisibility() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.selectFileToUpload(PageContent.FILE);
     mom.verifyDragToRepositionText();
@@ -56,7 +52,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_003"})
   public void HeroModuleTests_003_VerifyImmediateChangesForDescription() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     String momDescription = mom.getTimeStamp();
@@ -68,7 +63,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_004"})
   public void HeroModuleTests_004_OnlyAdminsAndStaffCanModify() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.verifyAdminStaffButtons();
     mom.logOut();
@@ -81,7 +75,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_005"})
   public void HeroModuleTests_005_VerifyImageDiscardDisplaysPreviousState() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String imgSrc = mom.getMoMSrc();
     mom.selectFileToUpload(PageContent.FILE);
@@ -94,7 +87,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_006"})
   public void HeroModuleTests_006_VerifyDraggingToRepositionFunctionality() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.selectFileToUpload(PageContent.FILE);
     mom.verifyDragToRepositionText();
@@ -107,7 +99,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_007"})
   public void HeroModuleTests_007_DeleteDescriptionAndCheckPublishButtonAvailability() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     mom.deleteDescriptionEditorContent();
@@ -118,7 +109,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_008"})
   public void HeroModuleTests_008_DescriptionFieldDiscardChanges() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     String publishedText = mom.getDescriptionText();
     mom.clickEditDescriptionLink();
@@ -131,7 +121,6 @@ public class HeroModuleTests extends NewTestTemplate {
   @Test(groups = {"HeroModuleTests", "HeroModuleTests_009"})
   public void HeroModuleTests_009_AddDescriptionAndCheckPublishButtonAvailability() {
     ModularMainPageObject mom = new ModularMainPageObject(driver);
-    mom.openWikiPage(urlBuilder.getUrlForWiki(WIKI_NAME));
     mom.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     mom.clickEditDescriptionLink();
     mom.deleteDescriptionEditorContent();


### PR DESCRIPTION
Tests should be executed in mediawiki119 when possible. This change simply involves deleting momrod2 wiki as the wiki for executing hero module tests. From now on, hero module tests will exclusively run on mediawiki119.