### PR TITLE
Concf 767

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
@@ -5,13 +5,9 @@ import java.io.File;
 public class PageContent {
 
   //wiki
-  public static final String WIKI_HEADLINE = "Lorem ipsum dolor";
+  public static final String LOREM_IPSUM_SHORT = "Lorem ipsum dolor";
   public static final String
-      WIKI_DESCRIPTION =
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
-  public static final String WIKI_PROMOTE_HEADLINE = "Lorem ipsum dolor Lorem";
-  public static final String
-      WIKI_PROMOTE_DESCRIPTION =
+      LOREM_IPSUM_LONG =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit "
       + "Lorem ipsum dolor sit amet, consectetur adipiscing Lorem ipsum dolor sit amet, consectetur "
       + "adipiscing elit Lorem ipsum dolor sit amet, consectetur adipiscing Lorem ipsum dolor sit amet,"

--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
@@ -163,6 +163,7 @@ public class URLsContent {
   //Urls for different namespace pages
   public static final String WIKI_MAINPAGE = "Main_Page";
   public static final String CATEGORY_PAGE = "Category:General_wiki_templates";
+  public static final String CATEGORY_HELP = "Category:Help";
   public static final String TEMPLATE_PAGE = "Template:Infobox";
   public static final String LIST_PAGE = "List:Listing";
   public static final String MEDIAWIKI = "mediawiki119";

--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
@@ -38,6 +38,7 @@ public class URLsContent {
   public static final String SPECIAL_CREATE_BLOGPAGE = "wiki/Special:CreateBlogPage";
   public static final String SPECIAL_ADMIN_DASHBOARD = "wiki/Special:AdminDashboard";
   public static final String SPECIAL_CSS = "wiki/Special:CSS";
+  public static final String SPECIAL_CURATED_CONTENT = "wiki/Special:CuratedContent";
   public static final String SPECIAL_RANDOM = "wiki/Special:Random";
   public static final String SPECIAL_FOLLOW = "wiki/Special:Following";
   public static final String SPECIAL_FORUM = "wiki/Special:Forum";

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -10,7 +10,6 @@ import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.CommonUtils;
 import com.wikia.webdriver.common.core.Global;
 import com.wikia.webdriver.common.core.MailFunctions;
-import com.wikia.webdriver.common.core.exceptions.TestFailedException;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.properties.HeliosConfig;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.actions.DeletePageObject;
@@ -31,6 +30,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialAdminDas
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialContributionsPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCreatePagePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCssPageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCuratedContentPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialEditHubPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialFactoryPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialManageWikiaHome;
@@ -64,18 +64,12 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.wikipage.WikiHistoryPag
 import com.wikia.webdriver.pageobjectsfactory.pageobject.wikipage.blog.BlogPageObject;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.CookieStore;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultBackoffStrategy;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
@@ -98,7 +92,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -398,6 +391,11 @@ public class WikiBasePageObject extends BasePageObject {
   public SpecialCssPageObject openSpecialCss(String wikiURL) {
     getUrl(wikiURL + URLsContent.SPECIAL_CSS);
     return new SpecialCssPageObject(driver);
+  }
+
+  public SpecialCuratedContentPageObject openSpecialCuratedContent(String wikiURL) {
+    getUrl(wikiURL + URLsContent.SPECIAL_CSS);
+    return new SpecialCuratedContentPageObject(driver);
   }
 
   public SpecialUploadPageObject openSpecialUpload(String wikiURL) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -394,7 +394,7 @@ public class WikiBasePageObject extends BasePageObject {
   }
 
   public SpecialCuratedContentPageObject openSpecialCuratedContent(String wikiURL) {
-    getUrl(wikiURL + URLsContent.SPECIAL_CSS);
+    getUrl(wikiURL + URLsContent.SPECIAL_CURATED_CONTENT);
     return new SpecialCuratedContentPageObject(driver);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -9,8 +9,7 @@ import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
 /**
- * @author Garth Webb
- * @author Saipetch Kongkatong
+ * @ownership Content
  */
 public class SpecialCuratedContentPageObject extends SpecialPageObject {
 
@@ -19,7 +18,7 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
   @FindBy(css = "#save")
   private WebElement saveButton;
   @FindBy(css = "#save.ok")
-  private WebElement successMark;
+  private WebElement successfulSaveMark;
   @FindBy(css = "li.item:last-of-type .item-input")
   private WebElement lastElementNameInput;
   @FindBy(css = "li.item:last-of-type .name")
@@ -54,7 +53,7 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
   }
 
   public void verifySuccesfulSave() {
-    waitForElementByElement(successMark);
+    waitForElementByElement(successfulSaveMark);
     PageObjectLogging.log("verifySuccesfulSave", "Curated Content saved with success", true);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -34,7 +34,6 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
 
   public SpecialCuratedContentPageObject(WebDriver driver) {
     super(driver);
-    PageFactory.initElements(driver, this);
   }
 
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.special;
 
+import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoAddComponentObject;
 
 import org.openqa.selenium.WebDriver;
@@ -25,6 +26,12 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
   private WebElement lastElementLabelInput;
   @FindBy(css = "li.item:last-of-type span.remove")
   private WebElement lastElementRemoveIcon;
+  @FindBy(css = "li.item:last-of-type .image")
+  private WebElement lastElementImage;
+  @FindBy(css = "li.item:last-of-type .image[style]")
+  private WebElement lastElementImageFilled;
+  @FindBy(css = "li.item:last-of-type .image.error")
+  private WebElement lastElementImageWithError;
 
   public SpecialCuratedContentPageObject(WebDriver driver) {
     super(driver);
@@ -48,6 +55,7 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
 
   public void verifySuccesfulSave() {
     waitForElementByElement(successMark);
+    PageObjectLogging.log("verifySuccesfulSave", "Curated Content saved with success", true);
   }
 
   public void removeLastElement(String label) {
@@ -55,10 +63,24 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
     scrollAndClick(lastElementRemoveIcon);
   }
 
-  public PhotoAddComponentObject addImage() {
-    return null;
+  public PhotoAddComponentObject clickImageOnLastElement() {
+    waitForElementByElement(lastElementImage);
+    scrollAndClick(lastElementImage);
+    return new PhotoAddComponentObject(driver);
   }
 
-  public void verifyImageInElement(String label) {
+  public void verifyImageInLastElement() {
+    waitForElementByElement(lastElementImageFilled);
+    PageObjectLogging.log("verifyImageInLastElement", "Image is present in the last element", true);
+  }
+
+  public void verifyImageErrorInLastElement() {
+    waitForElementByElement(lastElementImageWithError);
+    PageObjectLogging.log("verifyImageErrorInLastElement", "Image shows error", true);
+  }
+
+  public void verifySaveNotClickable() {
+    waitForElementNotClickableByElement(saveButton);
+    PageObjectLogging.log("verifySaveNotClickable", "Save button is not clickable", true);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -1,23 +1,11 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.special;
 
-import com.wikia.webdriver.common.contentpatterns.URLsContent;
-import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.video.YoutubeVideo;
-import com.wikia.webdriver.common.core.video.YoutubeVideoProvider;
-import com.wikia.webdriver.common.logging.PageObjectLogging;
-import com.wikia.webdriver.pageobjectsfactory.componentobject.lightbox.LightboxComponentObject;
-import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetAddVideoComponentObject;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.special.watch.WatchPageObject;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoAddComponentObject;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.FindBys;
 import org.openqa.selenium.support.PageFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 /**
  * @author Garth Webb
@@ -25,8 +13,18 @@ import java.util.Random;
  */
 public class SpecialCuratedContentPageObject extends SpecialPageObject {
 
-  @FindBy(css = ".WikiaPageHeader h1")
-  private WebElement h1Header;
+  @FindBy(css = "#addItem")
+  private WebElement addItemButton;
+  @FindBy(css = "#save")
+  private WebElement saveButton;
+  @FindBy(css = "#save.ok")
+  private WebElement successMark;
+  @FindBy(css = "li.item:last-of-type .item-input")
+  private WebElement lastElementNameInput;
+  @FindBy(css = "li.item:last-of-type .name")
+  private WebElement lastElementLabelInput;
+  @FindBy(css = "li.item:last-of-type span.remove")
+  private WebElement lastElementRemoveIcon;
 
   public SpecialCuratedContentPageObject(WebDriver driver) {
     super(driver);
@@ -34,4 +32,33 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
   }
 
 
+  public void addNewElement(String name, String label) {
+    waitForElementByElement(addItemButton);
+    scrollAndClick(addItemButton);
+    waitForElementByElement(lastElementNameInput);
+    lastElementNameInput.sendKeys(name);
+    waitForElementByElement(lastElementLabelInput);
+    lastElementLabelInput.sendKeys(label);
+  }
+
+  public void clickSave() {
+    waitForElementByElement(saveButton);
+    scrollAndClick(saveButton);
+  }
+
+  public void verifySuccesfulSave() {
+    waitForElementByElement(successMark);
+  }
+
+  public void removeLastElement(String label) {
+    waitForElementByElement(lastElementRemoveIcon);
+    scrollAndClick(lastElementRemoveIcon);
+  }
+
+  public PhotoAddComponentObject addImage() {
+    return null;
+  }
+
+  public void verifyImageInElement(String label) {
+  }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -1,0 +1,37 @@
+package com.wikia.webdriver.pageobjectsfactory.pageobject.special;
+
+import com.wikia.webdriver.common.contentpatterns.URLsContent;
+import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.video.YoutubeVideo;
+import com.wikia.webdriver.common.core.video.YoutubeVideoProvider;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.lightbox.LightboxComponentObject;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetAddVideoComponentObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.special.watch.WatchPageObject;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * @author Garth Webb
+ * @author Saipetch Kongkatong
+ */
+public class SpecialCuratedContentPageObject extends SpecialPageObject {
+
+  @FindBy(css = ".WikiaPageHeader h1")
+  private WebElement h1Header;
+
+  public SpecialCuratedContentPageObject(WebDriver driver) {
+    super(driver);
+    PageFactory.initElements(driver, this);
+  }
+
+
+}

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/special/SpecialCuratedContentPageObject.java
@@ -56,7 +56,7 @@ public class SpecialCuratedContentPageObject extends SpecialPageObject {
     PageObjectLogging.log("verifySuccesfulSave", "Curated Content saved with success", true);
   }
 
-  public void removeLastElement(String label) {
+  public void removeLastElement() {
     waitForElementByElement(lastElementRemoveIcon);
     scrollAndClick(lastElementRemoveIcon);
   }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -1,8 +1,12 @@
 package com.wikia.webdriver.testcases.specialpagestests;
 
+import com.wikia.webdriver.common.contentpatterns.PageContent;
+import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.annotations.CreationTicket;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoAddComponentObject;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoOptionsComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCuratedContentPageObject;
 
@@ -13,11 +17,14 @@ import org.testng.annotations.Test;
  */
 public class CuratedContentTests extends NewTestTemplate {
 
+  String category = URLsContent.CATEGORY_HELP;
+  String label = PageContent.LOREM_IPSUM_SHORT;
+
   Credentials credentials = config.getCredentials();
 
   @CreationTicket(ticketID = "CONCF-767")
   @Test(groups = {"CuratedContent001", "CuratedContent"})
-  public void cureatedContent001_saveWithoutImage() {
+  public void curatedContent001_saveWithoutImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
@@ -25,10 +32,21 @@ public class CuratedContentTests extends NewTestTemplate {
 
   @CreationTicket(ticketID = "CONCF-767")
   @Test(groups = {"CuratedContent002", "CuratedContent"})
-  public void cureatedContent002_saveWithImage() {
+  public void curatedContent002_saveWithImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
-
+    // add new element and add image to that element
+    cc.addNewElement(category, label);
+    PhotoAddComponentObject addPhotoModal = cc.addImage();
+    PhotoOptionsComponentObject photoOptionsModal = addPhotoModal.addPhotoFromWiki("image", 1);
+    photoOptionsModal.clickAddPhoto();
+    cc.verifyImageInElement(label);
+    cc.clickSave();
+    cc.verifySuccesfulSave();
+    //clean the added element
+    cc.removeLastElement(label);
+    cc.clickSave();
+    cc.verifySuccesfulSave();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -28,6 +28,9 @@ public class CuratedContentTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
+    cc.addNewElement(category, label);
+    cc.verifyImageErrorInLastElement();
+    cc.verifySaveNotClickable();
   }
 
   @CreationTicket(ticketID = "CONCF-767")
@@ -38,10 +41,9 @@ public class CuratedContentTests extends NewTestTemplate {
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
     // add new element and add image to that element
     cc.addNewElement(category, label);
-    PhotoAddComponentObject addPhotoModal = cc.addImage();
-    PhotoOptionsComponentObject photoOptionsModal = addPhotoModal.addPhotoFromWiki("image", 1);
-    photoOptionsModal.clickAddPhoto();
-    cc.verifyImageInElement(label);
+    PhotoAddComponentObject addPhotoModal = cc.clickImageOnLastElement();
+    PhotoOptionsComponentObject photoOptionsModal = addPhotoModal.clickAddThisPhoto(1);
+    cc.verifyImageInLastElement();
     cc.clickSave();
     cc.verifySuccesfulSave();
     //clean the added element

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -17,8 +17,8 @@ import org.testng.annotations.Test;
  */
 public class CuratedContentTests extends NewTestTemplate {
 
-  String category = URLsContent.CATEGORY_HELP;
-  String label = PageContent.LOREM_IPSUM_SHORT;
+  private static final String category = URLsContent.CATEGORY_HELP;
+  private static final String label = PageContent.LOREM_IPSUM_SHORT;
 
   Credentials credentials = config.getCredentials();
 
@@ -44,7 +44,7 @@ public class CuratedContentTests extends NewTestTemplate {
     // add new element and add image to that element
     cc.addNewElement(category, label);
     PhotoAddComponentObject addPhotoModal = cc.clickImageOnLastElement();
-    PhotoOptionsComponentObject photoOptionsModal = addPhotoModal.clickAddThisPhoto(1);
+    addPhotoModal.clickAddThisPhoto(1);
     cc.verifyImageInLastElement();
     cc.clickSave();
     cc.verifySuccesfulSave();

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -1,0 +1,34 @@
+package com.wikia.webdriver.testcases.specialpagestests;
+
+import com.wikia.webdriver.common.core.annotations.CreationTicket;
+import com.wikia.webdriver.common.properties.Credentials;
+import com.wikia.webdriver.common.templates.NewTestTemplate;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCuratedContentPageObject;
+
+import org.testng.annotations.Test;
+
+/**
+ * @ownership Content
+ */
+public class CuratedContentTests extends NewTestTemplate {
+
+  Credentials credentials = config.getCredentials();
+
+  @CreationTicket(ticketID = "CONCF-767")
+  @Test(groups = {"CuratedContent001", "CuratedContent"})
+  public void cureatedContent001_saveWithoutImage() {
+    WikiBasePageObject base = new WikiBasePageObject(driver);
+    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+    SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
+  }
+
+  @CreationTicket(ticketID = "CONCF-767")
+  @Test(groups = {"CuratedContent002", "CuratedContent"})
+  public void cureatedContent002_saveWithImage() {
+    WikiBasePageObject base = new WikiBasePageObject(driver);
+    base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
+    SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
+
+  }
+}

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -28,7 +28,9 @@ public class CuratedContentTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
+    // add new element without image
     cc.addNewElement(category, label);
+    // verify error message and save button not clickable
     cc.verifyImageErrorInLastElement();
     cc.verifySaveNotClickable();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -6,7 +6,6 @@ import com.wikia.webdriver.common.core.annotations.CreationTicket;
 import com.wikia.webdriver.common.properties.Credentials;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoAddComponentObject;
-import com.wikia.webdriver.pageobjectsfactory.componentobject.photo.PhotoOptionsComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialCuratedContentPageObject;
 
@@ -29,7 +28,7 @@ public class CuratedContentTests extends NewTestTemplate {
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
     // add new element without image
-    cc.addNewElement(CATEGORY, label);
+    cc.addNewElement(CATEGORY, LABEL);
     // verify error message and save button not clickable
     cc.verifyImageErrorInLastElement();
     cc.verifySaveNotClickable();
@@ -42,14 +41,14 @@ public class CuratedContentTests extends NewTestTemplate {
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
     // add new element and add image to that element
-    cc.addNewElement(CATEGORY, label);
+    cc.addNewElement(CATEGORY, LABEL);
     PhotoAddComponentObject addPhotoModal = cc.clickImageOnLastElement();
     addPhotoModal.clickAddThisPhoto(1);
     cc.verifyImageInLastElement();
     cc.clickSave();
     cc.verifySuccesfulSave();
     //clean the added element
-    cc.removeLastElement(label);
+    cc.removeLastElement(LABEL);
     cc.clickSave();
     cc.verifySuccesfulSave();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -48,7 +48,7 @@ public class CuratedContentTests extends NewTestTemplate {
     cc.clickSave();
     cc.verifySuccesfulSave();
     //clean the added element
-    cc.removeLastElement(LABEL);
+    cc.removeLastElement();
     cc.clickSave();
     cc.verifySuccesfulSave();
   }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -22,7 +22,7 @@ public class CuratedContentTests extends NewTestTemplate {
   Credentials credentials = config.getCredentials();
 
   @CreationTicket(ticketID = "CONCF-767")
-  @Test(groups = {"CuratedContent001", "CuratedContent"})
+  @Test(groups = {"CuratedContent001", "CuratedContent"}, invocationCount = 20)
   public void curatedContent001_saveWithoutImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
@@ -35,7 +35,7 @@ public class CuratedContentTests extends NewTestTemplate {
   }
 
   @CreationTicket(ticketID = "CONCF-767")
-  @Test(groups = {"CuratedContent002", "CuratedContent"})
+  @Test(groups = {"CuratedContent002", "CuratedContent"}, invocationCount = 20)
   public void curatedContent002_saveWithImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -17,8 +17,8 @@ import org.testng.annotations.Test;
  */
 public class CuratedContentTests extends NewTestTemplate {
 
-  private static final String category = URLsContent.CATEGORY_HELP;
-  private static final String label = PageContent.LOREM_IPSUM_SHORT;
+  private static final String CATEGORY = URLsContent.CATEGORY_HELP;
+  private static final String LABEL = PageContent.LOREM_IPSUM_SHORT;
 
   Credentials credentials = config.getCredentials();
 
@@ -29,7 +29,7 @@ public class CuratedContentTests extends NewTestTemplate {
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
     // add new element without image
-    cc.addNewElement(category, label);
+    cc.addNewElement(CATEGORY, label);
     // verify error message and save button not clickable
     cc.verifyImageErrorInLastElement();
     cc.verifySaveNotClickable();
@@ -42,7 +42,7 @@ public class CuratedContentTests extends NewTestTemplate {
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialCuratedContentPageObject cc = base.openSpecialCuratedContent(wikiURL);
     // add new element and add image to that element
-    cc.addNewElement(category, label);
+    cc.addNewElement(CATEGORY, label);
     PhotoAddComponentObject addPhotoModal = cc.clickImageOnLastElement();
     addPhotoModal.clickAddThisPhoto(1);
     cc.verifyImageInLastElement();

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/CuratedContentTests.java
@@ -22,7 +22,7 @@ public class CuratedContentTests extends NewTestTemplate {
   Credentials credentials = config.getCredentials();
 
   @CreationTicket(ticketID = "CONCF-767")
-  @Test(groups = {"CuratedContent001", "CuratedContent"}, invocationCount = 20)
+  @Test(groups = {"CuratedContent001", "CuratedContent"})
   public void curatedContent001_saveWithoutImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
@@ -35,7 +35,7 @@ public class CuratedContentTests extends NewTestTemplate {
   }
 
   @CreationTicket(ticketID = "CONCF-767")
-  @Test(groups = {"CuratedContent002", "CuratedContent"}, invocationCount = 20)
+  @Test(groups = {"CuratedContent002", "CuratedContent"})
   public void curatedContent002_saveWithImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/PromoteTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/PromoteTests.java
@@ -20,8 +20,8 @@ public class PromoteTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     base.logInCookie(credentials.userNameStaff, credentials.passwordStaff, wikiURL);
     SpecialPromotePageObject promote = base.openSpecialPromotePage(wikiURL);
-    promote.typeIntoHeadline(PageContent.WIKI_PROMOTE_HEADLINE);
-    promote.typeIntoDescription(PageContent.WIKI_PROMOTE_DESCRIPTION);
+    promote.typeIntoHeadline(PageContent.LOREM_IPSUM_SHORT);
+    promote.typeIntoDescription(PageContent.LOREM_IPSUM_LONG);
     promote.uploadThumbnailImage(PageContent.FILEPNG);
     promote.verifyUploadedImage(PageContent.FILEPNG);
     promote.modifyThumnailImage(PageContent.FILE2PNG);

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -149,6 +149,7 @@
             <class name="com.wikia.webdriver.testcases.signuptests.SignUpTests"/>
             <class name="com.wikia.webdriver.testcases.specialpagestests.CssChromeTests"/>
             <class name="com.wikia.webdriver.testcases.specialpagestests.CssChromeTests_TwoDrivers"/>
+            <class name="com.wikia.webdriver.testcases.specialpagestests.CuratedContentTests"/>
             <class name="com.wikia.webdriver.testcases.specialpagestests.EditAccountTests"/>
             <class name="com.wikia.webdriver.testcases.specialpagestests.EditingPreferencesTests"/>
             <class name="com.wikia.webdriver.testcases.specialpagestests.FilePageTests"/>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-767

* Create test which tries to save CC without an image
* Create test which saves CC with an image successfully

The test assumes that error message on image will be extended with error class. The class is used for verification of the error message.

In class SpecialCuratedContentPageObject I focused methods and webelement on the last element, on the page because most automated test scenarios will operate on the last element. The solution is simple when compared to alternative approach which uses list of all elements and operates on them in different loops. If any engineer would ever like to operate on elements other than the last one, he can create such methods. However i believe all atomated test scenarios in CuratedContent can be performed by operating only on the last element.

Please don't merge according to the Content Team board, which means the test must be verified after the code review, when the functionality is introduced.