### PR TITLE
Two generic fixes from ad engineering

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/Assertion.java
+++ b/src/test/java/com/wikia/webdriver/common/core/Assertion.java
@@ -34,12 +34,12 @@ public class Assertion extends Assert {
     return assertion;
   }
 
-  public static void assertEquals(String pattern, String current) {
+  public static void assertEquals(String current, String pattern) {
     String patternEncoded = encodeSpecialChars(pattern);
     String currentEncoded = encodeSpecialChars(current);
     boolean assertion = true;
     try {
-      Assert.assertEquals(pattern, current);
+      Assert.assertEquals(current, pattern);
     } catch (AssertionError err) {
       addVerificationFailure(err);
       assertion = false;

--- a/src/test/java/com/wikia/webdriver/common/core/Assertion.java
+++ b/src/test/java/com/wikia/webdriver/common/core/Assertion.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class Assertion extends Assert {
 
-  public static boolean assertStringContains(String pattern, String current) {
+  public static boolean assertStringContains(String current, String pattern) {
     String currentEncoded = encodeSpecialChars(current);
     String patternEncoded = encodeSpecialChars(pattern);
     boolean assertion = true;
@@ -52,7 +52,7 @@ public class Assertion extends Assert {
     );
   }
 
-  public static void assertNotEquals(String pattern, String current) {
+  public static void assertNotEquals(String current, String pattern) {
     String patternEncoded = encodeSpecialChars(pattern);
     String currentEncoded = encodeSpecialChars(current);
     boolean assertion = true;
@@ -70,7 +70,7 @@ public class Assertion extends Assert {
     );
   }
 
-  public static void assertNumber(Number expected, Number actual, String message) {
+  public static void assertNumber(Number actual, Number expected, String message) {
     boolean assertion = true;
     try {
       Assert.assertEquals(expected, actual);

--- a/src/test/java/com/wikia/webdriver/common/logging/PageObjectLogging.java
+++ b/src/test/java/com/wikia/webdriver/common/logging/PageObjectLogging.java
@@ -52,11 +52,17 @@ public class PageObjectLogging extends AbstractWebDriverEventListener implements
   private By lastFindBy;
   private WebDriver driver;
 
+  private static String getPageSource(WebDriver driver) {
+    return getPageSource(driver)
+            .replaceAll("<script", "<textarea style=\"display: none\"><script")
+            .replaceAll("</script", "</script></textarea");
+  }
+
   public static void log(String command, String description, boolean success, WebDriver driver) {
     logsResults.add(success);
     imageCounter += 1;
     new Shooter().savePageScreenshot(screenPath + imageCounter, driver);
-    CommonUtils.appendTextToFile(screenPath + imageCounter + ".html", driver.getPageSource());
+    CommonUtils.appendTextToFile(screenPath + imageCounter + ".html", getPageSource(driver));
     String className = success ? "success" : "error";
     StringBuilder builder = new StringBuilder();
     builder.append("<tr class=\"" + className + "\"><td>" + command + "</td><td>" + description
@@ -241,7 +247,7 @@ public class PageObjectLogging extends AbstractWebDriverEventListener implements
     if (Global.LOG_ENABLED) {
       try {
         new Shooter().savePageScreenshot(screenPath + imageCounter, driver);
-        CommonUtils.appendTextToFile(screenPath + imageCounter + ".html", driver.getPageSource());
+        CommonUtils.appendTextToFile(screenPath + imageCounter + ".html", getPageSource(driver));
       } catch (Exception e) {
         log("onException",
             "driver has no ability to catch screenshot or html source - driver may died", false);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
@@ -85,8 +85,8 @@ public class DropDownComponentObject extends WikiBasePageObject {
 
   public void remindPassword(String userName, String apiToken) {
     Assertion.assertEquals(
-        ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE,
-        resetForgotPasswordTime(userName, apiToken));
+            resetForgotPasswordTime(userName, apiToken), ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE
+    );
     fillUserNameInput(userName);
     waitForElementByElement(formForgotPasswordLink);
     scrollAndClick(formForgotPasswordLink);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/global_navitagtion/NavigationBar.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/global_navitagtion/NavigationBar.java
@@ -55,7 +55,7 @@ public class NavigationBar extends WikiBasePageObject {
                         "title");
             }
         }
-        Assertion.assertStringContains(suggestionText, allSuggestionTexts);
+        Assertion.assertStringContains(allSuggestionTexts, suggestionText);
     }
 
     /**

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/AddPinComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/AddPinComponentObject.java
@@ -165,7 +165,7 @@ public class AddPinComponentObject extends BasePageObject {
 
   public void verifyErrorContent(String errorMessage) {
     waitForElementByElement(errorField);
-    Assertion.assertEquals(errorMessage, errorField.getText());
+    Assertion.assertEquals(errorField.getText(), errorMessage);
   }
 
   public void verifyAssociatedImageIsVisible(String placeholderImageSrc) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/AddPinComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/AddPinComponentObject.java
@@ -170,7 +170,7 @@ public class AddPinComponentObject extends BasePageObject {
 
   public void verifyAssociatedImageIsVisible(String placeholderImageSrc) {
     waitForElementByElement(articleImageUrl);
-    Assertion.assertNotEquals(placeholderImageSrc, getAssociatedArticleImageSrc());
+    Assertion.assertNotEquals(getAssociatedArticleImageSrc(), placeholderImageSrc);
   }
 
   public void verifyAssociatedArticlePlaceholder() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/PalantirComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/interactivemaps/PalantirComponentObject.java
@@ -76,39 +76,39 @@ public class PalantirComponentObject extends InteractiveMapPageObject {
   }
 
   public void verifyMapPositionUpdated(PalantirContent handle) {
-    Assertion.assertEquals("true", handle.getSuccess());
-    Assertion.assertEquals("200", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_MAPPOS_SUCCESS, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "true");
+    Assertion.assertEquals(handle.getResponseCode(), "200");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_MAPPOS_SUCCESS);
   }
 
   public void verifyCorrectPlayerPos(PalantirContent handle) {
-    Assertion.assertEquals("true", handle.getSuccess());
-    Assertion.assertEquals("200", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_PLAYER_SUCCESS, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "true");
+    Assertion.assertEquals(handle.getResponseCode(), "200");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_PLAYER_SUCCESS);
   }
 
   public void verifyWrongPlayerPos(PalantirContent handle) {
-    Assertion.assertEquals("false", handle.getSuccess());
-    Assertion.assertEquals("422", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_MAP_OUTOFBOUNDARIES, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "false");
+    Assertion.assertEquals(handle.getResponseCode(), "422");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_MAP_OUTOFBOUNDARIES);
   }
 
   public void verifyWrongZoomLevel(PalantirContent handle) {
-    Assertion.assertEquals("false", handle.getSuccess());
-    Assertion.assertEquals("422", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_WRONG_ZOOM, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "false");
+    Assertion.assertEquals(handle.getResponseCode(), "422");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_WRONG_ZOOM);
   }
 
   public void verifyDecimalZoomLevel(PalantirContent handle) {
-    Assertion.assertEquals("false", handle.getSuccess());
-    Assertion.assertEquals("422", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_WRONG_PARAMETER, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "false");
+    Assertion.assertEquals(handle.getResponseCode(), "422");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_WRONG_PARAMETER);
   }
 
   public void verifyPlayerPosDeleted(PalantirContent handle) {
-    Assertion.assertEquals("true", handle.getSuccess());
-    Assertion.assertEquals("200", handle.getResponseCode());
-    Assertion.assertEquals(PalantirContent.PONTOMSG_REMOVEPLAYER, handle.getMessage());
+    Assertion.assertEquals(handle.getSuccess(), "true");
+    Assertion.assertEquals(handle.getResponseCode(), "200");
+    Assertion.assertEquals(handle.getMessage(), PalantirContent.PONTOMSG_REMOVEPLAYER);
   }
 
   public void verifyPoiAppearOnMap() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
@@ -165,7 +165,7 @@ public class LightboxComponentObject extends WikiBasePageObject {
 
   public void verifyTitleUrl(String expectedUrl) {
     String titleUrl = titleLink.getAttribute("href");
-    Assertion.assertEquals(expectedUrl, titleUrl);
+    Assertion.assertEquals(titleUrl, expectedUrl);
     PageObjectLogging.log("verifyTitleUrl", "Title URL is correct", true);
   }
 
@@ -178,7 +178,7 @@ public class LightboxComponentObject extends WikiBasePageObject {
 
   public void verifyMoreInfoUrl(String expectedUrl) {
     String moreInfoUrl = moreInfoLink.getAttribute("href");
-    Assertion.assertEquals(expectedUrl, moreInfoUrl);
+    Assertion.assertEquals(moreInfoUrl, expectedUrl);
     PageObjectLogging.log("verifyMoreInfoUrl", "More Info URL is correct", true);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
@@ -53,7 +53,7 @@ public class VideoComponentObject extends WikiBasePageObject {
   public void verifyVideoOoyalaEmbed() {
     WebElement container = videoEmbed.findElement(By.tagName("div"));
     String containerId = "ooyalaplayer-";
-    Assertion.assertStringContains(containerId, container.getAttribute("id"));
+    Assertion.assertStringContains(container.getAttribute("id"), containerId);
     waitForElementVisibleByElement(container.findElement(By.tagName("object")));
     PageObjectLogging.log("verifyVideoOoyalaEmbed", "Ooyala video is embedded", true);
   }
@@ -70,19 +70,19 @@ public class VideoComponentObject extends WikiBasePageObject {
 
   public void verifyVideoIgnEmbed() {
     String iframeSrc = "http://widgets.ign.com/video/embed/content.html?url=";
-    Assertion.assertStringContains(iframeSrc, getVideoPlayerIframe().getAttribute("src"));
+    Assertion.assertStringContains(getVideoPlayerIframe().getAttribute("src"), iframeSrc);
     PageObjectLogging.log("verifyVideoIgnEmbed", "IGN video is embedded", true);
   }
 
   public void verifyVideoAnyclipEmbed() {
     WebElement container = videoEmbed.findElement(By.tagName("div"));
     String containerId = "ACPContainer0";
-    Assertion.assertStringContains(containerId, container.getAttribute("id"));
+    Assertion.assertStringContains(container.getAttribute("id"), containerId);
 
     WebElement object = container.findElement(By.tagName("object"));
     waitForElementVisibleByElement(object);
-    Assertion.assertStringContains(object.getAttribute("id"),
-                                   getVideoPlayerObject().getAttribute("value"));
+    Assertion.assertStringContains(getVideoPlayerObject().getAttribute("value"), object.getAttribute("id")
+    );
     PageObjectLogging.log("verifyVideoAnyclipEmbed", "Anyclip video is embedded", true);
   }
 
@@ -135,7 +135,7 @@ public class VideoComponentObject extends WikiBasePageObject {
         break;
     }
 
-    Assertion.assertStringContains(autoplayStr, embedCode);
+    Assertion.assertStringContains(embedCode, autoplayStr);
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/minieditor/MiniEditorPreviewComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/minieditor/MiniEditorPreviewComponentObject.java
@@ -24,7 +24,7 @@ public class MiniEditorPreviewComponentObject extends WikiBasePageObject {
   By contentWrapper = By.cssSelector("#mw-content-text");
 
   public void verifyTextContent(String desiredText) {
-    Assertion.assertEquals(desiredText, previewModal.findElement(contentWrapper).getText());
+    Assertion.assertEquals(previewModal.findElement(contentWrapper).getText(), desiredText);
   }
 
   public void publish() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/monetizationmodule/MonetizationModuleComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/monetizationmodule/MonetizationModuleComponentObject.java
@@ -248,7 +248,7 @@ public class MonetizationModuleComponentObject extends WikiBasePageObject {
   public void verifyAdsenseHeaderShown() {
     waitForElementByElement(adHeader);
     Assertion.assertTrue(checkIfElementOnPage(adHeader));
-    Assertion.assertEquals(ADSENSE_HEADER_VALUE.toUpperCase(), adHeader.getText());
+    Assertion.assertEquals(adHeader.getText(), ADSENSE_HEADER_VALUE.toUpperCase());
     PageObjectLogging
         .log("verifyAdsenseHeaderShown", "The header of adsense unit is visible", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/toolbars/CustomizedToolbarComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/toolbars/CustomizedToolbarComponentObject.java
@@ -297,7 +297,7 @@ public class CustomizedToolbarComponentObject extends WikiBasePageObject {
 
   public void verifyToolInMoreTool(String toolName) {
     for (WebElement elem : myToolsList) {
-      Assertion.assertEquals(toolName.toLowerCase(), elem.getAttribute("data-name").toLowerCase());
+      Assertion.assertEquals(elem.getAttribute("data-name").toLowerCase(), toolName.toLowerCase());
     }
     PageObjectLogging.log("verifyToolInMoreTool", toolName + " appears in ToolbarMoreTool.", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/vet/VetOptionsComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/vet/VetOptionsComponentObject.java
@@ -142,7 +142,7 @@ public class VetOptionsComponentObject extends AddMediaModalComponentObject {
       default:
         desiredPositionId = "desired position not provided";
     }
-    Assertion.assertEquals(desiredPositionId, selectedPositionId);
+    Assertion.assertEquals(selectedPositionId, desiredPositionId);
   }
 
   public void clickUpdateVideo() {
@@ -163,7 +163,7 @@ public class VetOptionsComponentObject extends AddMediaModalComponentObject {
 
   public void verifyCaption(String captionDesired) {
     String caption = captionField.getAttribute("value");
-    Assertion.assertEquals(captionDesired, caption);
+    Assertion.assertEquals(caption, captionDesired);
   }
 
   public void verifyNameNotEditable() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/videosmodule/VideosModuleComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/videosmodule/VideosModuleComponentObject.java
@@ -49,7 +49,7 @@ public class VideosModuleComponentObject extends WikiBasePageObject {
       for (int j = i + 1; j < videos.size(); j++) {
         videoTitle1 = videos.get(i).getAttribute("data-video-key");
         videoTitle2 = videos.get(j).getAttribute("data-video-key");
-        Assertion.assertNotEquals(videoTitle1, videoTitle2);
+        Assertion.assertNotEquals(videoTitle2, videoTitle1);
       }
     }
     PageObjectLogging.log("verifyNoDuplicates", "Videos Module not showing duplicates", true);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorHyperLinkDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorHyperLinkDialog.java
@@ -123,26 +123,26 @@ public class VisualEditorHyperLinkDialog extends VisualEditorDialog {
 
   public void verifyNewPageIsTop() {
     indexLinkCategories();
-    Assertion.assertNumber(0, pageCategoryIndex[NEW_PAGE_INDEX],
-                           "Checking New Page is on the top of the results.");
+    Assertion.assertNumber(pageCategoryIndex[NEW_PAGE_INDEX], 0,
+            "Checking New Page is on the top of the results.");
   }
 
   public void verifyMatchingPageIsTop() {
     indexLinkCategories();
-    Assertion.assertNumber(0, pageCategoryIndex[MATCHING_PAGE_INDEX],
-                           "Checking Matching Page is on the top of the results.");
+    Assertion.assertNumber(pageCategoryIndex[MATCHING_PAGE_INDEX], 0,
+            "Checking Matching Page is on the top of the results.");
   }
 
   public void verifyExternalLinkIsTop() {
     indexLinkCategories();
-    Assertion.assertNumber(0, pageCategoryIndex[EXTERNAL_LINK_INDEX],
-                           "Checking External Link is on the top of the results.");
+    Assertion.assertNumber(pageCategoryIndex[EXTERNAL_LINK_INDEX], 0,
+            "Checking External Link is on the top of the results.");
   }
 
   public void verifyRedirectPageIsTop() {
     indexLinkCategories();
-    Assertion.assertNumber(0, pageCategoryIndex[REDIRECT_PAGE_INDEX],
-                           "Checking Redirect Page is on the top of the results.");
+    Assertion.assertNumber(pageCategoryIndex[REDIRECT_PAGE_INDEX], 0,
+            "Checking Redirect Page is on the top of the results.");
   }
 
   public void clickLinkResult() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertGalleryDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorInsertGalleryDialog.java
@@ -106,7 +106,7 @@ public class VisualEditorInsertGalleryDialog extends VisualEditorDialog {
 
   public void verifyNumOfCartItems(int expected) {
     waitForDialogVisible();
-    Assertion.assertNumber(expected, cartItems.size(), "Verify number of items in cart");
+    Assertion.assertNumber(cartItems.size(), expected, "Verify number of items in cart");
   }
 
   public void addMediaToCart(int number) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorReviewChangesDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorReviewChangesDialog.java
@@ -87,16 +87,16 @@ public class VisualEditorReviewChangesDialog extends VisualEditorDialog {
         }
       }
     }
-    Assertion.assertNumber(expectedCount, count, "Number of diffs.");
+    Assertion.assertNumber(count, expectedCount, "Number of diffs.");
     if (mode == INSERT) {
-      Assertion.assertNumber(0, targets.size(), "Number of diffs.");
+      Assertion.assertNumber(targets.size(), 0, "Number of diffs.");
     }
   }
 
   private void verifyNewArticleDiffs(List<String> targets) {
     String wikiText = wikiaAritlceFirstPreview.getText();
     for (String target : targets) {
-      Assertion.assertStringContains(target, wikiText);
+      Assertion.assertStringContains(wikiText, target);
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorSaveChangesDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorSaveChangesDialog.java
@@ -73,7 +73,7 @@ public class VisualEditorSaveChangesDialog extends VisualEditorDialog {
   }
 
   public void verifyIsNewRecaptcha(String target) {
-    Assertion.assertNotEquals(target, getRecaptchaImageSrc());
+    Assertion.assertNotEquals(getRecaptchaImageSrc(), target);
     PageObjectLogging.log("verifyIsNewRecaptcha", "A new ReCAPTCHA appeared", true);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -317,7 +317,7 @@ public class BasePageObject {
 
   public void verifyURLcontains(String givenString) {
     String currentURL = driver.getCurrentUrl();
-    Assertion.assertStringContains(givenString.toLowerCase(), currentURL.toLowerCase());
+    Assertion.assertStringContains(currentURL.toLowerCase(), givenString.toLowerCase());
     PageObjectLogging.log("verifyURLcontains",
                           "current url is the same as expetced url", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -336,7 +336,7 @@ public class BasePageObject {
   }
 
   public void verifyURL(String givenURL) {
-    Assertion.assertEquals(givenURL, driver.getCurrentUrl());
+    Assertion.assertEquals(driver.getCurrentUrl(), givenURL);
   }
 
   public String getCurrentUrl() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/HubBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/HubBasePageObject.java
@@ -103,8 +103,8 @@ public class HubBasePageObject extends WikiBasePageObject {
    */
   public void mosaicSliderVerifyLargeImageDescriptionDifferent(
       String previousLargeImageDescription) {
-    Assertion.assertNotEquals(previousLargeImageDescription,
-                              mosaicSliderGetCurrentLargeImageDescription());
+    Assertion.assertNotEquals(mosaicSliderGetCurrentLargeImageDescription(), previousLargeImageDescription
+    );
   }
 
   /**

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/ModularMainPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/ModularMainPageObject.java
@@ -100,7 +100,7 @@ public class ModularMainPageObject extends WikiBasePageObject{
 
   public void verifyEditedAndPublishedDescriptions(String editedDescription) {
     waitForElementByElement(heroPublishedDescription);
-    Assertion.assertEquals(editedDescription, heroPublishedDescription.getText());
+    Assertion.assertEquals(heroPublishedDescription.getText(), editedDescription);
   }
 
   public void verifyAdminStaffButtons() {
@@ -152,7 +152,7 @@ public class ModularMainPageObject extends WikiBasePageObject{
 
   public void verifyPublishedTextAndEditor(String publishedText) {
     waitForElementByElement(heroPublishedDescription);
-    Assertion.assertEquals(publishedText, heroPublishedDescription.getText());
+    Assertion.assertEquals(heroPublishedDescription.getText(), publishedText);
   }
 
   public void clickDiscardButton() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/ModularMainPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/ModularMainPageObject.java
@@ -120,7 +120,7 @@ public class ModularMainPageObject extends WikiBasePageObject{
 
   public void verifySrcTxtAreDifferent(String imgSrc, String newImgSrc) {
     waitForElementByElement(heroImageModule);
-    Assertion.assertNotEquals(imgSrc, newImgSrc);
+    Assertion.assertNotEquals(newImgSrc, imgSrc);
   }
 
   public void deleteDescriptionEditorContent() {
@@ -175,6 +175,6 @@ public class ModularMainPageObject extends WikiBasePageObject{
   }
 
   public void compareTopValues(String firstTopValue, String secondTopValue) {
-    Assertion.assertNotEquals(firstTopValue, secondTopValue);
+    Assertion.assertNotEquals(secondTopValue, firstTopValue);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/SearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/SearchPageObject.java
@@ -62,14 +62,14 @@ public class SearchPageObject extends WikiBasePageObject {
   }
 
   public void verifyNoResults() {
-    Assertion.assertEquals("No results found.", noResultsCaption.getText());
+    Assertion.assertEquals(noResultsCaption.getText(), "No results found.");
   }
 
   public void verifyPagination() {
     waitForElementByBy(paginationContainerBy);
     int i = 1;
     for (WebElement elem : paginationPages) {
-      Assertion.assertEquals(Integer.toString(i), elem.getText());
+      Assertion.assertEquals(elem.getText(), Integer.toString(i));
       i++;
     }
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -1046,7 +1046,7 @@ public class WikiBasePageObject extends BasePageObject {
 
   public void verifyHeader(String fileName) {
     waitForElementByElement(wikiFirstHeader);
-    Assertion.assertStringContains(fileName, wikiFirstHeader.getText());
+    Assertion.assertStringContains(wikiFirstHeader.getText(), fileName);
   }
 
   public void disableCaptcha() {
@@ -1215,7 +1215,7 @@ public class WikiBasePageObject extends BasePageObject {
   }
 
   public void verifyArticleName(String targetText) {
-    Assertion.assertStringContains(getArticleName(), targetText);
+    Assertion.assertStringContains(targetText, getArticleName());
     PageObjectLogging.log(
         "verifyArticleName",
         "The article shows " + targetText,
@@ -1232,7 +1232,7 @@ public class WikiBasePageObject extends BasePageObject {
         true,
         driver
     );
-    Assertion.assertStringContains(pattern, headerWhereIsMyExtensionPage.getText());
+    Assertion.assertStringContains(headerWhereIsMyExtensionPage.getText(), pattern);
   }
 
   protected Boolean isNewGlobalNavPresent() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -467,11 +467,11 @@ public class AdsBaseObject extends WikiBasePageObject {
         String dataGptSlotParams = getGptParams(slotName, "data-gpt-slot-params");
 
         for (String param : pageParams) {
-            Assertion.assertStringContains(param, dataGptPageParams);
+            Assertion.assertStringContains(dataGptPageParams, param);
         }
 
         for (String param : slotParams) {
-            Assertion.assertStringContains(param, dataGptSlotParams);
+            Assertion.assertStringContains(dataGptSlotParams, param);
         }
 
         PageObjectLogging.log(
@@ -559,7 +559,7 @@ public class AdsBaseObject extends WikiBasePageObject {
 
     public AdsBaseObject verifyLineItemId(String slotName, int lineItemId) {
         String lineItemParam = getGptParams(slotName, GPT_DATA_ATTRIBUTES[0]);
-        Assertion.assertStringContains(String.valueOf(lineItemId), lineItemParam);
+        Assertion.assertStringContains(lineItemParam, String.valueOf(lineItemId));
         PageObjectLogging
             .log("verifyLineItemId", slotName + " has following line item: " + lineItemParam, true);
         return this;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsGermanObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsGermanObject.java
@@ -207,7 +207,7 @@ public class AdsGermanObject extends AdsBaseObject {
 
   public void verify71MediaParams(String expectedParams) {
     String actualParams = Joiner.on("; ").join(get71MediaParams());
-    Assertion.assertEquals(expectedParams, actualParams);
+    Assertion.assertEquals(actualParams, expectedParams);
   }
 
   private ArrayList<String> get71MediaParams() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsHopObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsHopObject.java
@@ -35,7 +35,7 @@ public class AdsHopObject extends AdsBaseObject {
 
     public AdsHopObject verifyClassHidden(String slotName, String src) {
         WebElement testedDiv = getTestedDiv(slotName, src);
-        Assertion.assertEquals("hidden", testedDiv.getAttribute("class").trim());
+        Assertion.assertEquals(testedDiv.getAttribute("class").trim(), "hidden");
         return this;
     }
 
@@ -46,7 +46,7 @@ public class AdsHopObject extends AdsBaseObject {
         driver.switchTo().frame(iframe);
         WebElement postMessageScript = driver.findElement(By.xpath(POST_MESSAGE_SCRIPT_XPATH));
         Assertion
-            .assertEquals(getPostMessagePattern(src), postMessageScript.getAttribute("innerHTML"));
+            .assertEquals(postMessageScript.getAttribute("innerHTML"), getPostMessagePattern(src));
         driver.switchTo().defaultContent();
         return this;
     }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -42,7 +42,7 @@ public class AdsKruxObject extends AdsBaseObject {
    */
   public void verifyKruxControlTag(String kruxSiteId) {
     String expectedUrl = KRUX_CONTROL_TAG_URL_PREFIX + kruxSiteId;
-    Assertion.assertEquals(expectedUrl, kruxControlTag.getAttribute("src"));
+    Assertion.assertEquals(kruxControlTag.getAttribute("src"), expectedUrl);
   }
 
   /**

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -98,7 +98,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
         WebElement slot = driver.findElement(By.id(slotName));
         if (checkIfSlotExpanded(slot)) {
             String foundImg = getSlotImageAd(slot);
-            Assertion.assertStringContains(expectedImg, foundImg);
+            Assertion.assertStringContains(foundImg, expectedImg);
         } else {
             throw new NoSuchElementException("Slot is collapsed - should be expanded");
         }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/ArticlePageObject.java
@@ -183,7 +183,7 @@ public class ArticlePageObject extends WikiBasePageObject {
 
   public void verifyContent(String content) {
     waitForElementVisibleByElement(articleContent);
-    Assertion.assertStringContains(content, articleContent.getText());
+    Assertion.assertStringContains(articleContent.getText(), content);
   }
 
 
@@ -283,7 +283,7 @@ public class ArticlePageObject extends WikiBasePageObject {
   public void verifyCommentText(String comment) {
     WebElement mostRecentComment = articleComments.get(0);
     waitForTextToBePresentInElementByElement(mostRecentComment, comment);
-    Assertion.assertStringContains(comment, mostRecentComment.getText());
+    Assertion.assertStringContains(mostRecentComment.getText(), comment);
   }
 
   public void verifyCommentVideo(String videoName) {
@@ -333,7 +333,7 @@ public class ArticlePageObject extends WikiBasePageObject {
     WebElement mostRecentComment = articleComments.get(0);
     WebElement editedByArea = mostRecentComment.findElement(By.cssSelector(COMMENT_AUTHOR_LINK));
     waitForElementVisibleByElement(editedByArea);
-    Assertion.assertStringContains(userName, editedByArea.getText());
+    Assertion.assertStringContains(editedByArea.getText(), userName);
   }
 
   public MiniEditorComponentObject triggerCommentReply() {
@@ -354,14 +354,14 @@ public class ArticlePageObject extends WikiBasePageObject {
   public void verifyCommentReply(String reply) {
     WebElement mostRecentReply = commentReplies.get(0);
     waitForElementVisibleByElement(mostRecentReply);
-    Assertion.assertStringContains(reply, mostRecentReply.getText());
+    Assertion.assertStringContains(mostRecentReply.getText(), reply);
   }
 
   public void verifyReplyCreator(String userName) {
     WebElement mostRecentReply = commentReplies.get(0);
     WebElement editedByArea = mostRecentReply.findElement(By.cssSelector(COMMENT_AUTHOR_LINK));
     waitForElementVisibleByElement(editedByArea);
-    Assertion.assertStringContains(userName, editedByArea.getText());
+    Assertion.assertStringContains(editedByArea.getText(), userName);
   }
 
   public String getArticleName() {
@@ -495,7 +495,7 @@ public class ArticlePageObject extends WikiBasePageObject {
         position = "position is not provided";
         break;
     }
-    Assertion.assertStringContains(position, videoClass);
+    Assertion.assertStringContains(videoClass, position);
   }
 
   public Integer getVideoWidth(WebElement thumbnail) {
@@ -509,9 +509,8 @@ public class ArticlePageObject extends WikiBasePageObject {
   public void verifyVideoWidth(int widthDesired) {
     int videoWidth = getVideoWidth(videoThumbnail);
     Assertion.assertNumber(
-        widthDesired,
-        videoWidth,
-        "width should be " + widthDesired + " but is " + videoWidth
+            videoWidth, widthDesired,
+            "width should be " + widthDesired + " but is " + videoWidth
     );
   }
 
@@ -519,7 +518,7 @@ public class ArticlePageObject extends WikiBasePageObject {
     String caption = videoThumbnailWrapper.findElement(
         By.className("caption")
     ).getText();
-    Assertion.assertStringContains(captionDesired, caption);
+    Assertion.assertStringContains(caption, captionDesired);
     PageObjectLogging.log("verifyVideoCaption", "video has expected caption", true);
   }
 
@@ -527,7 +526,7 @@ public class ArticlePageObject extends WikiBasePageObject {
     String name = videoThumbnailWrapper.findElement(
         By.className("title")
     ).getText();
-    Assertion.assertStringContains(nameDesired, name);
+    Assertion.assertStringContains(name, nameDesired);
     PageObjectLogging.log("verifyVideoName", "video has expected name", true);
   }
 
@@ -683,7 +682,7 @@ public class ArticlePageObject extends WikiBasePageObject {
   }
 
   public void verifyWikiTitleOnCongratualtionsLightBox(String wikiName) {
-    Assertion.assertStringContains(wikiName, welcomeLightBoxTitle.getText());
+    Assertion.assertStringContains(welcomeLightBoxTitle.getText(), wikiName);
   }
 
   public void closeNewWikiCongratulationsLightBox() {
@@ -694,7 +693,7 @@ public class ArticlePageObject extends WikiBasePageObject {
   }
 
   public void verifyWikiTitleHeader(String wikiName) {
-    Assertion.assertStringContains(wikiName, wikiNameHeader.getText());
+    Assertion.assertStringContains(wikiNameHeader.getText(), wikiName);
   }
 
   public void verifyTableRemoved() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
@@ -84,7 +84,7 @@ public class PreviewEditModePageObject extends EditMode {
   }
 
   public void verifyTextContent(String desiredText) {
-    Assertion.assertEquals(desiredText, previewModal.findElement(contentWrapper).getText());
+    Assertion.assertEquals(previewModal.findElement(contentWrapper).getText(), desiredText);
   }
 
   public void publish() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/PreviewEditModePageObject.java
@@ -69,12 +69,12 @@ public class PreviewEditModePageObject extends EditMode {
         videoWidthSelector
     ).getAttribute("width"));
     Assertion
-        .assertNumber(desiredWidth, width, "width should be " + desiredWidth + " but is " + width);
+        .assertNumber(width, desiredWidth, "width should be " + desiredWidth + " but is " + width);
   }
 
   public void verifyVideoCaption(String desiredCaption) {
     String caption = previewModal.findElement(videoCaptionSelector).getText();
-    Assertion.assertStringContains(desiredCaption, caption);
+    Assertion.assertStringContains(caption, desiredCaption);
   }
 
   public void closePreviewModal() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -307,7 +307,7 @@ public class SourceEditModePageObject extends EditMode {
   }
 
   public void verifyVideoAlignment(PositionsVideo position) {
-    Assertion.assertStringContains(position.toString().toLowerCase(), getContent()
+    Assertion.assertStringContains(getContent(), position.toString().toLowerCase()
     );
   }
 
@@ -317,14 +317,13 @@ public class SourceEditModePageObject extends EditMode {
         content.substring(content.indexOf("px") - 4, content.indexOf("px") - 1)
     );
     Assertion.assertNumber(
-        width,
-        widthDesired,
-        "width is " + width + " should be " + widthDesired
+            widthDesired, width,
+            "width is " + width + " should be " + widthDesired
     );
   }
 
   public void verifyVideoCaption(String desiredCaption) {
-    Assertion.assertStringContains(desiredCaption, getContent());
+    Assertion.assertStringContains(getContent(), desiredCaption);
   }
 
   /**

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -91,12 +91,12 @@ public class SourceEditModePageObject extends EditMode {
 
   public void checkSourceContent(String desiredContent) {
     waitForElementClickableByElement(sourceModeTextArea);
-    Assertion.assertEquals(desiredContent, getSourceContent());
+    Assertion.assertEquals(getSourceContent(), desiredContent);
   }
 
   public void checkSourceVideoContent(String desiredContent) {
-    Assertion.assertEquals(desiredContent.substring(1, 38) + desiredContent.substring(48),
-                           getSourceContent().substring(1, 38) + getSourceContent().substring(48));
+    Assertion.assertEquals(getSourceContent().substring(1, 38) + getSourceContent().substring(48), desiredContent.substring(1, 38) + desiredContent.substring(48)
+    );
   }
 
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/VisualEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/VisualEditModePageObject.java
@@ -175,13 +175,13 @@ public class VisualEditModePageObject extends EditMode {
     driver.switchTo().defaultContent();
     switch (position) {
       case LEFT:
-        Assertion.assertStringContains("alignLeft", positionClass);
+        Assertion.assertStringContains(positionClass, "alignLeft");
         break;
       case CENTER:
-        Assertion.assertStringContains("alignCenter", positionClass);
+        Assertion.assertStringContains(positionClass, "alignCenter");
         break;
       case RIGHT:
-        Assertion.assertStringContains("alignRight", positionClass);
+        Assertion.assertStringContains(positionClass, "alignRight");
         break;
       default:
         throw new NoSuchElementException("Non-existing position selected");
@@ -194,9 +194,8 @@ public class VisualEditModePageObject extends EditMode {
     int widthCurrent = Integer.parseInt(video.getAttribute("width"));
     driver.switchTo().defaultContent();
     Assertion.assertNumber(
-        widthDesired,
-        widthCurrent,
-        "width should be " + widthDesired + " but is " + widthCurrent
+            widthCurrent, widthDesired,
+            "width should be " + widthDesired + " but is " + widthCurrent
     );
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/VisualEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/VisualEditModePageObject.java
@@ -202,7 +202,7 @@ public class VisualEditModePageObject extends EditMode {
 
   public void verifyVideoCaption(String captionDesired) {
     mouseOverComponent(Components.VIDEO);
-    Assertion.assertEquals(captionDesired, caption.getText());
+    Assertion.assertEquals(caption.getText(), captionDesired);
   }
 
   private void mouseOverComponent(Components component) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/chatpageobject/ChatPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/chatpageobject/ChatPageObject.java
@@ -190,9 +190,9 @@ public class ChatPageObject extends WikiBasePageObject {
     Assertion.assertNumber(3, userDropDownActionsElements.size(),
                            "Checking number of elements in the dropDown");
     Assertion
-        .assertEquals("message-wall", userDropDownActionsElements.get(0).getAttribute("class"));
-    Assertion.assertEquals("contribs", userDropDownActionsElements.get(1).getAttribute("class"));
-    Assertion.assertEquals("private", userDropDownActionsElements.get(2).getAttribute("class"));
+        .assertEquals(userDropDownActionsElements.get(0).getAttribute("class"), "message-wall");
+    Assertion.assertEquals(userDropDownActionsElements.get(1).getAttribute("class"), "contribs");
+    Assertion.assertEquals(userDropDownActionsElements.get(2).getAttribute("class"), "private");
   }
 
   public void verifyBlockingUserDropdown(String userName) {
@@ -202,9 +202,9 @@ public class ChatPageObject extends WikiBasePageObject {
     waitForProperNumberOfElementsInUserDropdown(userName);
     List<WebElement> list = userDropDownActionsElements;
     Assertion.assertNumber(3, list.size(), "Checking number of elements in the drop-down");
-    Assertion.assertEquals("message-wall", list.get(0).getAttribute("class"));
-    Assertion.assertEquals("contribs", list.get(1).getAttribute("class"));
-    Assertion.assertEquals("private-allow", list.get(2).getAttribute("class"));
+    Assertion.assertEquals(list.get(0).getAttribute("class"), "message-wall");
+    Assertion.assertEquals(list.get(1).getAttribute("class"), "contribs");
+    Assertion.assertEquals(list.get(2).getAttribute("class"), "private-allow");
   }
 
   public void verifyPrivateUserDropdown(String userName) {
@@ -212,10 +212,10 @@ public class ChatPageObject extends WikiBasePageObject {
     Assertion.assertNumber(3, userDropDownActionsElements.size(),
                            "Checking number of elements in the drop-down");
     Assertion
-        .assertEquals("message-wall", userDropDownActionsElements.get(0).getAttribute("class"));
-    Assertion.assertEquals("contribs", userDropDownActionsElements.get(1).getAttribute("class"));
+        .assertEquals(userDropDownActionsElements.get(0).getAttribute("class"), "message-wall");
+    Assertion.assertEquals(userDropDownActionsElements.get(1).getAttribute("class"), "contribs");
     Assertion
-        .assertEquals("private-block", userDropDownActionsElements.get(2).getAttribute("class"));
+        .assertEquals(userDropDownActionsElements.get(2).getAttribute("class"), "private-block");
   }
 
   public void verifyAdminUserDropdown(String userName) {
@@ -226,9 +226,9 @@ public class ChatPageObject extends WikiBasePageObject {
     Assertion.assertNumber(3, adminDropDownActionsElements.size(),
                            "Checking number of elements in the drop-down");
     Assertion
-        .assertEquals("give-chat-mod", adminDropDownActionsElements.get(0).getAttribute("class"));
-    Assertion.assertEquals("kick", adminDropDownActionsElements.get(1).getAttribute("class"));
-    Assertion.assertEquals("ban", adminDropDownActionsElements.get(2).getAttribute("class"));
+        .assertEquals(adminDropDownActionsElements.get(0).getAttribute("class"), "give-chat-mod");
+    Assertion.assertEquals(adminDropDownActionsElements.get(1).getAttribute("class"), "kick");
+    Assertion.assertEquals(adminDropDownActionsElements.get(2).getAttribute("class"), "ban");
   }
 
   public void writeOnChat(String message) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/chatpageobject/ChatPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/chatpageobject/ChatPageObject.java
@@ -187,8 +187,8 @@ public class ChatPageObject extends WikiBasePageObject {
     if (checkIfPrivateMessagesNotAllowed(userName)) {
       allowPrivateMessageFromUser(userName);
     }
-    Assertion.assertNumber(3, userDropDownActionsElements.size(),
-                           "Checking number of elements in the dropDown");
+    Assertion.assertNumber(userDropDownActionsElements.size(), 3,
+            "Checking number of elements in the dropDown");
     Assertion
         .assertEquals(userDropDownActionsElements.get(0).getAttribute("class"), "message-wall");
     Assertion.assertEquals(userDropDownActionsElements.get(1).getAttribute("class"), "contribs");
@@ -201,7 +201,7 @@ public class ChatPageObject extends WikiBasePageObject {
     //We need to click it more then once sometimes to actually load everything
     waitForProperNumberOfElementsInUserDropdown(userName);
     List<WebElement> list = userDropDownActionsElements;
-    Assertion.assertNumber(3, list.size(), "Checking number of elements in the drop-down");
+    Assertion.assertNumber(list.size(), 3, "Checking number of elements in the drop-down");
     Assertion.assertEquals(list.get(0).getAttribute("class"), "message-wall");
     Assertion.assertEquals(list.get(1).getAttribute("class"), "contribs");
     Assertion.assertEquals(list.get(2).getAttribute("class"), "private-allow");
@@ -209,8 +209,8 @@ public class ChatPageObject extends WikiBasePageObject {
 
   public void verifyPrivateUserDropdown(String userName) {
     openUserDropDownInPrivateMessageSection(userName);
-    Assertion.assertNumber(3, userDropDownActionsElements.size(),
-                           "Checking number of elements in the drop-down");
+    Assertion.assertNumber(userDropDownActionsElements.size(), 3,
+            "Checking number of elements in the drop-down");
     Assertion
         .assertEquals(userDropDownActionsElements.get(0).getAttribute("class"), "message-wall");
     Assertion.assertEquals(userDropDownActionsElements.get(1).getAttribute("class"), "contribs");
@@ -223,8 +223,8 @@ public class ChatPageObject extends WikiBasePageObject {
     verifyNormalUserDropdown(userName);
 
     //and admin dropDown
-    Assertion.assertNumber(3, adminDropDownActionsElements.size(),
-                           "Checking number of elements in the drop-down");
+    Assertion.assertNumber(adminDropDownActionsElements.size(), 3,
+            "Checking number of elements in the drop-down");
     Assertion
         .assertEquals(adminDropDownActionsElements.get(0).getAttribute("class"), "give-chat-mod");
     Assertion.assertEquals(adminDropDownActionsElements.get(1).getAttribute("class"), "kick");

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiLogInSignUpPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiLogInSignUpPageObject.java
@@ -53,8 +53,8 @@ public class CreateNewWikiLogInSignUpPageObject extends WikiBasePageObject {
 
   public void clickForgotPassword(String userName, String apiToken) {
     Assertion.assertEquals(
-            ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE,
-            resetForgotPasswordTime(userName, apiToken));
+            resetForgotPasswordTime(userName, apiToken), ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE
+    );
     waitForElementByElement(forgotPasswordLink);
     forgotPasswordLink.click();
   }
@@ -75,24 +75,24 @@ public class CreateNewWikiLogInSignUpPageObject extends WikiBasePageObject {
 
   public void verifyEmptyUserNameValidation() {
     waitForElementByCss(ERROR_MESSAGE_CSS);
-    Assertion.assertEquals(CreateWikiMessages.BLANK_USERNAME_ERROR_MESSAGE, errorMessage.getText());
+    Assertion.assertEquals(errorMessage.getText(), CreateWikiMessages.BLANK_USERNAME_ERROR_MESSAGE);
   }
 
   public void verifyInvalidUserNameValidation() {
     waitForElementByCss(ERROR_MESSAGE_CSS);
-    Assertion.assertEquals(CreateWikiMessages.INVALID_USERNAME_ERROR_MESSAGE,
-                           errorMessage.getText());
+    Assertion.assertEquals(errorMessage.getText(), CreateWikiMessages.INVALID_USERNAME_ERROR_MESSAGE
+    );
   }
 
   public void verifyBlankPasswordValidation() {
     waitForElementByCss(ERROR_MESSAGE_CSS);
-    Assertion.assertEquals(CreateWikiMessages.BLANK_PASSWORD_ERROR_MESSAGE, errorMessage.getText());
+    Assertion.assertEquals(errorMessage.getText(), CreateWikiMessages.BLANK_PASSWORD_ERROR_MESSAGE);
   }
 
   public void verifyInvalidPasswordValidation() {
     waitForElementByCss(ERROR_MESSAGE_CSS);
-    Assertion.assertEquals(CreateWikiMessages.INVALID_PASSWORD_ERROR_MESSAGE,
-                           errorMessage.getText());
+    Assertion.assertEquals(errorMessage.getText(), CreateWikiMessages.INVALID_PASSWORD_ERROR_MESSAGE
+    );
   }
 
   public void verifyMessageAboutNewPassword(String userName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep1.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep1.java
@@ -57,7 +57,7 @@ public class CreateNewWikiPageObjectStep1 extends WikiBasePageObject {
       String langDropElement = langList.get(i).getText();
       if (langDropElement.contains(lang + ":")) {
         language.selectByIndex(i);
-        Assertion.assertEquals(lang + ".", languageSelectedIndicator.getText());
+        Assertion.assertEquals(languageSelectedIndicator.getText(), lang + ".");
         break;
       }
     }
@@ -108,7 +108,7 @@ public class CreateNewWikiPageObjectStep1 extends WikiBasePageObject {
   }
 
   public void verifyWikiName(String expectedWikiName) {
-    Assertion.assertEquals(expectedWikiName, wikiName.getAttribute("value"));
+    Assertion.assertEquals(wikiName.getAttribute("value"), expectedWikiName);
     PageObjectLogging.log("verifyWikiName", "verified wiki name equals: " + expectedWikiName, true);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep2.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep2.java
@@ -61,6 +61,6 @@ public class CreateNewWikiPageObjectStep2 extends BasePageObject {
 
   public void verifyCategoryError() {
     waitForElementByElement(categoryErrorMsg);
-    Assertion.assertEquals(CreateWikiMessages.CATEGORY_ERROR_MESSAGE, categoryErrorMsg.getText());
+    Assertion.assertEquals(categoryErrorMsg.getText(), CreateWikiMessages.CATEGORY_ERROR_MESSAGE);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumManageBoardsPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumManageBoardsPageObject.java
@@ -180,7 +180,7 @@ public class ForumManageBoardsPageObject extends BasePageObject {
         waitForElementByXPath(
             "//a[contains(text(), '" + forumName + "')]/../..//span[@class='movedown']");
     down.click();
-    Assertion.assertEquals(temp, getSecondForumName());
+    Assertion.assertEquals(getSecondForumName(), temp);
     PageObjectLogging.log("clickMoveDown", "move down button clicked", true);
   }
 
@@ -191,7 +191,7 @@ public class ForumManageBoardsPageObject extends BasePageObject {
         waitForElementByXPath(
             "//a[contains(text(), '" + forumName + "')]/../..//span[@class='moveup']");
     up.click();
-    Assertion.assertEquals(temp, getFirstForumName());
+    Assertion.assertEquals(getFirstForumName(), temp);
     PageObjectLogging.log("clickMoveDown", "move up button clicked", true);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWall.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWall.java
@@ -257,89 +257,88 @@ public class NewMessageWall extends WikiBasePageObject {
   public void verifyMessageText(String title, String message, String userName) {
     waitForTextToBePresentInElementByBy(messageTitleBy, title);
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText(), title
+            title, driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy).getText(), message
+            message, driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText(), userName
+            userName, driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText()
     );
   }
 
   public void verifyMessageBoldText(String title, String message, String userName) {
     waitForTextToBePresentInElementByBy(messageTitleBy, title);
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText(), title
+            title, driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy)
-            .findElement(messageTextBoldBy).getText(), message
+            message, driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy)
+            .findElement(messageTextBoldBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText(), userName
+            userName, driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText()
     );
   }
 
   public void verifyMessageItalicText(String title, String message, String userName) {
     waitForTextToBePresentInElementByBy(messageTitleBy, title);
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText(), title
+            title, driver.findElement(firstMessageWrapperBy).findElement(messageTitleBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy)
-            .findElement(messageTextItalicBy).getText(), message
+            message, driver.findElement(firstMessageWrapperBy).findElement(messageBodyBy)
+            .findElement(messageTextItalicBy).getText()
     );
     Assertion.assertEquals(
-        driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText(), userName
+            userName, driver.findElement(firstMessageWrapperBy).findElement(messageUserNameBy).getText()
     );
   }
 
   public void verifyMessageEditText(String title, String message, String userName) {
     waitForElementByElement(editMessageWrapper);
     Assertion.assertEquals(
-        title, editMessageWrapper.findElement(messageTitleBy).getText()
+            editMessageWrapper.findElement(messageTitleBy).getText(), title
     );
     Assertion.assertEquals(
-        message, editMessageWrapper.findElement(messageBodyBy).getText()
+            editMessageWrapper.findElement(messageBodyBy).getText(), message
     );
     Assertion.assertEquals(
-        userName, editMessageWrapper.findElement(messageUserNameBy).getText()
+            editMessageWrapper.findElement(messageUserNameBy).getText(), userName
     );
   }
 
   public void verifyInternalLink(String title, String target, String text, String wikiURL) {
     waitForTextToBePresentInElementByBy(messageTitleBy, title);
     Assertion.assertEquals(
-        title, editMessageWrapper.findElement(messageTitleBy).getText()
+            editMessageWrapper.findElement(messageTitleBy).getText(), title
     );
     Assertion.assertEquals(
-        wikiURL + "wiki/" + target,
-        editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy)
-            .getAttribute("href")
+            editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy)
+                .getAttribute("href"), wikiURL + "wiki/" + target
     );
     Assertion.assertEquals(
-        text, editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy).getText()
+            editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy).getText(), text
     );
   }
 
   public void verifyExternalLink(String title, String target, String text, String wikiURL) {
     waitForTextToBePresentInElementByBy(messageTitleBy, title);
     Assertion.assertEquals(
-        title, editMessageWrapper.findElement(messageTitleBy).getText()
+            editMessageWrapper.findElement(messageTitleBy).getText(), title
     );
     Assertion.assertEquals(
-        target, editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy)
-        .getAttribute("href")
+            editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy)
+            .getAttribute("href"), target
     );
     Assertion.assertEquals(
-        text, editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy).getText()
+            editMessageWrapper.findElement(messageBodyBy).findElement(messageLinkBy).getText(), text
     );
   }
 
   public void verifyQuote(String quoteText) {
     Assertion.assertEquals(
-        quoteText, driver.findElement(firstMessageWrapperBy).findElement(quoteMessageBy).getText()
+            driver.findElement(firstMessageWrapperBy).findElement(quoteMessageBy).getText(), quoteText
     );
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWall.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWall.java
@@ -233,8 +233,7 @@ public class NewMessageWall extends WikiBasePageObject {
   public void verifyThreadClosed(String userName, String reason, String message) {
     refreshPage();
     Assertion.assertStringContains(
-        userName + " closed this thread because:\n" + reason,
-        driver.findElement(firstMessageWrapperBy).findElement(closeThreadInfobox).getText()
+            driver.findElement(firstMessageWrapperBy).findElement(closeThreadInfobox).getText(), userName + " closed this thread because:\n" + reason
     );
     PageObjectLogging.log("verifyThreadClosed", "verifyed thread closed", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWallThreadPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/messagewall/NewMessageWallThreadPageObject.java
@@ -37,8 +37,8 @@ public class NewMessageWallThreadPageObject extends NewMessageWall {
 
   public void verifyLastReply(String userName, String message) {
     waitForElementByElement(replyBody);
-    Assertion.assertEquals(userName, lastReplyEditor.get(lastReplyEditor.size() - 1).getText());
-    Assertion.assertEquals(message, lastReplyText.get(lastReplyEditor.size() - 1).getText());
+    Assertion.assertEquals(lastReplyEditor.get(lastReplyEditor.size() - 1).getText(), userName);
+    Assertion.assertEquals(lastReplyText.get(lastReplyEditor.size() - 1).getText(), message);
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileBasePageObject.java
@@ -122,7 +122,7 @@ public class MobileBasePageObject extends WikiBasePageObject {
   public void verifyFBLogin() {
     Object[] windows = driver.getWindowHandles().toArray();
     driver.switchTo().window(windows[1].toString());
-    Assertion.assertStringContains(URLsContent.FACEBOOK_DOMAIN, getCurrentUrl());
+    Assertion.assertStringContains(getCurrentUrl(), URLsContent.FACEBOOK_DOMAIN);
     PageObjectLogging.log("VerifyFBLogin", "FB login window was opened", true, driver);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileCategoryPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileCategoryPageObject.java
@@ -57,7 +57,7 @@ public class MobileCategoryPageObject extends MobileBasePageObject {
 
   public void verifyChevronClosed() {
     for (WebElement elem : chevronList) {
-      Assertion.assertNotEquals("collSec open", elem.getAttribute("class"));
+      Assertion.assertNotEquals(elem.getAttribute("class"), "collSec open");
     }
   }
 
@@ -133,7 +133,7 @@ public class MobileCategoryPageObject extends MobileBasePageObject {
   }
 
   public void verifyArticlesNotEquals(String article, String article2) {
-    Assertion.assertNotEquals(article, article2);
+    Assertion.assertNotEquals(article2, article);
   }
 
   public void showNextArticles(String articlesFirstLetter) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileCategoryPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileCategoryPageObject.java
@@ -51,7 +51,7 @@ public class MobileCategoryPageObject extends MobileBasePageObject {
 
   public void verifyChevronOpened() {
     for (WebElement elem : chevronList) {
-      Assertion.assertEquals("collSec open", elem.getAttribute("class"));
+      Assertion.assertEquals(elem.getAttribute("class"), "collSec open");
     }
   }
 
@@ -129,7 +129,7 @@ public class MobileCategoryPageObject extends MobileBasePageObject {
   }
 
   public void verifyArticlesEquals(String article, String article2) {
-    Assertion.assertEquals(article, article2);
+    Assertion.assertEquals(article2, article);
   }
 
   public void verifyArticlesNotEquals(String article, String article2) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileEditModePageObject.java
@@ -43,7 +43,7 @@ public class MobileEditModePageObject extends MobileBasePageObject {
   }
 
   public void verifyModeName() {
-    Assertion.assertEquals(MobilePageContent.EDITMODE_HEADER, getModeName());
+    Assertion.assertEquals(getModeName(), MobilePageContent.EDITMODE_HEADER);
     PageObjectLogging.log(
         "verifyModeName",
         "The header shows '" + MobilePageContent.EDITMODE_HEADER + "'",
@@ -62,7 +62,7 @@ public class MobileEditModePageObject extends MobileBasePageObject {
   public void verifyEditText(String targetText) {
     waitForValueToBePresentInElementsAttributeByElement(
         editArea, "value", targetText);
-    Assertion.assertEquals(targetText, getEditText());
+    Assertion.assertEquals(getEditText(), targetText);
     PageObjectLogging.log(
         "verifyEditText",
         "The summary shows " + targetText,

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileEditPreviewPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileEditPreviewPageObject.java
@@ -27,7 +27,7 @@ public class MobileEditPreviewPageObject extends MobileBasePageObject {
   private WebElement previewZoomer;
 
   public void verifyEditModeContent(String targetText) {
-    Assertion.assertStringContains(articleText.getText(), targetText);
+    Assertion.assertStringContains(targetText, articleText.getText());
     PageObjectLogging.log(
         "verifyEditModeContent",
         "The article shows " + targetText,
@@ -36,7 +36,7 @@ public class MobileEditPreviewPageObject extends MobileBasePageObject {
   }
 
   public void verifyPreviewPageHeader(String targetText) {
-    Assertion.assertStringContains(selectedPageHeader.getText(), targetText);
+    Assertion.assertStringContains(targetText, selectedPageHeader.getText());
     PageObjectLogging.log(
         "verifyPreviewPageHeader",
         "The summary shows " + targetText,

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileHistoryPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileHistoryPageObject.java
@@ -30,7 +30,7 @@ public class MobileHistoryPageObject extends MobileBasePageObject {
   }
 
   public void verifyHistoryPageHeader(String targetText) {
-    Assertion.assertStringContains(getModeName(), targetText);
+    Assertion.assertStringContains(targetText, getModeName());
     PageObjectLogging.log(
         "verifyHistoryPageHeader",
         "The summary shows " + targetText,
@@ -43,7 +43,7 @@ public class MobileHistoryPageObject extends MobileBasePageObject {
   }
 
   public void verifyLastEditHistoryDevice(String targetText) {
-    Assertion.assertStringContains(getLastEditHistoryDevice(), targetText);
+    Assertion.assertStringContains(targetText, getLastEditHistoryDevice());
     PageObjectLogging.log(
         "verifyLastEditHistoryDevice",
         "The last edit shows " + targetText,
@@ -52,7 +52,7 @@ public class MobileHistoryPageObject extends MobileBasePageObject {
   }
 
   public void verifyLastEditHistorySummary(String targetText) {
-    Assertion.assertStringContains(getLastHistorySummary(), targetText);
+    Assertion.assertStringContains(targetText, getLastHistorySummary());
     PageObjectLogging.log(
         "verifyLastEditHistorySummary",
         "The last edit summary shows " + targetText,

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileSearchPageObject.java
@@ -59,7 +59,7 @@ public class MobileSearchPageObject extends MobileBasePageObject {
   }
 
   public void compareResultsEquals(List<String> beforePagination, List<String> afterPagination) {
-    Assertion.assertNumber(beforePagination.size(), afterPagination.size(), "checking length");
+    Assertion.assertNumber(afterPagination.size(), beforePagination.size(), "checking length");
     for (int i = 0; i < beforePagination.size(); i++) {
       Assertion.assertEquals(beforePagination.get(i), afterPagination.get(i),
                              "list's elements are not equals");

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileSpecialUserLogin.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/mobile/MobileSpecialUserLogin.java
@@ -19,24 +19,21 @@ public class MobileSpecialUserLogin extends MobileBasePageObject {
   public void verifyWrongPasswordErrorMessage() {
     waitForElementByElement(errorMessage);
     Assertion.assertEquals(
-        MobilePageContent.LOGIN_WRONG_PASSWORD_ERROR_MESSAGE,
-        errorMessage.getText()
+            errorMessage.getText(), MobilePageContent.LOGIN_WRONG_PASSWORD_ERROR_MESSAGE
     );
   }
 
   public void verifyWrongLoginErrorMessage() {
     waitForElementByElement(errorMessage);
     Assertion.assertEquals(
-        MobilePageContent.LOGIN_WRONG_LOGIN_ERROR_MESSAGE,
-        errorMessage.getText()
+            errorMessage.getText(), MobilePageContent.LOGIN_WRONG_LOGIN_ERROR_MESSAGE
     );
   }
 
   public void verifyEmptyPasswordErrorMessage() {
     waitForElementByElement(errorMessage);
     Assertion.assertEquals(
-        MobilePageContent.LOGIN_EMPTY_PASSWORD_ERROR_MESSAGE,
-        errorMessage.getText()
+            errorMessage.getText(), MobilePageContent.LOGIN_EMPTY_PASSWORD_ERROR_MESSAGE
     );
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/crosswikisearch/CrossWikiSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/crosswikisearch/CrossWikiSearchPageObject.java
@@ -179,7 +179,7 @@ public class CrossWikiSearchPageObject extends SearchPageObject {
 
   public void verifyResultsNumber(int number) {
     waitForElementByElement(searchResultList.get(0));
-    Assertion.assertNumber(number, searchResultList.size(), "checking number of search results");
+    Assertion.assertNumber(searchResultList.size(), number, "checking number of search results");
   }
 
   public void verifyNoPagination() {
@@ -196,16 +196,16 @@ public class CrossWikiSearchPageObject extends SearchPageObject {
   }
 
   public void verifyThumbnails(int number) {
-    Assertion.assertNumber(number, thumbnails.size(), "checking number of thumbnails");
+    Assertion.assertNumber(thumbnails.size(), number, "checking number of thumbnails");
     for (WebElement elem : thumbnails) {
-      Assertion.assertStringContains(".png", elem.getAttribute("src"));
+      Assertion.assertStringContains(elem.getAttribute("src"), ".png");
     }
     PageObjectLogging.log("verifyThumbnails", "thumbnails verified",
                           true);
   }
 
   public void verifyDescription(int number) {
-    Assertion.assertNumber(number, descriptions.size(), "checking number of thumbnails");
+    Assertion.assertNumber(descriptions.size(), number, "checking number of thumbnails");
     for (WebElement elem : descriptions) {
       Assertion.assertTrue(!elem.getText().isEmpty(), "checking if description is not empty");
     }
@@ -218,9 +218,9 @@ public class CrossWikiSearchPageObject extends SearchPageObject {
     Assertion.assertEquals(statisticsImages.size(), number);
     Assertion.assertEquals(statisticsVideos.size(), number);
     for (int i = 0; i < number; i++) {
-      Assertion.assertStringContains("PAGE", statisticsPages.get(i).getText());
-      Assertion.assertStringContains("IMAGE", statisticsImages.get(i).getText());
-      Assertion.assertStringContains("VIDEO", statisticsVideos.get(i).getText());
+      Assertion.assertStringContains(statisticsPages.get(i).getText(), "PAGE");
+      Assertion.assertStringContains(statisticsImages.get(i).getText(), "IMAGE");
+      Assertion.assertStringContains(statisticsVideos.get(i).getText(), "VIDEO");
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/crosswikisearch/CrossWikiSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/crosswikisearch/CrossWikiSearchPageObject.java
@@ -190,7 +190,7 @@ public class CrossWikiSearchPageObject extends SearchPageObject {
 
   public void verifyNoResultsCaption() {
     waitForElementByElement(noResultsCaption);
-    Assertion.assertEquals("No results found.", noResultsCaption.getText());
+    Assertion.assertEquals(noResultsCaption.getText(), "No results found.");
     PageObjectLogging.log("verifyNoResultsCaption", "verified no results caption",
                           true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
@@ -164,8 +164,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
 
     public void verifyFirstArticleNameTheSame(String firstResult) {
         Assertion.assertEquals(
-    	    firstResult.toLowerCase(),
-    	    titles.get(0).getText().toLowerCase()
+                titles.get(0).getText().toLowerCase(), firstResult.toLowerCase()
         );
     }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/search/intrawikisearch/IntraWikiSearchPageObject.java
@@ -114,7 +114,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
     public void verifySuggestions(String suggestion) {
         waitForElementByElement(suggestionsList.get(0));
         for (int i = 0; i < suggestionsList.size(); i++) {
-            Assertion.assertStringContains(suggestion, suggestionsList.get(i).getText());
+            Assertion.assertStringContains(suggestionsList.get(i).getText(), suggestion);
         }
     }
 
@@ -140,7 +140,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
     }
 
     public void verifyFirstResult(String query) {
-        Assertion.assertStringContains(query.replaceAll("_", " "), firstResult.getText());
+        Assertion.assertStringContains(firstResult.getText(), query.replaceAll("_", " "));
         for (WebElement elem : descriptions) {
             Assertion.assertTrue(!elem.getText().isEmpty());
         }
@@ -173,11 +173,11 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
     }
 
     public void verifyFirstArticleNameNotTheSame(String firstResult) {
-        Assertion.assertNotEquals(firstResult, titles.get(0).getText());
+        Assertion.assertNotEquals(titles.get(0).getText(), firstResult);
     }
 
     public void verifyResultsCount(int i) {
-        Assertion.assertNumber(i, titles.size(), "checking results count");
+        Assertion.assertNumber(titles.size(), i, "checking results count");
     }
 
     public void clickAdvancedButton() {
@@ -267,7 +267,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
 
     public void verifyTopModule() {
         waitForElementByElement(topModule);
-        Assertion.assertNumber(7, topModuleResults.size(), "Top module has correct amount of results");
+        Assertion.assertNumber(topModuleResults.size(), 7, "Top module has correct amount of results");
         for (int i = 0; i < topModuleResults.size(); i++) {
             Assertion.assertTrue(topModuleArticleThumbnail.get(i).isDisplayed());
             Assertion.assertTrue(topModuleArticleText.get(i).isDisplayed());
@@ -332,7 +332,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
     }
 
     public void verifyPushToTopWikiTitle(String searchWiki) {
-        Assertion.assertStringContains(searchWiki, pushToTopWikiResult.getText());
+        Assertion.assertStringContains(pushToTopWikiResult.getText(), searchWiki);
     }
 
     public void verifyPushToTopWikiThumbnail() {
@@ -348,7 +348,7 @@ public class IntraWikiSearchPageObject extends SearchPageObject {
         waitForElementByElement(newSuggestionsList.get(0));
         System.out.println(newSuggestionsList.size());
         for (int i = 0; i < newSuggestionsList.size(); i++) {
-            Assertion.assertStringContains(query, suggestionTextsList.get(i).getText());
+            Assertion.assertStringContains(suggestionTextsList.get(i).getText(), query);
             Assertion.assertTrue(suggestionImagesList.get(i).isDisplayed());
         }
         PageObjectLogging.log("verifyNewSuggestionsTextAndImages",

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFactoryPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialFactoryPageObject.java
@@ -78,7 +78,7 @@ public class SpecialFactoryPageObject extends SpecialPageObject {
 
   public void verifyVariableValue(WikiFactoryVariables variableName, String expectedValue) {
     selectVariableByVisibleText(variableName);
-    Assertion.assertEquals(expectedValue, variableValue.getText());
+    Assertion.assertEquals(variableValue.getText(), expectedValue);
   }
 
   private void selectVariableByVisibleText(WikiFactoryVariables variableName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialMultipleUploadPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialMultipleUploadPageObject.java
@@ -82,7 +82,7 @@ public class SpecialMultipleUploadPageObject extends WikiBasePageObject {
   public void verifySuccessfulUpload(String[] filesNamesList) {
     waitForElementByElement(uploadedFilesListContener);
     for (int i = 0; i < filesNamesList.length; i++) {
-      Assertion.assertStringContains(filesNamesList[i], uploadedFileslist.get(i).getText());
+      Assertion.assertStringContains(uploadedFileslist.get(i).getText(), filesNamesList[i]);
     }
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialPromotePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialPromotePageObject.java
@@ -107,8 +107,8 @@ public class SpecialPromotePageObject extends BasePageObject {
   public void verifyCrossWikiSearchDescription(String firstDescription) {
     waitForElementByElement(wikiaDescription);
     Assertion.assertStringContains(
-        firstDescription.substring(0,
-                                   firstDescription.length() - 3), wikiaDescription.getText()
+            wikiaDescription.getText(), firstDescription.substring(0,
+                                   firstDescription.length() - 3)
     );
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialPromotePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialPromotePageObject.java
@@ -115,7 +115,7 @@ public class SpecialPromotePageObject extends BasePageObject {
   public void verifyCrossWikiSearchImage(String firstImage) {
     waitForElementByElement(thumbnailImage);
     String secondImage = getUniqueThumbnailTextSpecialPromotePage();
-    Assertion.assertEquals(firstImage, secondImage);
+    Assertion.assertEquals(secondImage, firstImage);
   }
 
   public void verifyUploadedImage(String fileName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialRestorePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialRestorePageObject.java
@@ -26,7 +26,7 @@ public class SpecialRestorePageObject extends WikiBasePageObject {
 
   public void verifyArticleName(String articleName) {
     waitForElementVisibleByElement(articleToRestore);
-    Assertion.assertStringContains(articleName, articleToRestore.getText());
+    Assertion.assertStringContains(articleToRestore.getText(), articleName);
   }
 
   public void giveReason(String reason) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialVideosPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialVideosPageObject.java
@@ -145,7 +145,7 @@ public class SpecialVideosPageObject extends SpecialPageObject {
     addVideoViaAjax(video.getUrl());
     deleteVideo();
     verifyNotificationMessage();
-    Assertion.assertNotEquals(video.getTitle(), getNewestVideoTitle());
+    Assertion.assertNotEquals(getNewestVideoTitle(), video.getTitle());
     PageObjectLogging.log("verifyDeleteVideoNotPresent", "verify video "
         + video.getTitle() + " was deleted", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialVideosPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialVideosPageObject.java
@@ -134,7 +134,7 @@ public class SpecialVideosPageObject extends SpecialPageObject {
     deleteVideo();
     String deletedVideo =
         "\"File:" + video.getTitle() + "\" has been deleted. (undelete)";
-    Assertion.assertEquals(deletedVideo, getFlashMessageText());
+    Assertion.assertEquals(getFlashMessageText(), deletedVideo);
     PageObjectLogging.log("verifyDeleteVideoGlobalNotifications", "verify video " + deletedVideo
         + " was deleted", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/filepage/FilePagePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/filepage/FilePagePageObject.java
@@ -212,8 +212,7 @@ public class FilePagePageObject extends WikiBasePageObject {
 
   public void verifyImageLicense(ImageLicense imageLicense) {
     Assertion.assertStringContains(
-        imageLicense.getText(),
-        imgLicensePlate.getText()
+            imgLicensePlate.getText(), imageLicense.getText()
     );
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/filepage/FilePagePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/filepage/FilePagePageObject.java
@@ -91,7 +91,7 @@ public class FilePagePageObject extends WikiBasePageObject {
 
   public void verifySelectedTab(String tabName) {
     waitForElementByElement(tabBody);
-    Assertion.assertEquals(tabName, tabBody.getAttribute("data-tab-body"));
+    Assertion.assertEquals(tabBody.getAttribute("data-tab-body"), tabName);
     PageObjectLogging.log(
         "verified selected tab",
         tabName + " selected",
@@ -176,7 +176,7 @@ public class FilePagePageObject extends WikiBasePageObject {
   public void verifyTabsExist(String[] expectedTabs) {
     for (int i = 0; i < expectedTabs.length; i++) {
       String tab = tabs.get(i).getAttribute("data-tab");
-      Assertion.assertEquals(expectedTabs[i], tab);
+      Assertion.assertEquals(tab, expectedTabs[i]);
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/interactivemaps/InteractiveMapPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/interactivemaps/InteractiveMapPageObject.java
@@ -288,7 +288,7 @@ public class InteractiveMapPageObject extends BasePageObject {
 
   public void verifyCreatedMapTitle(String mapTitle) {
     waitForElementByElement(createdMapTitle);
-    Assertion.assertEquals(mapTitle, createdMapTitle.getText());
+    Assertion.assertEquals(createdMapTitle.getText(), mapTitle);
   }
 
   public void verifyCreatedPinTypesForNewMap() {
@@ -436,8 +436,8 @@ public class InteractiveMapPageObject extends BasePageObject {
           .contains(pinTypeName)
           ) {
         Assertion.assertEquals(
-            pinTypeName,
-            createdPinNames.get(createdPinNames.size() - 1).getText());
+                createdPinNames.get(createdPinNames.size() - 1).getText(), pinTypeName
+        );
       } else {
         PageObjectLogging.log(
             "verifyPinTypeExist",
@@ -483,7 +483,7 @@ public class InteractiveMapPageObject extends BasePageObject {
   }
 
   public void verifyOpenMapId(String mapIdActual, String mapIdExpected) {
-    Assertion.assertEquals(mapIdExpected, mapIdActual);
+    Assertion.assertEquals(mapIdActual, mapIdExpected);
   }
 
   public void verifyEscapedFragmentMetaTag() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/interactivemaps/InteractiveMapPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/interactivemaps/InteractiveMapPageObject.java
@@ -389,8 +389,8 @@ public class InteractiveMapPageObject extends BasePageObject {
     scrollToElement(popUpContent);
     waitForElementVisibleByElement(pinTitle);
     waitForElementVisibleByElement(pinDescription);
-    Assertion.assertNotEquals(pinName, pinTitle.getText());
-    Assertion.assertNotEquals(pinDesc, pinDescription.getText());
+    Assertion.assertNotEquals(pinTitle.getText(), pinName);
+    Assertion.assertNotEquals(pinDescription.getText(), pinDesc);
   }
 
   public void verifyControlButtonsAreVisible() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/login/SpecialUserLoginPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/login/SpecialUserLoginPageObject.java
@@ -92,8 +92,8 @@ public class SpecialUserLoginPageObject extends SpecialPageObject {
 
   public void remindPassword(String name, String apiToken) {
     Assertion.assertEquals(
-        ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE,
-        resetForgotPasswordTime(name, apiToken));
+            resetForgotPasswordTime(name, apiToken), ApiActions.API_ACTION_FORGOT_PASSWORD_RESPONSE
+    );
     typeInUserName(name);
     clickForgotPasswordLink();
   }
@@ -125,8 +125,7 @@ public class SpecialUserLoginPageObject extends SpecialPageObject {
   public void verifyClosedAccountMessage() {
     waitForElementByElement(messagePlaceholder);
     Assertion.assertEquals(
-        DISABLED_ACCOUNT_MESSAGE,
-        messagePlaceholder.getText()
+            messagePlaceholder.getText(), DISABLED_ACCOUNT_MESSAGE
     );
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/multiwikifinder/SpecialMultiWikiFinderPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/multiwikifinder/SpecialMultiWikiFinderPageObject.java
@@ -74,8 +74,8 @@ public class SpecialMultiWikiFinderPageObject extends WikiBasePageObject {
     nextResultsButton.click();
     String firstLinkOnSecondPage = listOfLinks.get(0).getAttribute("href");
     String lastLinkOnSecondPage = listOfLinks.get(listOfLinks.size() - 1).getAttribute("href");
-    Assertion.assertNotEquals(firstLinkOnFirstPage, firstLinkOnSecondPage);
-    Assertion.assertNotEquals(lastLinkOnFirstPage, lastLinkOnSecondPage);
+    Assertion.assertNotEquals(firstLinkOnSecondPage, firstLinkOnFirstPage);
+    Assertion.assertNotEquals(lastLinkOnSecondPage, lastLinkOnFirstPage);
     previousResultsButton.click();
     String firstLinkAfterBack = listOfLinks.get(0).getAttribute("href");
     String lastLinkAfterBack = listOfLinks.get(listOfLinks.size() - 1).getAttribute("href");

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/multiwikifinder/SpecialMultiWikiFinderPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/multiwikifinder/SpecialMultiWikiFinderPageObject.java
@@ -79,8 +79,8 @@ public class SpecialMultiWikiFinderPageObject extends WikiBasePageObject {
     previousResultsButton.click();
     String firstLinkAfterBack = listOfLinks.get(0).getAttribute("href");
     String lastLinkAfterBack = listOfLinks.get(listOfLinks.size() - 1).getAttribute("href");
-    Assertion.assertEquals(firstLinkOnFirstPage, firstLinkAfterBack);
-    Assertion.assertEquals(lastLinkOnFirstPage, lastLinkAfterBack);
+    Assertion.assertEquals(firstLinkAfterBack, firstLinkOnFirstPage);
+    Assertion.assertEquals(lastLinkAfterBack, lastLinkOnFirstPage);
   }
 
   public void verifyAllLinksHavePagenameInPath(String pageName) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/preferences/PreferencesPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/preferences/PreferencesPageObject.java
@@ -73,8 +73,8 @@ public class PreferencesPageObject extends WikiBasePageObject {
   public void verifyEmailMeSection() {
     for (WebElement elem : emailMeSectionRows) {
       PageObjectLogging.log("verifyEmailSection", "verifying " + elem.getText(), true);
-      Assertion.assertEquals("true",
-          elem.findElement(By.cssSelector("input")).getAttribute("checked"));
+      Assertion.assertEquals(elem.findElement(By.cssSelector("input")).getAttribute("checked"), "true"
+      );
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/themedesigner/SpecialThemeDesignerPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/themedesigner/SpecialThemeDesignerPageObject.java
@@ -100,7 +100,7 @@ public class SpecialThemeDesignerPageObject extends WikiBasePageObject {
 
   public void verifyThemeSelected(String themeName) {
     waitForElementByCss("li.selected[data-theme='" + themeName + "']");
-    Assertion.assertEquals(themeName, executeScriptRet("ThemeDesigner.settings.theme"));
+    Assertion.assertEquals(executeScriptRet("ThemeDesigner.settings.theme"), themeName);
     PageObjectLogging.log("verifyThemeSelected",
                           "theme " + themeName + " selection verified", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/videohomepage/FeaturedVideoAdminPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/videohomepage/FeaturedVideoAdminPageObject.java
@@ -44,7 +44,7 @@ public class FeaturedVideoAdminPageObject extends WikiBasePageObject {
     waitForElementByElement(featuredVideoForm);
     WebElement videoTitle = featuredVideoForm.findElement(By.cssSelector(".video-title"));
     String title = videoTitle.getText();
-    Assertion.assertEquals(title, name);
+    Assertion.assertEquals(name, title);
     PageObjectLogging.log("verifyVideoTitleUpdated", "Video title was updated", true);
   }
 
@@ -52,7 +52,7 @@ public class FeaturedVideoAdminPageObject extends WikiBasePageObject {
     waitForElementByElement(featuredVideoForm);
     WebElement displayTitle = featuredVideoForm.findElement(By.cssSelector(".display-title"));
     String title = displayTitle.getAttribute("value");
-    Assertion.assertEquals(title, name);
+    Assertion.assertEquals(name, title);
     PageObjectLogging
         .log("verifyVideoDisplayTitleUpdated", "Video display title input was populated", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
@@ -151,22 +151,22 @@ public class VisualEditorPageObject extends VisualEditorMenu {
 
   public void verifyNumList(List<String> elements) {
     for (int i = 0; i < elements.size(); i++) {
-      Assertion.assertEquals(elements.get(i), numList.get(i).getText());
+      Assertion.assertEquals(numList.get(i).getText(), elements.get(i));
     }
   }
 
   public void verifyBullList(List<String> elements) {
     for (int i = 0; i < elements.size(); i++) {
-      Assertion.assertEquals(elements.get(i), bullList.get(i).getText());
+      Assertion.assertEquals(bullList.get(i).getText(), elements.get(i));
     }
   }
 
   public void verifyFormatting(Formatting format, String text) {
-    Assertion.assertEquals(text, editArea.findElement(format.getTag()).getText());
+    Assertion.assertEquals(editArea.findElement(format.getTag()).getText(), text);
   }
 
   public void verifyStyle(Style style, String text) {
-    Assertion.assertEquals(text, editArea.findElement(style.getTag()).getText());
+    Assertion.assertEquals(editArea.findElement(style.getTag()).getText(), text);
   }
 
   public void verifyEditorSurfacePresent() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/visualeditor/VisualEditorPageObject.java
@@ -197,8 +197,8 @@ public class VisualEditorPageObject extends VisualEditorMenu {
 
   public void verifyVideos(int expected) {
     waitForElementVisibleByElement(mediaNode);
-    Assertion.assertNumber(expected, videoNodes.size(),
-                           "Checking the correct number of video nodes added");
+    Assertion.assertNumber(videoNodes.size(), expected,
+            "Checking the correct number of video nodes added");
     PageObjectLogging.log("verifyVideos", videoNodes.size() + " videos displayed", true);
   }
 
@@ -207,9 +207,8 @@ public class VisualEditorPageObject extends VisualEditorMenu {
       waitForElementVisibleByElement(galleryNode);
     }
     Assertion.assertNumber(
-        expected,
-        getNumOfElementOnPage(By.cssSelector(".media-gallery-wrapper.ve-ce-branchNode")),
-        "Checking the correct number of gallery nodes");
+            getNumOfElementOnPage(By.cssSelector(".media-gallery-wrapper.ve-ce-branchNode")), expected,
+            "Checking the correct number of gallery nodes");
   }
 
   public void verifyMediasInGallery(int expected) {
@@ -217,8 +216,8 @@ public class VisualEditorPageObject extends VisualEditorMenu {
     String className = galleryNode.getAttribute("class");
     String count = className.substring(className.indexOf("count-"));
     int numOfMediasInGallery = Integer.parseInt(count.substring(count.indexOf('-') + 1));
-    Assertion.assertNumber(expected, numOfMediasInGallery,
-                           "Checking the correct number of media in gallery");
+    Assertion.assertNumber(numOfMediasInGallery, expected,
+            "Checking the correct number of media in gallery");
     PageObjectLogging
         .log("verifyMediasInGallery", numOfMediasInGallery + " medias displayed", true);
   }
@@ -226,8 +225,8 @@ public class VisualEditorPageObject extends VisualEditorMenu {
   public void verifyMedias(int expected) {
     waitForElementByElement(mediaNode);
     waitForElementVisibleByElement(mediaNode);
-    Assertion.assertNumber(expected, mediaNodes.size(),
-                           "Checking the correct number of media nodes added");
+    Assertion.assertNumber(mediaNodes.size(), expected,
+            "Checking the correct number of media nodes added");
     PageObjectLogging.log("verifyMedias", mediaNodes.size() + " media displayed", true);
   }
 
@@ -385,13 +384,13 @@ public class VisualEditorPageObject extends VisualEditorMenu {
   }
 
   public void verifyNumberOfBlockTransclusion(int expected) {
-    Assertion.assertNumber(expected, getNumOfElementOnPage(blockTransclusionBy),
-                           "The number of blocked transclusion node is not equal");
+    Assertion.assertNumber(getNumOfElementOnPage(blockTransclusionBy), expected,
+            "The number of blocked transclusion node is not equal");
   }
 
   public void verifyNumberOfInlineTransclusion(int expected) {
-    Assertion.assertNumber(expected, getNumOfElementOnPage(inlineTransclusionBy),
-                           "The number of inline transclusion node is not equal");
+    Assertion.assertNumber(getNumOfElementOnPage(inlineTransclusionBy), expected,
+            "The number of inline transclusion node is not equal");
   }
 
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -99,7 +99,7 @@ public class WamPageObject extends BasePageObject {
    */
   public void verifyWamIndexHasExactRowsNo(int expectedRowsNo) {
     waitForElementByBy(WAM_INDEX_TABLE);
-    Assertion.assertNumber(expectedRowsNo, wamIndexRows.size(), "wam index rows equals "
+    Assertion.assertNumber(wamIndexRows.size(), expectedRowsNo, "wam index rows equals "
         + expectedRowsNo);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/WikiHistoryPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/WikiHistoryPageObject.java
@@ -71,6 +71,6 @@ public class WikiHistoryPageObject extends WikiBasePageObject {
   public void verifyLatestEditSummary(String text) {
     String editSummary = getFirstCssRevision();
     editSummary = editSummary.substring(1, editSummary.length() - 1);
-    Assertion.assertEquals(text, editSummary);
+    Assertion.assertEquals(editSummary, text);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/blog/BlogPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/blog/BlogPageObject.java
@@ -31,7 +31,7 @@ public class BlogPageObject extends ArticlePageObject {
 
   public void verifyBlogTitle(String title) {
     waitForElementByElement(blogHeader);
-    Assertion.assertEquals(title, blogHeader.getText());
+    Assertion.assertEquals(blogHeader.getText(), title);
   }
 
   public String getBlogName() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/editmode/WikiArticleEditMode.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/editmode/WikiArticleEditMode.java
@@ -383,6 +383,6 @@ public class WikiArticleEditMode extends WikiEditMode {
     driver.switchTo().defaultContent();
     waitForElementByElement(embededMap);
     String embededMapID = embededMap.getAttribute("data-map-id");
-    Assertion.assertEquals(mapID, embededMapID);
+    Assertion.assertEquals(embededMapID, mapID);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/editmode/WikiArticleEditMode.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wikipage/editmode/WikiArticleEditMode.java
@@ -231,7 +231,7 @@ public class WikiArticleEditMode extends WikiEditMode {
 
   public void verifyWikiTextInSourceMode(String text) {
     String wikiText = sourceModeTextArea.getAttribute("value");
-    Assertion.assertStringContains(text, wikiText);
+    Assertion.assertStringContains(wikiText, text);
   }
 
   public void clickOnModifyImageLink() {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestExtraMarker.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestExtraMarker.java
@@ -24,6 +24,6 @@ public class TestExtraMarker extends TemplateDontLogout {
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage);
     String logs = wikiPage.getBrowserLogs(slot).toString();
     Assertion.assertStringNotEmpty(logs);
-    Assertion.assertStringContains(extraMarkerMessage, logs);
+    Assertion.assertStringContains(logs, extraMarkerMessage);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestKruxSegment.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestKruxSegment.java
@@ -8,8 +8,6 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsKruxObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 
@@ -31,7 +29,7 @@ public class TestKruxSegment extends TemplateDontLogout {
       adsKruxObject.getUrl(url);
       adsKruxObject.waitForKrux();
     }
-    Assertion.assertStringContains(segmentId, adsKruxObject.getKxsegs());
+    Assertion.assertStringContains(adsKruxObject.getKxsegs(), segmentId);
   }
 
   @Test(
@@ -77,8 +75,8 @@ public class TestKruxSegment extends TemplateDontLogout {
     }
     String segmentsLocalStorage = adsKruxObject.getKxsegs();
     String dataGptPageParams = adsKruxObject.getGptParams("LEADERBOARD", "data-gpt-page-params");
-    Assertion.assertStringContains(adsKruxObject.getKsgmntPattern(segmentsLocalStorage),
-                                   dataGptPageParams);
+    Assertion.assertStringContains(dataGptPageParams, adsKruxObject.getKsgmntPattern(segmentsLocalStorage)
+    );
     Assertion.assertEquals(segmentsLocalStorage.contains(segment), isPresent);
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestUrlBuilder.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestUrlBuilder.java
@@ -203,20 +203,20 @@ public class TestUrlBuilder extends TemplateDontLogout {
   @Test(groups = "TestUrlBuilder")
   public void testUrlBuilder() {
     for (Object[] data : TEST_DATA) {
-      Assertion.assertEquals((String) data[2], new UrlBuilder("prod")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[3], new UrlBuilder("preview")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[4], new UrlBuilder("sandbox")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[5], new UrlBuilder("sandbox-mercurydev")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[6], new UrlBuilder("dev-dmytror")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[7], new UrlBuilder("dev-nandy", "CHROMEMOBILEMERCURY")
-          .getUrlForPath((String) data[0], (String) data[1]));
-      Assertion.assertEquals((String) data[8], new UrlBuilder("prod", "CHROMEMOBILE")
-          .getUrlForPath((String) data[0], (String) data[1]));
+      Assertion.assertEquals(new UrlBuilder("prod")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[2]);
+      Assertion.assertEquals(new UrlBuilder("preview")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[3]);
+      Assertion.assertEquals(new UrlBuilder("sandbox")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[4]);
+      Assertion.assertEquals(new UrlBuilder("sandbox-mercurydev")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[5]);
+      Assertion.assertEquals(new UrlBuilder("dev-dmytror")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[6]);
+      Assertion.assertEquals(new UrlBuilder("dev-nandy", "CHROMEMOBILEMERCURY")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[7]);
+      Assertion.assertEquals(new UrlBuilder("prod", "CHROMEMOBILE")
+          .getUrlForPath((String) data[0], (String) data[1]), (String) data[8]);
     }
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleRTETest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleRTETest.java
@@ -339,7 +339,7 @@ public class ArticleRTETest extends NewTestTemplate {
 
       e = driver.findElement(By.cssSelector(".cke_source"));
       ;
-      if (Assertion.assertStringContains(wikitext, e.getAttribute("value"))) {
+      if (Assertion.assertStringContains(e.getAttribute("value"), wikitext)) {
         tmp1 = e.getAttribute("value").replace("<", "&lt");
         tmp1.replace(">", "&gt");
         PageObjectLogging

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationHubLinks.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationHubLinks.java
@@ -28,7 +28,7 @@ public class GlobalNavigationHubLinks extends NewTestTemplate {
             WebElement hub = globalNav.openHub(hubName);
             String link = globalNav.getHubLink(hub);
             hub.click();
-            Assertion.assertEquals(link, driver.getCurrentUrl());
+            Assertion.assertEquals(driver.getCurrentUrl(), link);
         }
     }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationSearch.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationSearch.java
@@ -40,8 +40,8 @@ public class GlobalNavigationSearch extends NewTestTemplate {
         .searchGlobally(query);
 
     String currentUrl = driver.getCurrentUrl();
-    Assertion.assertStringContains(expectedSpecialPage, currentUrl);
-    Assertion.assertStringContains(resultLang, currentUrl);
+    Assertion.assertStringContains(currentUrl, expectedSpecialPage);
+    Assertion.assertStringContains(currentUrl, resultLang);
     Assertion.assertTrue(search.isResultPresent());
   }
 
@@ -69,8 +69,8 @@ public class GlobalNavigationSearch extends NewTestTemplate {
         .searchGlobally(query);
 
     String currentUrl = driver.getCurrentUrl();
-    Assertion.assertStringContains(expectedSpecialPage, currentUrl);
-    Assertion.assertStringContains(resultLang, currentUrl);
+    Assertion.assertStringContains(currentUrl, expectedSpecialPage);
+    Assertion.assertStringContains(currentUrl, resultLang);
     Assertion.assertTrue(search.isResultPresent());
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationWikiaLogo.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationtests/GlobalNavigationWikiaLogo.java
@@ -26,7 +26,7 @@ public class GlobalNavigationWikiaLogo extends NewTestTemplate {
     HomePageObject homePage = new HomePageObject(driver);
     homePage.getUrl(urlBuilder.getUrlForWiki(wikiName));
     homePage.getVenusGlobalNav().clickWikiaLogo();
-    Assertion.assertStringContains(urlBuilder.getUrlForWiki(expectedCentralUrl),
-        driver.getCurrentUrl());
+    Assertion.assertStringContains(driver.getCurrentUrl(), urlBuilder.getUrlForWiki(expectedCentralUrl)
+    );
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/DeleteAndRestoreMapTests.java
@@ -45,7 +45,7 @@ public class DeleteAndRestoreMapTests extends NewTestTemplate {
         base.openInteractiveMapById(wikiURL, InteractiveMapsContent.MAP_TO_DELETE_AND_RESTORE[1]);
     DeleteAMapComponentObject deleteMapModal = selectedMap.deleteMap();
     deleteMapModal.clickDeleteMap();
-    Assertion.assertEquals(InteractiveMapsContent.MAP_DELETE_ERROR, deleteMapModal.getDeleteMapError());
+    Assertion.assertEquals(deleteMapModal.getDeleteMapError(), InteractiveMapsContent.MAP_DELETE_ERROR);
   }
 
   @RelatedIssue(issueID = "QAART-557")

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/GameGuidesPreview.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/GameGuidesPreview.java
@@ -60,7 +60,7 @@ public class GameGuidesPreview extends NewTestTemplate {
     MobileModalComponentObject modal = mobile.clickModal();
     String current = modal.getCurrentImageUrl();
     modal.goToNextImage();
-    Assertion.assertNotEquals(current, modal.getCurrentImageUrl());
+    Assertion.assertNotEquals(modal.getCurrentImageUrl(), current);
     modal.closeModal();
     modal.verifyModalClosed();
   }
@@ -75,7 +75,7 @@ public class GameGuidesPreview extends NewTestTemplate {
     MobileModalComponentObject modal = mobile.clickModal();
     String current = modal.getCurrentImageUrl();
     modal.goToPreviousImage();
-    Assertion.assertNotEquals(current, modal.getCurrentImageUrl());
+    Assertion.assertNotEquals(modal.getCurrentImageUrl(), current);
     modal.closeModal();
     modal.verifyModalClosed();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/MobileModalTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/MobileModalTests.java
@@ -35,7 +35,7 @@ public class MobileModalTests extends NewTestTemplate {
     MobileModalComponentObject modal = mobile.clickModal();
     String current = modal.getCurrentImageUrl();
     modal.goToNextImage();
-    Assertion.assertNotEquals(current, modal.getCurrentImageUrl());
+    Assertion.assertNotEquals(modal.getCurrentImageUrl(), current);
     modal.closeModal();
     modal.verifyModalClosed();
   }
@@ -47,7 +47,7 @@ public class MobileModalTests extends NewTestTemplate {
     MobileModalComponentObject modal = mobile.clickModal();
     String current = modal.getCurrentImageUrl();
     modal.goToPreviousImage();
-    Assertion.assertNotEquals(current, modal.getCurrentImageUrl());
+    Assertion.assertNotEquals(modal.getCurrentImageUrl(), current);
     modal.closeModal();
     modal.verifyModalClosed();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/notificationstests/ForumNotificationsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/notificationstests/ForumNotificationsTests.java
@@ -77,6 +77,6 @@ public class ForumNotificationsTests extends NewTestTemplate {
         forumBoardTitle.replace("_", " ")
     );
     String anchor = anchoredLink.substring(anchoredLink.indexOf("#"));
-    Assertion.assertEquals("#2", anchor);
+    Assertion.assertEquals(anchor, "#2");
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CssChromeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CssChromeTests.java
@@ -49,7 +49,7 @@ public class CssChromeTests extends NewTestTemplate {
     specialCss.saveCssContent(currentTimestamp);
     specialCss.openArticleByName(wikiURL, URLsContent.MEDIAWIKI_CSS);
     String cssContent = specialCss.getWikiaCssContent();
-    Assertion.assertEquals(currentTimestamp, cssContent);
+    Assertion.assertEquals(cssContent, currentTimestamp);
   }
 
   /**
@@ -78,7 +78,7 @@ public class CssChromeTests extends NewTestTemplate {
     specialCss.clickShowChanges();
     specialCss.showChangesModal();
     String addedLine = specialCss.getAddedLineText();
-    Assertion.assertEquals(currentTimestamp, addedLine);
+    Assertion.assertEquals(addedLine, currentTimestamp);
   }
 
   /**

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CssChromeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CssChromeTests.java
@@ -64,7 +64,7 @@ public class CssChromeTests extends NewTestTemplate {
     specialCss.openArticleByName(wikiURL, URLsContent.MEDIAWIKI_CSS);
     specialCss.appendToUrl(URLsContent.ACTION_HISTORY);
     String editSummary = specialCss.getFirstCssRevision();
-    Assertion.assertStringContains(currentTimestamp, editSummary);
+    Assertion.assertStringContains(editSummary, currentTimestamp);
   }
 
   /**


### PR DESCRIPTION
This pull requests adds two fixes to this repo.

Firstly the HTML dumps generated by PageObjectLogging include the scripts, which causes them to be run again (even though the effects of them are already applied to the HTML dump). In my change I wrap them in invisible textareas, so they are not run again, but if you need to see what they were, you can find them using Chrome or Firefox inspector.

The second change is how Assertion.assertEquals is called. It used to be:

    Assertion.assertEquals(String pattern, String current);

I changed that to:

    Assertion.assertEquals(String current, String pattern);

This matches org.testng.Assert:

    Assert.assertEquals(String actual, String expected);

Also this fixes the issue with reporting the pattern and current value in the HTML log.

The remaining Assertion.assert* methods were updated to match this convention as well (see a5a69c10fce)