### PR TITLE
Different email addresses were being used within the method. Changed …

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/logintests/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/logintests/ForgottenPasswordTests.java
@@ -91,7 +91,7 @@ public class ForgottenPasswordTests extends NewTestTemplate {
     String
         newPassword =
         cnwLogin
-            .receiveMailWithNewPassword(credentials.emailQaart1, credentials.emailPasswordQaart1);
+            .receiveMailWithNewPassword(credentials.email, credentials.emailPassword);
     cnwLogin.typeInPassword(newPassword);
     CreateNewWikiPageObjectStep2 cnw2 = cnwLogin.submitLogin();
     new SpecialUserLoginPageObject(driver).setNewPassword();


### PR DESCRIPTION
Two different email addresses were being used within the method. Effect was that incorrect mail box was being looked in for the the forgotten password email. Therefore I changed the method to use one email address.