### PR TITLE
ADEN-2186 Fix for ads-mercury-ad-types job in Jenkins

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdType.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdType.java
@@ -13,9 +13,9 @@ public class TestAdType extends TemplateDontLogout {
   @Test(
       dataProviderClass = AdTypeDataProvider.class,
       dataProvider = "collapse",
-      groups = {"Ads", "TestAdTypeCollapse_001", "TestAdType"}
+      groups = {"Ads", "TestAdTypeCollapse"}
   )
-  public void TestAdTypeCollapse_001(String wikiName, String article, String adUnit, String slotName) {
+  public void TestAdTypeCollapse(String wikiName, String article, String adUnit, String slotName) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject ads = new AdsBaseObject(driver, testedPage);
 


### PR DESCRIPTION
We created a new synthetic test for Oasis (`TestAdTypeCollapse_001`) and added it to `TestAdType` group which tests are being ran while executing Jenkins' `ads-mercury-ad-type` job. This job runs only on Mercury skin and this causes failure for the new test.

I renamed the test and excluded it from `TestAdType` group here. After it passes code review, I'm going to create a job in Jenkins to execute only the new synthetic test.