### PR TITLE
ADEN-2201 Small change in `TestLeaderboardAndPrefooterOnConsecutivePageViews`

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -523,10 +523,10 @@ public class AdsBaseObject extends WikiBasePageObject {
     public void verifyParamValue(String paramName, String paramValue, boolean expected) {
         Assertion
             .assertEquals(isGptParamPresent(LEADERBOARD_GPT_SELECTOR, paramName, paramValue),
-                          expected,
-                          "parameter \"" + paramName + "\" not found");
+                    expected,
+                    "parameter \"" + paramName + "\" not found");
         PageObjectLogging.log("verifyParamState", "parameter \"" + paramName + "\" as expected: "
-                                                  + expected, true, driver);
+                + expected, true, driver);
     }
 
     public void checkSpotlights() {
@@ -629,32 +629,13 @@ public class AdsBaseObject extends WikiBasePageObject {
 
     /**
      * Mercury is a single page application (SPA) and if you want to test navigating between
-     * different pages in the application you might want to use this method before clicking anything
+     * different pages in the application you might want to use this method after clicking anything
      * which is not on the first page.
      *
      * First page in Mercury loads just as a regular web page but next articles in Mercury just
-     * change part of loaded DOM and between them the preloader layer is displayed. This layer is on
-     * the very top and may block driver from clicking elements.
+     * change part of loaded DOM. We tried few things but waiting for the page title to change
+     * was so far the best way to make sure we can move on with our tests.
      */
-    public void mercuryWaitForPreloaderToHide() {
-        driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
-        try {
-            PageObjectLogging.log(
-                "mercuryWaitForPreloaderToHide",
-                "Waiting till loaded...",
-                true,
-                driver
-            );
-            wait.until(
-                ExpectedConditions.invisibilityOfElementLocated(
-                    By.cssSelector(MERCURY_LOADING_OVERLAY_SELECTOR)
-                )
-            );
-        } finally {
-            restoreDeaultImplicitWait();
-        }
-    }
-
     public void waitTitleChangesTo(String desiredArticleTitle) {
         driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
         try {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/mobileadstests/TestSlotsMobile.java
@@ -94,13 +94,13 @@ public class TestSlotsMobile extends MobileTestTemplate {
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryWaitForPreloaderToHide();
         ads.mercuryNavigateToAnArticle(secondArticle);
+        ads.waitTitleChangesTo(secondArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
 
-        ads.mercuryWaitForPreloaderToHide();
         ads.mercuryNavigateToAnArticle(thirdArticle);
+        ads.waitTitleChangesTo(thirdArticle);
         ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, "mobile");
         ads.verifyGptIframe(adUnit, MOBILE_PREFOOTER, "mobile");
     }


### PR DESCRIPTION
While working on Amazon tests in Mercury we found out waiting for preloader in Mercury isn't good enough. We used this method (`mercuryWaitForPreloaderToHide()`) also in `TestLeaderboardAndPrefooterOnConsecutivePageViews` which started failing today on preview. We decided to get rid of suboptimal method and used `waitTitleChangesTo()` instead.