### PR TITLE
ADEN-2311 First attempt to make interstitial tests more stable

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -497,28 +497,24 @@ public class AdsDataProvider {
             "adtest",
             "SyntheticTests/Interstitial",
             new Dimension(1920, 1080),
-            new Dimension(600, 590),
             true
         },
         {
             "adtest",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(1920, 1080),
-            new Dimension(300, 343),
             false
         },
         {
             "adtest",
             "SyntheticTests/Interstitial",
             new Dimension(800, 800),
-            new Dimension(569, 564),
             true
         },
         {
             "adtest",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(800, 800),
-            new Dimension(300, 343),
             false
         },
     };

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -491,7 +491,7 @@ public class AdsDataProvider {
   }
 
   @DataProvider
-  public static Object[][] interstitial() {
+  public static Object[][] interstitialOasis() {
     return new Object[][]{
         {
             "adtest",
@@ -525,7 +525,7 @@ public class AdsDataProvider {
   }
 
   @DataProvider
-  public static Object[][] interstitialMobile() {
+  public static Object[][] interstitialMercury() {
     return new Object[][]{
         {
             "adtest",

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -497,24 +497,28 @@ public class AdsDataProvider {
             "adtest",
             "SyntheticTests/Interstitial",
             new Dimension(1920, 1080),
+            new Dimension(600, 590),
             true
         },
         {
             "adtest",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(1920, 1080),
+            new Dimension(300, 343),
             false
         },
         {
             "adtest",
             "SyntheticTests/Interstitial",
             new Dimension(800, 800),
+            new Dimension(569, 564),
             true
         },
         {
             "adtest",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(800, 800),
+            new Dimension(300, 343),
             false
         },
     };

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -29,7 +29,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
    *
    * @see AdsInterstitialObject::isSizeCorrect()
    */
-  private final int SIZE_DIFFERENCE_TOLERANCE = 1;
+  private final static int sizeDifferenceTolerance = 1;
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
@@ -65,9 +65,8 @@ public class AdsInterstitialObject extends AdsBaseObject {
   }
 
   private boolean isSizeCorrect(int actualSize, int expectedSize) {
-    return (
-        actualSize >= expectedSize - SIZE_DIFFERENCE_TOLERANCE ||
-        actualSize <= expectedSize + SIZE_DIFFERENCE_TOLERANCE
-    );
+    return
+        actualSize >= expectedSize - sizeDifferenceTolerance ||
+        actualSize <= expectedSize + sizeDifferenceTolerance;
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
  * @ownership AdEng
  */
 public class AdsInterstitialObject extends AdsBaseObject {
+  public static final Dimension NOT_SCALED_AD_WRAPPER_SIZE = new Dimension(300, 343);
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
@@ -37,7 +38,27 @@ public class AdsInterstitialObject extends AdsBaseObject {
     Assertion.assertEquals(matcher.group(1), matcher.group(2), "Ad is scaled unproportionally");
   }
 
-  public void verifySize(Dimension size) {
-    Assertion.assertEquals(interstitialAdWrapper.getSize(), size);
+  public void verifySize(boolean shouldAdBeScaled) {
+    if( shouldAdBeScaled ) {
+      Assertion.assertEquals(
+          interstitialAdWrapper.getSize().getWidth() > NOT_SCALED_AD_WRAPPER_SIZE.getWidth(),
+          true
+      );
+
+      Assertion.assertEquals(
+          interstitialAdWrapper.getSize().getHeight() > NOT_SCALED_AD_WRAPPER_SIZE.getHeight(),
+          true
+      );
+    } else {
+      Assertion.assertEquals(
+          interstitialAdWrapper.getSize().getWidth(),
+          NOT_SCALED_AD_WRAPPER_SIZE.getWidth()
+      );
+
+      Assertion.assertEquals(
+          interstitialAdWrapper.getSize().getHeight(),
+          NOT_SCALED_AD_WRAPPER_SIZE.getHeight()
+      );
+    }
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -29,7 +29,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
    *
    * @see AdsInterstitialObject::isSizeCorrect()
    */
-  private final static int sizeDifferenceTolerance = 1;
+  private final static int SIZE_DIFFERENCE_TOLERANCE = 1;
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
@@ -66,7 +66,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
 
   private boolean isSizeCorrect(int actualSize, int expectedSize) {
     return
-        actualSize >= expectedSize - sizeDifferenceTolerance ||
-        actualSize <= expectedSize + sizeDifferenceTolerance;
+        actualSize >= expectedSize - SIZE_DIFFERENCE_TOLERANCE ||
+        actualSize <= expectedSize + SIZE_DIFFERENCE_TOLERANCE;
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -29,7 +29,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
    *
    * @see AdsInterstitialObject::isSizeCorrect()
    */
-  private final static int SIZE_DIFFERENCE_TOLERANCE = 32;
+  private static final int SIZE_DIFFERENCE_TOLERANCE = 32;
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -53,9 +53,9 @@ public class AdsInterstitialObject extends AdsBaseObject {
   }
 
   public void verifySize(Dimension size) {
-    Assertion.assertEquals(
+    Assertion.assertTrue(
         isSizeCorrect(interstitialAdWrapper.getSize().getWidth(), size.getWidth()),
-        true
+        "The size of ad unit is within tolerance range"
     );
 
     Assertion.assertEquals(

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -29,7 +29,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
    *
    * @see AdsInterstitialObject::isSizeCorrect()
    */
-  private final static int SIZE_DIFFERENCE_TOLERANCE = 1;
+  private final static int SIZE_DIFFERENCE_TOLERANCE = 32;
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
@@ -52,21 +52,35 @@ public class AdsInterstitialObject extends AdsBaseObject {
     Assertion.assertEquals(matcher.group(1), matcher.group(2), "Ad is scaled unproportionally");
   }
 
-  public void verifySize(Dimension size) {
+  public void verifySize(Dimension expectedSize) {
+    Dimension actualSize = interstitialAdWrapper.getSize();
+
     Assertion.assertTrue(
-        isSizeCorrect(interstitialAdWrapper.getSize().getWidth(), size.getWidth()),
-        "The size of ad unit is within tolerance range"
+        isSizeCorrect(actualSize.getWidth(), expectedSize.getWidth()),
+        String.format(
+            "The width of ad unit is not within tolerance range " +
+            "[actual: %d, expected: %d, tolerance: +-%d]",
+            actualSize.getWidth(),
+            expectedSize.getWidth(),
+            SIZE_DIFFERENCE_TOLERANCE
+        )
     );
 
-    Assertion.assertEquals(
-        isSizeCorrect(interstitialAdWrapper.getSize().getHeight(), size.getHeight()),
-        true
+    Assertion.assertTrue(
+        isSizeCorrect(actualSize.getHeight(), expectedSize.getHeight()),
+        String.format(
+            "The height of ad unit is not within tolerance range " +
+            "[actual: %d, expected: %d, tolerance: +-%d]",
+            actualSize.getHeight(),
+            expectedSize.getHeight(),
+            SIZE_DIFFERENCE_TOLERANCE
+        )
     );
   }
 
   private boolean isSizeCorrect(int actualSize, int expectedSize) {
     return
-        actualSize >= expectedSize - SIZE_DIFFERENCE_TOLERANCE ||
+        actualSize >= expectedSize - SIZE_DIFFERENCE_TOLERANCE &&
         actualSize <= expectedSize + SIZE_DIFFERENCE_TOLERANCE;
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
  * @ownership AdEng
  */
 public class AdsInterstitialObject extends AdsBaseObject {
-  public static final Dimension NOT_SCALED_AD_WRAPPER_SIZE = new Dimension(300, 343);
 
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
@@ -38,27 +37,7 @@ public class AdsInterstitialObject extends AdsBaseObject {
     Assertion.assertEquals(matcher.group(1), matcher.group(2), "Ad is scaled unproportionally");
   }
 
-  public void verifySize(boolean shouldAdBeScaled) {
-    if( shouldAdBeScaled ) {
-      Assertion.assertEquals(
-          interstitialAdWrapper.getSize().getWidth() > NOT_SCALED_AD_WRAPPER_SIZE.getWidth(),
-          true
-      );
-
-      Assertion.assertEquals(
-          interstitialAdWrapper.getSize().getHeight() > NOT_SCALED_AD_WRAPPER_SIZE.getHeight(),
-          true
-      );
-    } else {
-      Assertion.assertEquals(
-          interstitialAdWrapper.getSize().getWidth(),
-          NOT_SCALED_AD_WRAPPER_SIZE.getWidth()
-      );
-
-      Assertion.assertEquals(
-          interstitialAdWrapper.getSize().getHeight(),
-          NOT_SCALED_AD_WRAPPER_SIZE.getHeight()
-      );
-    }
+  public void verifySize(Dimension size) {
+    Assertion.assertEquals(interstitialAdWrapper.getSize(), size);
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -16,6 +16,21 @@ import java.util.regex.Pattern;
  */
 public class AdsInterstitialObject extends AdsBaseObject {
 
+  /**
+   * Checks if the actual size (width or height) is within the "range of correctness" ;)
+   *
+   * We don't want to be pixel perfect in terms of checking the size of element because
+   * it depends on many things such as in example components of a browser's window.
+   *
+   * We also don't want to just check if the content of scalable interstitial is bigger
+   * than the original image. So, we came up with a reasonable size difference margin.
+   *
+   * The size defined here is doubled at the end.
+   *
+   * @see AdsInterstitialObject::isSizeCorrect()
+   */
+  private final int SIZE_DIFFERENCE_TOLERANCE = 1;
+
   @FindBy(css = "iframe.wikia-ad-iframe")
   private WebElement interstitialAdIframe;
 
@@ -38,6 +53,21 @@ public class AdsInterstitialObject extends AdsBaseObject {
   }
 
   public void verifySize(Dimension size) {
-    Assertion.assertEquals(interstitialAdWrapper.getSize(), size);
+    Assertion.assertEquals(
+        isSizeCorrect(interstitialAdWrapper.getSize().getWidth(), size.getWidth()),
+        true
+    );
+
+    Assertion.assertEquals(
+        isSizeCorrect(interstitialAdWrapper.getSize().getHeight(), size.getHeight()),
+        true
+    );
+  }
+
+  private boolean isSizeCorrect(int actualSize, int expectedSize) {
+    return (
+        actualSize >= expectedSize - SIZE_DIFFERENCE_TOLERANCE ||
+        actualSize <= expectedSize + SIZE_DIFFERENCE_TOLERANCE
+    );
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
@@ -11,14 +11,14 @@ import org.testng.annotations.Test;
  * @author drets
  * @ownership AdEng
  */
-public class TestInterstitial extends TemplateNoFirstLoad {
+public class TestAdsInterstitial extends TemplateNoFirstLoad {
 
   @Test(
       dataProviderClass = AdsDataProvider.class,
-      groups = "Interstitial",
-      dataProvider = "interstitial"
+      groups = "TestInterstitialOasis",
+      dataProvider = "interstitialOasis"
   )
-  public void interstitialAdScaled(
+  public void adsInterstitialAdScaledOasis(
       String wikiName,
       String article,
       Dimension pageSize,
@@ -30,10 +30,10 @@ public class TestInterstitial extends TemplateNoFirstLoad {
 
   @Test(
       dataProviderClass = AdsDataProvider.class,
-      groups = "InterstitialMobile",
-      dataProvider = "interstitialMobile"
+      groups = "TestInterstitialMercury",
+      dataProvider = "interstitialMercury"
   )
-  public void interstitialAdScaledMobile(
+  public void adsInterstitialAdScaledMercury(
       String wikiName,
       String article,
       Dimension pageSize,

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestInterstitial.java
@@ -22,9 +22,10 @@ public class TestInterstitial extends TemplateNoFirstLoad {
       String wikiName,
       String article,
       Dimension pageSize,
+      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
-    testInterstitial(wikiName, article, pageSize, shouldAdBeScaled);
+    testInterstitial(wikiName, article, pageSize, adSize, shouldAdBeScaled);
   }
 
   @Test(
@@ -36,22 +37,24 @@ public class TestInterstitial extends TemplateNoFirstLoad {
       String wikiName,
       String article,
       Dimension pageSize,
+      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
-    testInterstitial(wikiName, article, pageSize, shouldAdBeScaled);
+    testInterstitial(wikiName, article, pageSize, adSize, shouldAdBeScaled);
   }
 
   private void testInterstitial(
       String wikiName,
       String article,
       Dimension pageSize,
+      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
     String url = urlBuilder.getUrlForPath(wikiName, article);
     String testedPage = urlBuilder.appendQueryStringToURL(url, "highimpactslot=1");
     AdsInterstitialObject adsInterstitial = new AdsInterstitialObject(driver, testedPage, pageSize);
     adsInterstitial.waitForPageLoaded();
-    adsInterstitial.verifySize(shouldAdBeScaled);
+    adsInterstitial.verifySize(adSize);
     if (shouldAdBeScaled) {
       adsInterstitial.verifyAdRatio();
     }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestInterstitial.java
@@ -22,10 +22,9 @@ public class TestInterstitial extends TemplateNoFirstLoad {
       String wikiName,
       String article,
       Dimension pageSize,
-      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
-    testInterstitial(wikiName, article, pageSize, adSize, shouldAdBeScaled);
+    testInterstitial(wikiName, article, pageSize, shouldAdBeScaled);
   }
 
   @Test(
@@ -37,24 +36,22 @@ public class TestInterstitial extends TemplateNoFirstLoad {
       String wikiName,
       String article,
       Dimension pageSize,
-      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
-    testInterstitial(wikiName, article, pageSize, adSize, shouldAdBeScaled);
+    testInterstitial(wikiName, article, pageSize, shouldAdBeScaled);
   }
 
   private void testInterstitial(
       String wikiName,
       String article,
       Dimension pageSize,
-      Dimension adSize,
       boolean shouldAdBeScaled
   ) {
     String url = urlBuilder.getUrlForPath(wikiName, article);
     String testedPage = urlBuilder.appendQueryStringToURL(url, "highimpactslot=1");
     AdsInterstitialObject adsInterstitial = new AdsInterstitialObject(driver, testedPage, pageSize);
     adsInterstitial.waitForPageLoaded();
-    adsInterstitial.verifySize(adSize);
+    adsInterstitial.verifySize(shouldAdBeScaled);
     if (shouldAdBeScaled) {
       adsInterstitial.verifyAdRatio();
     }

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -32,7 +32,7 @@
             <class name="com.wikia.webdriver.testcases.adstests.TestEvolveAds"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestExtraMarker"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestIncontentBoxad"/>
-            <class name="com.wikia.webdriver.testcases.adstests.TestInterstitial"/>
+            <class name="com.wikia.webdriver.testcases.adstests.TestAdsInterstitial"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestIVW2AnalyticsProvider"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestKruxIntegration"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsKruxSegments"/>


### PR DESCRIPTION
Many times the interstitial test for scaled content fails because of 1px higher ad content than expected while writing the test.

This change just checks if the "default" (not scaled) version equals exactly the size and then verifies if the scaled version on bigger window is just bigger than default.