### PR TITLE
SOC-843 add logic to reset forgot password time

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiLogInSignUpPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiLogInSignUpPageObject.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.createnewwiki;
 
+import com.wikia.webdriver.common.contentpatterns.ApiActions;
 import com.wikia.webdriver.common.contentpatterns.CreateWikiMessages;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
@@ -50,7 +51,10 @@ public class CreateNewWikiLogInSignUpPageObject extends WikiBasePageObject {
     PageObjectLogging.log("typeInPassword", "password name was typed", true);
   }
 
-  public void clickForgotPassword() {
+  public void clickForgotPassword(String userName, String apiToken) {
+    Assertion.assertEquals(
+            ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE,
+            resetForgotPasswordTime(userName, apiToken));
     waitForElementByElement(forgotPasswordLink);
     forgotPasswordLink.click();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/logintests/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/logintests/ForgottenPasswordTests.java
@@ -82,14 +82,15 @@ public class ForgottenPasswordTests extends NewTestTemplate {
   )
   @RelatedIssue(issueID = "SOC-843", comment = "Automation test is broken. Please test manually")
   public void ForgottenPassword_003_createWiki() {
+    String userName = credentials.userNameForgottenPassword3;
     WikiBasePageObject base = new WikiBasePageObject(driver);
     CreateNewWikiPageObjectStep1 cnw1 = base.openSpecialCreateNewWikiPage(wikiCorporateURL);
     String wikiName = cnw1.getWikiName();
     cnw1.typeInWikiName(wikiName);
     cnw1.verifySuccessIcon();
     CreateNewWikiLogInSignUpPageObject cnwLogin = cnw1.submitToLogInSignUp();
-    cnwLogin.typeInUserName(credentials.userNameForgottenPassword3);
-    cnwLogin.clickForgotPassword();
+    cnwLogin.typeInUserName(userName);
+    cnwLogin.clickForgotPassword(userName, credentials.apiToken);
     cnwLogin.verifyMessageAboutNewPassword(credentials.userNameForgottenPassword3);
     String newPassword = cnwLogin.receiveMailWithNewPassowrd(credentials.emailQaart1, credentials.emailPasswordQaart1);
     cnwLogin.typeInPassword(newPassword);
@@ -101,6 +102,6 @@ public class ForgottenPasswordTests extends NewTestTemplate {
     article.verifyWikiTitleOnCongratualtionsLightBox(wikiName);
     article.closeNewWikiCongratulationsLightBox();
     article.verifyWikiTitleHeader(wikiName);
-    article.verifyUserLoggedIn(credentials.userNameForgottenPassword3);
+    article.verifyUserLoggedIn(userName);
   }
 }


### PR DESCRIPTION
added logic that was initially left out to reset the forgot password timing so that a user can request new password multiple times in a 24 hour period.