### PR TITLE
wait for element clickability before click

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -221,7 +221,7 @@ public class BasePageObject {
 
   protected void scrollAndClick(WebElement element) {
     scrollToElement(element);
-    waitForElementClickableByElement(element);
+    waitForElementClickableByElement(element, 5);
     element.click();
   }
 
@@ -633,6 +633,17 @@ public class BasePageObject {
     try {
       wait.until(CommonExpectedConditions.elementToBeClickable(element));
     } finally {
+      restoreDeaultImplicitWait();
+    }
+  }
+
+  public void waitForElementClickableByElement(WebElement element, int newTimeOut) {
+    changeImplicitWait(250, TimeUnit.MILLISECONDS);
+    wait = new WebDriverWait(driver, newTimeOut);
+    try {
+      wait.until(CommonExpectedConditions.elementToBeClickable(element));
+    } finally {
+      wait = new WebDriverWait(driver, timeOut);
       restoreDeaultImplicitWait();
     }
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -638,14 +638,8 @@ public class BasePageObject {
   }
 
   public void waitForElementClickableByElement(WebElement element, int newTimeOut) {
-    changeImplicitWait(250, TimeUnit.MILLISECONDS);
-    wait = new WebDriverWait(driver, newTimeOut);
-    try {
-      wait.until(CommonExpectedConditions.elementToBeClickable(element));
-    } finally {
-      wait = new WebDriverWait(driver, timeOut);
-      restoreDeaultImplicitWait();
-    }
+    new WebDriverWait(driver, newTimeOut).until(
+        CommonExpectedConditions.elementToBeClickable(element));
   }
 
   public void waitForElementNotClickableByElement(WebElement element) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -221,6 +221,7 @@ public class BasePageObject {
 
   protected void scrollAndClick(WebElement element) {
     scrollToElement(element);
+    waitForElementClickableByElement(element);
     element.click();
   }
 


### PR DESCRIPTION
Lest be careful here and wait for the element clickability after we scroll to it.
The scroll may be very fast and timings are unknown so its more safe to wait for the element to be clickable. 

I suspect this wait to be the fix of a failure that I noticed today.
It's very rare failure but this fix may prevent it.