### PR TITLE
Concf 626

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
+++ b/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
@@ -1,0 +1,17 @@
+package com.wikia.webdriver.common.core.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation serves as a placeholder to mark test methods failing as a result of known issues.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface CreationTicket {
+  String ticketID();
+
+  String comment() default "";
+}

--- a/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
+++ b/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
@@ -6,11 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation serves as a placeholder to mark test methods failing as a result of known issues.
+ * This annotation serves as a placeholder to mark test methods failing as a result of known
+ * issues.
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
 public @interface CreationTicket {
+
   String ticketID();
 
   String comment() default "";

--- a/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
+++ b/src/test/java/com/wikia/webdriver/common/core/annotations/CreationTicket.java
@@ -6,8 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation serves as a placeholder to mark test methods failing as a result of known
- * issues.
+ * This annotation serves as a placeholder to mark creation ticket ID issues.
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})

--- a/src/test/java/com/wikia/webdriver/common/core/annotations/RelatedIssue.java
+++ b/src/test/java/com/wikia/webdriver/common/core/annotations/RelatedIssue.java
@@ -6,11 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation serves as a placeholder to mark test methods failing as a result of known issues.
+ * This annotation serves as a placeholder to mark test methods failing as a result of known
+ * issues.
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
 public @interface RelatedIssue {
+
   String issueID();
 
   String comment() default "";

--- a/src/test/java/com/wikia/webdriver/common/core/video/Video.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/Video.java
@@ -2,28 +2,33 @@ package com.wikia.webdriver.common.core.video;
 
 /**
  * Created by Ludwik Kaźmierczak on 2015-02-12.
- * 
+ * <p/>
  * Interface used for videos object.
  */
 
 public interface Video {
 
-  /**
-   * When adding a video to WIKIA, backend is replacing some special characters, make sure you
-   * return a title in the same form that is presented on front-end
-   */
-  public String getTitle();
+    /**
+     * When adding a video to WIKIA, backend is replacing some special characters, make sure you
+     * return a title in the same form that is presented on front-end
+     */
+    public String getTitle();
 
-  /**
-   * Returns URL to video
-   */
-  public String getUrl();
+    /**
+     * Returns URL to video
+     */
+    public String getUrl();
 
-  /**
-   * Get a video title in a WIKIA file link format. e. g. for a video titled 'WikiEvolution -
-   * Poznańska Wiki-1424144130' a proper filename should be,
-   * 'WikiEvolution_-_Poznańska_Wiki-1424144130', so a url to video on WIKIA should look like:
-   * (wikiName).wikia.com/wiki/File:WikiEvolution_-_Poznańska_Wiki-1424144130
-   */
-  public String getWikiFileName();
+    /**
+     * Returns Id to video
+     */
+    public String getID();
+
+    /**
+     * Get a video title in a WIKIA file link format. e. g. for a video titled 'WikiEvolution -
+     * Poznańska Wiki-1424144130' a proper filename should be,
+     * 'WikiEvolution_-_Poznańska_Wiki-1424144130', so a url to video on WIKIA should look like:
+     * (wikiName).wikia.com/wiki/File:WikiEvolution_-_Poznańska_Wiki-1424144130
+     */
+    public String getWikiFileName();
 }

--- a/src/test/java/com/wikia/webdriver/common/core/video/Video.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/Video.java
@@ -1,34 +1,31 @@
 package com.wikia.webdriver.common.core.video;
 
 /**
- * Created by Ludwik Kaźmierczak on 2015-02-12.
- * <p/>
- * Interface used for videos object.
+ * Created by Ludwik Kaźmierczak on 2015-02-12. <p/> Interface used for videos object.
  */
 
 public interface Video {
 
-    /**
-     * When adding a video to WIKIA, backend is replacing some special characters, make sure you
-     * return a title in the same form that is presented on front-end
-     */
-    public String getTitle();
+  /**
+   * When adding a video to WIKIA, backend is replacing some special characters, make sure you
+   * return a title in the same form that is presented on front-end
+   */
+  public String getTitle();
 
-    /**
-     * Returns URL to video
-     */
-    public String getUrl();
+  /**
+   * Returns URL to video
+   */
+  public String getUrl();
 
-    /**
-     * Returns Id to video
-     */
-    public String getID();
+  /**
+   * Returns Id to video
+   */
+  public String getID();
 
-    /**
-     * Get a video title in a WIKIA file link format. e. g. for a video titled 'WikiEvolution -
-     * Poznańska Wiki-1424144130' a proper filename should be,
-     * 'WikiEvolution_-_Poznańska_Wiki-1424144130', so a url to video on WIKIA should look like:
-     * (wikiName).wikia.com/wiki/File:WikiEvolution_-_Poznańska_Wiki-1424144130
-     */
-    public String getWikiFileName();
+  /**
+   * Get a video title in a WIKIA file link format. e. g. for a video titled 'WikiEvolution -
+   * Poznańska Wiki-1424144130' a proper filename should be, 'WikiEvolution_-_Poznańska_Wiki-1424144130',
+   * so a url to video on WIKIA should look like: (wikiName).wikia.com/wiki/File:WikiEvolution_-_Poznańska_Wiki-1424144130
+   */
+  public String getWikiFileName();
 }

--- a/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideo.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideo.java
@@ -17,12 +17,14 @@ public class YoutubeVideo implements Video {
   private final String url;
   private final String title;
   private final String fileName;
+  private final String videoID;
 
-  public YoutubeVideo(String title, String url) {
+  public YoutubeVideo(String title, String url, String videoId) {
     this.url = url;
     this.title = capitaliseFirstWord(escapeSpecialCharactersAndReduceSpacesFromTitle(title));
 
     this.fileName = transformTitleToFileName(this.title);
+    this.videoID = videoId;
   }
 
   private static String escapeSpecialCharactersAndReduceSpacesFromTitle(String title) {
@@ -52,6 +54,9 @@ public class YoutubeVideo implements Video {
   public String getUrl() {
     return this.url;
   }
+
+  @Override
+  public String getID() { return this.videoID; }
 
   @Override
   public String getWikiFileName() {

--- a/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideo.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideo.java
@@ -56,7 +56,9 @@ public class YoutubeVideo implements Video {
   }
 
   @Override
-  public String getID() { return this.videoID; }
+  public String getID() {
+    return this.videoID;
+  }
 
   @Override
   public String getWikiFileName() {

--- a/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideoProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideoProvider.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTimeZone;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
+
 import com.wikia.webdriver.common.core.configuration.ConfigurationFactory;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 
@@ -32,11 +33,7 @@ public class YoutubeVideoProvider {
 
   /**
    * This method returns latest youtube video(added no longer then hour ago) for a specified query.
-   * This one is using a YouTube Data API (v3) - see for reference -
-   * https://developers.google.com/youtube/v3/
-   *
-   * @param searchQuery
-   * @return
+   * This one is using a YouTube Data API (v3) - see for reference - https://developers.google.com/youtube/v3/
    */
   public static YoutubeVideo getLatestVideoForQuery(String searchQuery) {
     HttpClient httpclient =
@@ -55,12 +52,11 @@ public class YoutubeVideoProvider {
 
     HttpGet httpPost =
         new HttpGet("https://www.googleapis.com/youtube/v3/search?"
-            + URLEncodedUtils.format(nvps, "utf-8"));
+                    + URLEncodedUtils.format(nvps, "utf-8"));
 
     String videoTitle = null;
     String videoUrl = null;
     String videoId = null;
-
 
     try {
       HttpResponse response = httpclient.execute(httpPost);
@@ -76,7 +72,7 @@ public class YoutubeVideoProvider {
 
     } catch (IOException e) {
       PageObjectLogging.log("A problem occurred while receiving a YouTube video", e.getMessage(),
-          false);
+                            false);
     }
 
     return new YoutubeVideo(videoTitle, videoUrl, videoId);

--- a/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideoProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/core/video/YoutubeVideoProvider.java
@@ -59,6 +59,8 @@ public class YoutubeVideoProvider {
 
     String videoTitle = null;
     String videoUrl = null;
+    String videoId = null;
+
 
     try {
       HttpResponse response = httpclient.execute(httpPost);
@@ -68,7 +70,7 @@ public class YoutubeVideoProvider {
       ReadContext responseValue = JsonPath.parse(EntityUtils.toString(entity));
 
       videoTitle = responseValue.read("$.items[0].snippet.title");
-      String videoId = responseValue.read("$.items[0].id.videoId");
+      videoId = responseValue.read("$.items[0].id.videoId");
 
       videoUrl = String.format("https://www.youtube.com/watch?v=%s", videoId);
 
@@ -77,6 +79,6 @@ public class YoutubeVideoProvider {
           false);
     }
 
-    return new YoutubeVideo(videoTitle, videoUrl);
+    return new YoutubeVideo(videoTitle, videoUrl, videoId);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
@@ -423,6 +423,13 @@ public class ArticlePageObject extends WikiBasePageObject {
     PageObjectLogging.log("verifyVideo", "video is visible", true);
   }
 
+  public void verifyVideo(String videoId) {
+      WebElement video = driver.findElement(By.cssSelector("#mw-content-text object"));
+      waitForElementByElement(video);
+      waitForValueToBePresentInElementsAttributeByElement(video, "id", videoId);
+      PageObjectLogging.log("verifyVideo", "video is visible", true);
+  }
+
   public void verifyVideoInline() {
     waitForElementByElement(videoInline);
     PageObjectLogging.log("verifyVideoInline", "Video is visible", true);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
@@ -424,10 +424,10 @@ public class ArticlePageObject extends WikiBasePageObject {
   }
 
   public void verifyVideo(String videoId) {
-      WebElement video = driver.findElement(By.cssSelector("#mw-content-text object"));
-      waitForElementByElement(video);
-      waitForValueToBePresentInElementsAttributeByElement(video, "id", videoId);
-      PageObjectLogging.log("verifyVideo", "video is visible", true);
+    WebElement video = driver.findElement(By.cssSelector("#mw-content-text object"));
+    waitForElementByElement(video);
+    waitForValueToBePresentInElementsAttributeByElement(video, "id", videoId);
+    PageObjectLogging.log("verifyVideo", "video is visible", true);
   }
 
   public void verifyVideoInline() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
@@ -15,6 +15,8 @@ public class PreviewEditModePageObject extends EditMode {
 
   @FindBy(css = ".modalWrapper.preview")
   private WebElement previewModal;
+  @FindBy(css = "#mw-content-text object")
+  protected WebElement video;
   @FindBy(css = ".preview .video-thumbnail")
   protected WebElement videoArticle;
 
@@ -83,6 +85,11 @@ public class PreviewEditModePageObject extends EditMode {
 
   public void verifyTextContent(String desiredText) {
     Assertion.assertEquals(desiredText, previewModal.findElement(contentWrapper).getText());
+  }
+
+  public void verifyVideoOnPreview(String videoID) {
+      waitForElementByElement(video);
+      waitForValueToBePresentInElementsAttributeByElement(video, "id", videoID);
   }
 
   public void publish() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
@@ -88,8 +88,8 @@ public class PreviewEditModePageObject extends EditMode {
   }
 
   public void verifyVideoOnPreview(String videoID) {
-      waitForElementByElement(video);
-      waitForValueToBePresentInElementsAttributeByElement(video, "id", videoID);
+    waitForElementByElement(video);
+    waitForValueToBePresentInElementsAttributeByElement(video, "id", videoID);
   }
 
   public void publish() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFollowPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFollowPageObject.java
@@ -41,7 +41,7 @@ public class SpecialFollowPageObject extends SpecialPageObject {
     Assertion.assertTrue(isPresent, "image " + imageVideo
                                     + " is not present on the following list");
     PageObjectLogging.log("verifyFollowedImageVideo",
-                          imageVideo + "is visible on followed list", true);
+                          imageVideo + "is visible on followed list", true, driver);
   }
 
   public void verifyFollowedBlog(String userName, String blogTitle) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFollowPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFollowPageObject.java
@@ -41,7 +41,7 @@ public class SpecialFollowPageObject extends SpecialPageObject {
     Assertion.assertTrue(isPresent, "image " + imageVideo
                                     + " is not present on the following list");
     PageObjectLogging.log("verifyFollowedImageVideo",
-                          imageVideo + "is visible on followed list", true, driver);
+                          imageVideo + "is visible on followed list", true);
   }
 
   public void verifyFollowedBlog(String userName, String blogTitle) {

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
@@ -4,6 +4,8 @@ import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.contentpatterns.VideoContent;
 import com.wikia.webdriver.common.core.annotations.CreationTicket;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
+import com.wikia.webdriver.common.core.video.YoutubeVideo;
+import com.wikia.webdriver.common.core.video.YoutubeVideoProvider;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.addphoto.AddPhotoComponentObject;
@@ -21,6 +23,7 @@ import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetAddVideoCom
 import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetOptionsComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.article.editmode.PreviewEditModePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.editmode.SourceEditModePageObject;
 
 import org.testng.annotations.BeforeMethod;
@@ -286,22 +289,28 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     }
 
     @CreationTicket(ticketID ="CONCF-626")
-    @Test(groups = {"RTE_extended", "RTE_extended_019"})
+    @Test(groups = {"RTE_extended", "RTE_extended_020"})
     public void RTE_020_YoutubeTag_Preview() {
-//        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-//        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-//        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-//        source.checkSymbolsTools();
-//        source.submitArticle();
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
+        String videoID = video.getID();
+        source.addContent("<youtube>\n"+videoID+"\n</youtube>");
+        PreviewEditModePageObject preview = source.previewArticle();
+        preview.verifyVideoOnPreview(videoID);
     }
 
     @CreationTicket(ticketID ="CONCF-626")
-    @Test(groups = {"RTE_extended", "RTE_extended_019"})
-    public void RTE_020_YoutubeTag_Publish() {
-//        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-//        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-//        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-//        source.checkSymbolsTools();
-//        source.submitArticle();
+    @Test(groups = {"RTE_extended", "RTE_extended_021"})
+    public void RTE_021_YoutubeTag_Publish() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
+        String videoID = video.getID();
+        source.addContent("<youtube>\n"+videoID+"\n</youtube>");
+        article = source.clickPublishButton();
+        article.verifyVideo(videoID);
     }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
@@ -38,279 +38,279 @@ import java.util.List;
  */
 public class ArticleSourceModeTests extends NewTestTemplate {
 
-    Credentials credentials = config.getCredentials();
-    WikiBasePageObject base;
+  Credentials credentials = config.getCredentials();
+  WikiBasePageObject base;
 
-    @BeforeMethod(alwaysRun = true)
-    public void setup_VEPreferred() {
-        base = new WikiBasePageObject(driver);
-        base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
-    }
+  @BeforeMethod(alwaysRun = true)
+  public void setup_VEPreferred() {
+    base = new WikiBasePageObject(driver);
+    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_001"})
-    public void RTE_001_Bold() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickBold();
-        source.checkSourceContent("'''Bold text'''");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_001"})
+  public void RTE_001_Bold() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickBold();
+    source.checkSourceContent("'''Bold text'''");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_002"})
-    public void RTE_002_Italic() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickItalic();
-        source.checkSourceContent("''Italic text''");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_002"})
+  public void RTE_002_Italic() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickItalic();
+    source.checkSourceContent("''Italic text''");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_003"})
-    public void RTE_003_InternalLink() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickInternalLink();
-        source.checkSourceContent("[[Link title]]");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_003"})
+  public void RTE_003_InternalLink() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickInternalLink();
+    source.checkSourceContent("[[Link title]]");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_004"})
-    public void RTE_004_ExternalLink() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickExternalLink();
-        source.checkSourceContent("[http://www.example.com link title]");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_004"})
+  public void RTE_004_ExternalLink() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickExternalLink();
+    source.checkSourceContent("[http://www.example.com link title]");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_005"})
-    public void RTE_005_HeadLine() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickLvl2Headline();
-        source.checkSourceContent("\n== Headline text ==\n");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_005"})
+  public void RTE_005_HeadLine() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickLvl2Headline();
+    source.checkSourceContent("\n== Headline text ==\n");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_006"})
-    public void RTE_006_EmbedFile() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickEmbedFile();
-        source.checkSourceContent("[[File:Example.jpg]]");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_006"})
+  public void RTE_006_EmbedFile() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickEmbedFile();
+    source.checkSourceContent("[[File:Example.jpg]]");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_007"})
-    public void RTE_007_EmbedMedia() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickEmbedMedia();
-        source.checkSourceContent("[[Media:Example.ogg]]");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_007"})
+  public void RTE_007_EmbedMedia() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickEmbedMedia();
+    source.checkSourceContent("[[Media:Example.ogg]]");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_008"})
-    public void RTE_008_Math() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickMath();
-        source.checkSourceContent("<math>Insert formula here</math>");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_008"})
+  public void RTE_008_Math() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickMath();
+    source.checkSourceContent("<math>Insert formula here</math>");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_009"})
-    public void RTE_009_Nowiki() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickNowiki();
-        source.checkSourceContent("<nowiki>Insert non-formatted text here</nowiki>");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_009"})
+  public void RTE_009_Nowiki() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickNowiki();
+    source.checkSourceContent("<nowiki>Insert non-formatted text here</nowiki>");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_010"})
-    public void RTE_010_Signature() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickSignature();
-        source.checkSourceContent("--~~~~");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_010"})
+  public void RTE_010_Signature() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickSignature();
+    source.checkSourceContent("--~~~~");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_011"})
-    public void RTE_011_HLine() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickHorizontalLine();
-        source.checkSourceContent("\n----\n");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_011"})
+  public void RTE_011_HLine() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickHorizontalLine();
+    source.checkSourceContent("\n----\n");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_012"})
-    public void RTE_012_Photo() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
-        PhotoOptionsComponentObject
-                photoOptions =
-                photoAddPhoto.addPhotoFromWiki(PageContent.ARTICLESOURCEMODEFILE);
-        photoOptions.setCaption(PageContent.CAPTION);
-        photoOptions.clickAddPhoto();
-        String photoName = photoAddPhoto.getPhotoName();
-        source.checkSourceContent(String.format(
-                PageContent.WIKI_TEXT_PHOTO.replace("%photoName%", photoName), PageContent.CAPTION));
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_012"})
+  public void RTE_012_Photo() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
+    PhotoOptionsComponentObject
+        photoOptions =
+        photoAddPhoto.addPhotoFromWiki(PageContent.ARTICLESOURCEMODEFILE);
+    photoOptions.setCaption(PageContent.CAPTION);
+    photoOptions.clickAddPhoto();
+    String photoName = photoAddPhoto.getPhotoName();
+    source.checkSourceContent(String.format(
+        PageContent.WIKI_TEXT_PHOTO.replace("%photoName%", photoName), PageContent.CAPTION));
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_013"})
-    public void RTE_013_Slideshow() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickAddGallery();
-        source.verifyComponentSelector();
-        SlideshowBuilderComponentObject
-                slideshowBuilder =
-                (SlideshowBuilderComponentObject) source.addComponent("slideshow");
-        AddPhotoComponentObject slideshowAddPhoto = slideshowBuilder.clickAddPhoto();
-        slideshowAddPhoto.search("image");
-        List<String> photoNames = slideshowAddPhoto.choosePhotos(4);
-        slideshowAddPhoto.clickSelect();
-        slideshowBuilder.adjustPosition(Positions.CENTER);
-        slideshowBuilder.clickFinish();
-        source.checkSourceContent(
-                "<gallery type=\"slideshow\" position=\"center\">\n" + photoNames.get(0) + "\n" + photoNames
-                        .get(
-                                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_013"})
+  public void RTE_013_Slideshow() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickAddGallery();
+    source.verifyComponentSelector();
+    SlideshowBuilderComponentObject
+        slideshowBuilder =
+        (SlideshowBuilderComponentObject) source.addComponent("slideshow");
+    AddPhotoComponentObject slideshowAddPhoto = slideshowBuilder.clickAddPhoto();
+    slideshowAddPhoto.search("image");
+    List<String> photoNames = slideshowAddPhoto.choosePhotos(4);
+    slideshowAddPhoto.clickSelect();
+    slideshowBuilder.adjustPosition(Positions.CENTER);
+    slideshowBuilder.clickFinish();
+    source.checkSourceContent(
+        "<gallery type=\"slideshow\" position=\"center\">\n" + photoNames.get(0) + "\n" + photoNames
+            .get(
+                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_014"})
-    public void RTE_014_Gallery() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickAddGallery();
-        source.verifyComponentSelector();
-        GalleryBuilderComponentObject
-                galleryBuiler =
-                (GalleryBuilderComponentObject) source.addComponent("gallery");
-        AddPhotoComponentObject galleryAddPhoto = galleryBuiler.clickAddPhoto();
-        galleryAddPhoto.search("image");
-        List<String> photoNames = galleryAddPhoto.choosePhotos(4);
-        galleryAddPhoto.clickSelect();
-        galleryBuiler.adjustPosition(PositionsGallery.CENTER);
-        galleryBuiler.adjustColumns("2");
-        galleryBuiler.adjustSpacing(SpacingGallery.SMALL);
-        galleryBuiler.adjustOrientation(Orientation.LANDSCAPE);
-        galleryBuiler.clickFinish();
-        source.checkSourceContent(
-                "<gallery position=\"center\" columns=\"2\" spacing=\"small\">\n" + photoNames.get(0) + "\n"
-                        + photoNames.get(1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_014"})
+  public void RTE_014_Gallery() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickAddGallery();
+    source.verifyComponentSelector();
+    GalleryBuilderComponentObject
+        galleryBuiler =
+        (GalleryBuilderComponentObject) source.addComponent("gallery");
+    AddPhotoComponentObject galleryAddPhoto = galleryBuiler.clickAddPhoto();
+    galleryAddPhoto.search("image");
+    List<String> photoNames = galleryAddPhoto.choosePhotos(4);
+    galleryAddPhoto.clickSelect();
+    galleryBuiler.adjustPosition(PositionsGallery.CENTER);
+    galleryBuiler.adjustColumns("2");
+    galleryBuiler.adjustSpacing(SpacingGallery.SMALL);
+    galleryBuiler.adjustOrientation(Orientation.LANDSCAPE);
+    galleryBuiler.clickFinish();
+    source.checkSourceContent(
+        "<gallery position=\"center\" columns=\"2\" spacing=\"small\">\n" + photoNames.get(0) + "\n"
+        + photoNames.get(1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_015"})
-    public void RTE_015_Slider() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.clickAddGallery();
-        source.verifyComponentSelector();
-        SliderBuilderComponentObject
-                sliderBuilder =
-                (SliderBuilderComponentObject) source.addComponent("slider");
-        sliderBuilder.selectMenuPosition(MenuPositions.VERTICAL);
-        AddPhotoComponentObject sliderAddPhoto = sliderBuilder.clickAddPhoto();
-        sliderAddPhoto.search("image");
-        List<String> photoNames = sliderAddPhoto.choosePhotos(4);
-        sliderAddPhoto.clickSelect();
-        sliderBuilder.clickFinish();
-        source.checkSourceContent(
-                "<gallery type=\"slider\" orientation=\"right\">\n" + photoNames.get(0) + "\n" + photoNames
-                        .get(
-                                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_015"})
+  public void RTE_015_Slider() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.clickAddGallery();
+    source.verifyComponentSelector();
+    SliderBuilderComponentObject
+        sliderBuilder =
+        (SliderBuilderComponentObject) source.addComponent("slider");
+    sliderBuilder.selectMenuPosition(MenuPositions.VERTICAL);
+    AddPhotoComponentObject sliderAddPhoto = sliderBuilder.clickAddPhoto();
+    sliderAddPhoto.search("image");
+    List<String> photoNames = sliderAddPhoto.choosePhotos(4);
+    sliderAddPhoto.clickSelect();
+    sliderBuilder.clickFinish();
+    source.checkSourceContent(
+        "<gallery type=\"slider\" orientation=\"right\">\n" + photoNames.get(0) + "\n" + photoNames
+            .get(
+                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_016", "Media"})
-    public void RTE_016_Video() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        VetAddVideoComponentObject vetAddingVideo = source.clickAddVideo();
-        VetOptionsComponentObject
-                vetOptions =
-                vetAddingVideo.addVideoByUrl(VideoContent.YOUTUBE_VIDEO_URL);
-        vetOptions.setCaption(PageContent.CAPTION);
-        vetOptions.submit();
-        source.checkSourceVideoContent(
-                "[[" + VideoContent.YOUTUBE_VIDEO_WIKITEXT + PageContent.CAPTION + "]]");
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_016", "Media"})
+  public void RTE_016_Video() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    VetAddVideoComponentObject vetAddingVideo = source.clickAddVideo();
+    VetOptionsComponentObject
+        vetOptions =
+        vetAddingVideo.addVideoByUrl(VideoContent.YOUTUBE_VIDEO_URL);
+    vetOptions.setCaption(PageContent.CAPTION);
+    vetOptions.submit();
+    source.checkSourceVideoContent(
+        "[[" + VideoContent.YOUTUBE_VIDEO_WIKITEXT + PageContent.CAPTION + "]]");
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_017"})
-    public void RTE_017_MoreMainTools() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.checkMainTools();
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_017"})
+  public void RTE_017_MoreMainTools() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.checkMainTools();
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_018"})
-    public void RTE_018_MoreWikiMarkupTools() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.checkWikiMarkupTools();
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_018"})
+  public void RTE_018_MoreWikiMarkupTools() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.checkWikiMarkupTools();
+    source.submitArticle();
+  }
 
-    @Test(groups = {"RTE_extended", "RTE_extended_019"})
-    public void RTE_019_MoreSympolsTools() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        source.checkSymbolsTools();
-        source.submitArticle();
-    }
+  @Test(groups = {"RTE_extended", "RTE_extended_019"})
+  public void RTE_019_MoreSympolsTools() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    source.checkSymbolsTools();
+    source.submitArticle();
+  }
 
-    @CreationTicket(ticketID ="CONCF-626")
-    @Test(groups = {"RTE_extended", "RTE_extended_020"})
-    public void RTE_020_YoutubeTag_Preview() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
-        String videoID = video.getID();
-        source.addContent("<youtube>\n"+videoID+"\n</youtube>");
-        PreviewEditModePageObject preview = source.previewArticle();
-        preview.verifyVideoOnPreview(videoID);
-    }
+  @CreationTicket(ticketID = "CONCF-626")
+  @Test(groups = {"RTE_extended", "RTE_extended_020"})
+  public void RTE_020_YoutubeTag_Preview() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
+    String videoID = video.getID();
+    source.addContent("<youtube>\n" + videoID + "\n</youtube>");
+    PreviewEditModePageObject preview = source.previewArticle();
+    preview.verifyVideoOnPreview(videoID);
+  }
 
-    @CreationTicket(ticketID ="CONCF-626")
-    @Test(groups = {"RTE_extended", "RTE_extended_021"})
-    public void RTE_021_YoutubeTag_Publish() {
-        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-        YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
-        String videoID = video.getID();
-        source.addContent("<youtube>\n"+videoID+"\n</youtube>");
-        article = source.clickPublishButton();
-        article.verifyVideo(videoID);
-    }
+  @CreationTicket(ticketID = "CONCF-626")
+  @Test(groups = {"RTE_extended", "RTE_extended_021"})
+  public void RTE_021_YoutubeTag_Publish() {
+    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+    YoutubeVideo video = YoutubeVideoProvider.getLatestVideoForQuery("water");
+    String videoID = video.getID();
+    source.addContent("<youtube>\n" + videoID + "\n</youtube>");
+    article = source.clickPublishButton();
+    article.verifyVideo(videoID);
+  }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
@@ -2,6 +2,7 @@ package com.wikia.webdriver.testcases.articlecrudtests;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.contentpatterns.VideoContent;
+import com.wikia.webdriver.common.core.annotations.CreationTicket;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -34,253 +35,273 @@ import java.util.List;
  */
 public class ArticleSourceModeTests extends NewTestTemplate {
 
-  Credentials credentials = config.getCredentials();
-  WikiBasePageObject base;
+    Credentials credentials = config.getCredentials();
+    WikiBasePageObject base;
 
-  @BeforeMethod(alwaysRun = true)
-  public void setup_VEPreferred() {
-    base = new WikiBasePageObject(driver);
-    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
-  }
+    @BeforeMethod(alwaysRun = true)
+    public void setup_VEPreferred() {
+        base = new WikiBasePageObject(driver);
+        base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_001"})
-  public void RTE_001_Bold() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickBold();
-    source.checkSourceContent("'''Bold text'''");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_001"})
+    public void RTE_001_Bold() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickBold();
+        source.checkSourceContent("'''Bold text'''");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_002"})
-  public void RTE_002_Italic() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickItalic();
-    source.checkSourceContent("''Italic text''");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_002"})
+    public void RTE_002_Italic() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickItalic();
+        source.checkSourceContent("''Italic text''");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_003"})
-  public void RTE_003_InternalLink() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickInternalLink();
-    source.checkSourceContent("[[Link title]]");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_003"})
+    public void RTE_003_InternalLink() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickInternalLink();
+        source.checkSourceContent("[[Link title]]");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_004"})
-  public void RTE_004_ExternalLink() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickExternalLink();
-    source.checkSourceContent("[http://www.example.com link title]");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_004"})
+    public void RTE_004_ExternalLink() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickExternalLink();
+        source.checkSourceContent("[http://www.example.com link title]");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_005"})
-  public void RTE_005_HeadLine() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickLvl2Headline();
-    source.checkSourceContent("\n== Headline text ==\n");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_005"})
+    public void RTE_005_HeadLine() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickLvl2Headline();
+        source.checkSourceContent("\n== Headline text ==\n");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_006"})
-  public void RTE_006_EmbedFile() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickEmbedFile();
-    source.checkSourceContent("[[File:Example.jpg]]");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_006"})
+    public void RTE_006_EmbedFile() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickEmbedFile();
+        source.checkSourceContent("[[File:Example.jpg]]");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_007"})
-  public void RTE_007_EmbedMedia() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickEmbedMedia();
-    source.checkSourceContent("[[Media:Example.ogg]]");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_007"})
+    public void RTE_007_EmbedMedia() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickEmbedMedia();
+        source.checkSourceContent("[[Media:Example.ogg]]");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_008"})
-  public void RTE_008_Math() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickMath();
-    source.checkSourceContent("<math>Insert formula here</math>");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_008"})
+    public void RTE_008_Math() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickMath();
+        source.checkSourceContent("<math>Insert formula here</math>");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_009"})
-  public void RTE_009_Nowiki() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickNowiki();
-    source.checkSourceContent("<nowiki>Insert non-formatted text here</nowiki>");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_009"})
+    public void RTE_009_Nowiki() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickNowiki();
+        source.checkSourceContent("<nowiki>Insert non-formatted text here</nowiki>");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_010"})
-  public void RTE_010_Signature() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickSignature();
-    source.checkSourceContent("--~~~~");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_010"})
+    public void RTE_010_Signature() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickSignature();
+        source.checkSourceContent("--~~~~");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_011"})
-  public void RTE_011_HLine() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickHorizontalLine();
-    source.checkSourceContent("\n----\n");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_011"})
+    public void RTE_011_HLine() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickHorizontalLine();
+        source.checkSourceContent("\n----\n");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_012"})
-  public void RTE_012_Photo() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
-    PhotoOptionsComponentObject
-        photoOptions =
-        photoAddPhoto.addPhotoFromWiki(PageContent.ARTICLESOURCEMODEFILE);
-    photoOptions.setCaption(PageContent.CAPTION);
-    photoOptions.clickAddPhoto();
-    String photoName = photoAddPhoto.getPhotoName();
-    source.checkSourceContent(String.format(
-        PageContent.WIKI_TEXT_PHOTO.replace("%photoName%", photoName), PageContent.CAPTION));
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_012"})
+    public void RTE_012_Photo() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
+        PhotoOptionsComponentObject
+                photoOptions =
+                photoAddPhoto.addPhotoFromWiki(PageContent.ARTICLESOURCEMODEFILE);
+        photoOptions.setCaption(PageContent.CAPTION);
+        photoOptions.clickAddPhoto();
+        String photoName = photoAddPhoto.getPhotoName();
+        source.checkSourceContent(String.format(
+                PageContent.WIKI_TEXT_PHOTO.replace("%photoName%", photoName), PageContent.CAPTION));
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_013"})
-  public void RTE_013_Slideshow() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickAddGallery();
-    source.verifyComponentSelector();
-    SlideshowBuilderComponentObject
-        slideshowBuilder =
-        (SlideshowBuilderComponentObject) source.addComponent("slideshow");
-    AddPhotoComponentObject slideshowAddPhoto = slideshowBuilder.clickAddPhoto();
-    slideshowAddPhoto.search("image");
-    List<String> photoNames = slideshowAddPhoto.choosePhotos(4);
-    slideshowAddPhoto.clickSelect();
-    slideshowBuilder.adjustPosition(Positions.CENTER);
-    slideshowBuilder.clickFinish();
-    source.checkSourceContent(
-        "<gallery type=\"slideshow\" position=\"center\">\n" + photoNames.get(0) + "\n" + photoNames
-            .get(
-                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_013"})
+    public void RTE_013_Slideshow() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickAddGallery();
+        source.verifyComponentSelector();
+        SlideshowBuilderComponentObject
+                slideshowBuilder =
+                (SlideshowBuilderComponentObject) source.addComponent("slideshow");
+        AddPhotoComponentObject slideshowAddPhoto = slideshowBuilder.clickAddPhoto();
+        slideshowAddPhoto.search("image");
+        List<String> photoNames = slideshowAddPhoto.choosePhotos(4);
+        slideshowAddPhoto.clickSelect();
+        slideshowBuilder.adjustPosition(Positions.CENTER);
+        slideshowBuilder.clickFinish();
+        source.checkSourceContent(
+                "<gallery type=\"slideshow\" position=\"center\">\n" + photoNames.get(0) + "\n" + photoNames
+                        .get(
+                                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_014"})
-  public void RTE_014_Gallery() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickAddGallery();
-    source.verifyComponentSelector();
-    GalleryBuilderComponentObject
-        galleryBuiler =
-        (GalleryBuilderComponentObject) source.addComponent("gallery");
-    AddPhotoComponentObject galleryAddPhoto = galleryBuiler.clickAddPhoto();
-    galleryAddPhoto.search("image");
-    List<String> photoNames = galleryAddPhoto.choosePhotos(4);
-    galleryAddPhoto.clickSelect();
-    galleryBuiler.adjustPosition(PositionsGallery.CENTER);
-    galleryBuiler.adjustColumns("2");
-    galleryBuiler.adjustSpacing(SpacingGallery.SMALL);
-    galleryBuiler.adjustOrientation(Orientation.LANDSCAPE);
-    galleryBuiler.clickFinish();
-    source.checkSourceContent(
-        "<gallery position=\"center\" columns=\"2\" spacing=\"small\">\n" + photoNames.get(0) + "\n"
-        + photoNames.get(1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_014"})
+    public void RTE_014_Gallery() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickAddGallery();
+        source.verifyComponentSelector();
+        GalleryBuilderComponentObject
+                galleryBuiler =
+                (GalleryBuilderComponentObject) source.addComponent("gallery");
+        AddPhotoComponentObject galleryAddPhoto = galleryBuiler.clickAddPhoto();
+        galleryAddPhoto.search("image");
+        List<String> photoNames = galleryAddPhoto.choosePhotos(4);
+        galleryAddPhoto.clickSelect();
+        galleryBuiler.adjustPosition(PositionsGallery.CENTER);
+        galleryBuiler.adjustColumns("2");
+        galleryBuiler.adjustSpacing(SpacingGallery.SMALL);
+        galleryBuiler.adjustOrientation(Orientation.LANDSCAPE);
+        galleryBuiler.clickFinish();
+        source.checkSourceContent(
+                "<gallery position=\"center\" columns=\"2\" spacing=\"small\">\n" + photoNames.get(0) + "\n"
+                        + photoNames.get(1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_015"})
-  public void RTE_015_Slider() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.clickAddGallery();
-    source.verifyComponentSelector();
-    SliderBuilderComponentObject
-        sliderBuilder =
-        (SliderBuilderComponentObject) source.addComponent("slider");
-    sliderBuilder.selectMenuPosition(MenuPositions.VERTICAL);
-    AddPhotoComponentObject sliderAddPhoto = sliderBuilder.clickAddPhoto();
-    sliderAddPhoto.search("image");
-    List<String> photoNames = sliderAddPhoto.choosePhotos(4);
-    sliderAddPhoto.clickSelect();
-    sliderBuilder.clickFinish();
-    source.checkSourceContent(
-        "<gallery type=\"slider\" orientation=\"right\">\n" + photoNames.get(0) + "\n" + photoNames
-            .get(
-                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_015"})
+    public void RTE_015_Slider() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.clickAddGallery();
+        source.verifyComponentSelector();
+        SliderBuilderComponentObject
+                sliderBuilder =
+                (SliderBuilderComponentObject) source.addComponent("slider");
+        sliderBuilder.selectMenuPosition(MenuPositions.VERTICAL);
+        AddPhotoComponentObject sliderAddPhoto = sliderBuilder.clickAddPhoto();
+        sliderAddPhoto.search("image");
+        List<String> photoNames = sliderAddPhoto.choosePhotos(4);
+        sliderAddPhoto.clickSelect();
+        sliderBuilder.clickFinish();
+        source.checkSourceContent(
+                "<gallery type=\"slider\" orientation=\"right\">\n" + photoNames.get(0) + "\n" + photoNames
+                        .get(
+                                1) + "\n" + photoNames.get(2) + "\n" + photoNames.get(3) + "\n</gallery>");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_016", "Media"})
-  public void RTE_016_Video() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    VetAddVideoComponentObject vetAddingVideo = source.clickAddVideo();
-    VetOptionsComponentObject
-        vetOptions =
-        vetAddingVideo.addVideoByUrl(VideoContent.YOUTUBE_VIDEO_URL);
-    vetOptions.setCaption(PageContent.CAPTION);
-    vetOptions.submit();
-    source.checkSourceVideoContent(
-        "[[" + VideoContent.YOUTUBE_VIDEO_WIKITEXT + PageContent.CAPTION + "]]");
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_016", "Media"})
+    public void RTE_016_Video() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        VetAddVideoComponentObject vetAddingVideo = source.clickAddVideo();
+        VetOptionsComponentObject
+                vetOptions =
+                vetAddingVideo.addVideoByUrl(VideoContent.YOUTUBE_VIDEO_URL);
+        vetOptions.setCaption(PageContent.CAPTION);
+        vetOptions.submit();
+        source.checkSourceVideoContent(
+                "[[" + VideoContent.YOUTUBE_VIDEO_WIKITEXT + PageContent.CAPTION + "]]");
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_017"})
-  public void RTE_017_MoreMainTools() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.checkMainTools();
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_017"})
+    public void RTE_017_MoreMainTools() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.checkMainTools();
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_018"})
-  public void RTE_018_MoreWikiMarkupTools() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.checkWikiMarkupTools();
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_018"})
+    public void RTE_018_MoreWikiMarkupTools() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.checkWikiMarkupTools();
+        source.submitArticle();
+    }
 
-  @Test(groups = {"RTE_extended", "RTE_extended_019"})
-  public void RTE_019_MoreSympolsTools() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
-    ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
-    SourceEditModePageObject source = article.openCurrectArticleSourceMode();
-    source.checkSymbolsTools();
-    source.submitArticle();
-  }
+    @Test(groups = {"RTE_extended", "RTE_extended_019"})
+    public void RTE_019_MoreSympolsTools() {
+        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+        source.checkSymbolsTools();
+        source.submitArticle();
+    }
+
+    @CreationTicket(ticketID ="CONCF-626")
+    @Test(groups = {"RTE_extended", "RTE_extended_019"})
+    public void RTE_020_YoutubeTag_Preview() {
+//        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+//        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+//        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+//        source.checkSymbolsTools();
+//        source.submitArticle();
+    }
+
+    @CreationTicket(ticketID ="CONCF-626")
+    @Test(groups = {"RTE_extended", "RTE_extended_019"})
+    public void RTE_020_YoutubeTag_Publish() {
+//        String articleName = PageContent.ARTICLE_NAME_PREFIX + base.getTimeStamp();
+//        ArticlePageObject article = base.openArticleByName(wikiURL, articleName);
+//        SourceEditModePageObject source = article.openCurrectArticleSourceMode();
+//        source.checkSymbolsTools();
+//        source.submitArticle();
+    }
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-626 Original bug is the parent ticket

changes:
2 selenium test that add youtube video to article using youtube tag
CreationTicket annotation that related a test to its ticket id
Modified video and videoprovider so that it supports sending youtube ID

Test cases covered:

Test Case 1:
1. Get a video id from youtube via API or hardcoded ID. The ID appears in url after v"="
2. put tag 
<youtube> 
ID 
</youtube> to article in source mode
3. Click preview 
4. Verify that the video appears on preview

Test Case 2:
1. Get a video id from youtube via API or hardcoded ID. The ID appears in url after v"="
2. put multiline tag 
<youtube>
HXnGWKdRIOs
</youtube>  to article in source mode
3. Click Publish
4. Verify that the video appears in the article