### PR TITLE
move tests to proper groups

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LoginTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LoginTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile.mercury;
+package com.wikia.webdriver.testcases.mercurytests;
 
 import org.testng.annotations.Test;
 
@@ -11,7 +11,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.mercury.LoginPage;
  * Created by Qaga on 2015-06-29.
  */
 @Test(groups = {"MercuryMobileLogin"})
-public class Login extends NewTestTemplate {
+public class LoginTests extends NewTestTemplate {
 
   private static final String ERROR_MESSAGE =
       "Hm, we don't recognize these credentials. Please try again or register a new account.";

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SignupTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SignupTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.mercurytests;
 
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
  * Created by rcunningham on 6/30/15.
  */
 @Test(groups = {"MobileSignup", "Mobile"})
-public class MobileSignupTests extends NewTestTemplate {
+public class SignupTests extends NewTestTemplate {
 
   @RelatedIssue(issueID = "QAART-635", comment = "Jenkins problem: Manual testing should be done. ASk Social team how to do it")
   @Test(groups = {"MobileSignup_001"})

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/GameGuidesPreview.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/GameGuidesPreview.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileArticleCommentTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileArticleCommentTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.configuration.Configuration;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileCategoriesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileCategoriesTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.properties.Credentials;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileEditModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileEditModeTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.contentpatterns.MobilePageContent;
 import com.wikia.webdriver.common.contentpatterns.PageContent;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileInteractiveMapsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileInteractiveMapsTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.configuration.Configuration;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileLoginTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileLoginTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileModalTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileModalTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.configuration.Configuration;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileSearchTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileSearchTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.properties.Credentials;

--- a/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileTopbarTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wikiamobiletests/MobileTopbarTests.java
@@ -1,4 +1,4 @@
-package com.wikia.webdriver.testcases.mobile;
+package com.wikia.webdriver.testcases.wikiamobiletests;
 
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.properties.Credentials;

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -126,17 +126,10 @@
             <class name="com.wikia.webdriver.testcases.mercurytests.SEOTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SmartBannerTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.TOCTests"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.SignupTests"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.LoginTests"/>
             <class name="com.wikia.webdriver.testcases.messagewall.MessageWallFeaturesTests"/>
             <class name="com.wikia.webdriver.testcases.messagewall.MessageWallTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.GameGuidesPreview"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileArticleCommentTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileCategoriesTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileEditModeTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileInteractiveMapsTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileLoginTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileModalTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileSearchTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileTopbarTests"/>
             <class name="com.wikia.webdriver.testcases.monetizationtests.monetizationmodule.MonetizationModuleTests"/>
             <class name="com.wikia.webdriver.testcases.multiwikifindertests.MultiWikiFinderTests"/>
             <class name="com.wikia.webdriver.testcases.notificationstests.ForumNotificationsTests"/>
@@ -181,7 +174,15 @@
             <class name="com.wikia.webdriver.testcases.visualeditor.VETemplateTests"/>
             <class name="com.wikia.webdriver.testcases.visualeditor.VisualEditorMultiplePublishTests"/>
             <class name="com.wikia.webdriver.testcases.wampagetests.WamPageTests"/>
-            <class name="com.wikia.webdriver.testcases.mobile.MobileSignupTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.GameGuidesPreview"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileArticleCommentTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileCategoriesTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileEditModeTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileInteractiveMapsTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileLoginTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileModalTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileSearchTests"/>
+            <class name="com.wikia.webdriver.testcases.wikiamobiletests.MobileTopbarTests"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Changes:
- all `wikiamobile skin` tests are in `wikiamobiletests` folder
- all `mercury skin` tests are in `mercurytests` folder
- @qaga's tests `Login` were renamed to `LoginTests` and were moved to `mercurytests` folder
- @bekcunning's tests `MobileSignupTests` were renamed to `SignupTests` and were moved to `mercurytests` folder