### PR TITLE
ADEN-2438 Fix hub slot paths

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/elemnt/Wait.java
+++ b/src/test/java/com/wikia/webdriver/common/core/elemnt/Wait.java
@@ -49,7 +49,7 @@ public class Wait {
       PageObjectLogging.log(
           ELEMENT_PRESENT_MESSAGE,
           String.format(ELEMENT_PRESENT_ERROR_FORMAT, by.toString()),
-          true
+          false
       );
       throw e;
     } finally {

--- a/src/test/java/com/wikia/webdriver/common/core/elemnt/Wait.java
+++ b/src/test/java/com/wikia/webdriver/common/core/elemnt/Wait.java
@@ -5,6 +5,7 @@ import com.wikia.webdriver.common.core.SelectorStack;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -26,7 +27,8 @@ public class Wait {
   private static final int DEFAULT_TIMEOUT = 30;
   private static final String INIT_MESSAGE = "INIT ELEMENT";
   private static final String INIT_ERROR_MESSAGE = "PROBLEM WITH ELEMENT INIT";
-
+  private static final String ELEMENT_PRESENT_MESSAGE = "ELEMENT PRESENT";
+  private static final String ELEMENT_PRESENT_ERROR_FORMAT = "PROBLEM WITH FINDING ELEMENT %s";
 
   private WebDriverWait wait;
   private WebDriver webDriver;
@@ -43,6 +45,13 @@ public class Wait {
     changeImplicitWait(250, TimeUnit.MILLISECONDS);
     try {
       return wait.until(ExpectedConditions.presenceOfElementLocated(by));
+    } catch(TimeoutException e) {
+      PageObjectLogging.log(
+          ELEMENT_PRESENT_MESSAGE,
+          String.format(ELEMENT_PRESENT_ERROR_FORMAT, by.toString()),
+          true
+      );
+      throw e;
     } finally {
       restoreDeaultImplicitWait();
     }

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -84,9 +84,8 @@ public class AdsDataProvider {
         {"gameshub", "What's_Hot", "wka.hub/_gaming_hub//hub", "HUB_TOP_LEADERBOARD"},
         {"lifestylehub", "Lifestyle_Hub", "wka.hub/_life_hub//hub", "HUB_TOP_LEADERBOARD"},
         {"lifestylehub", "From_the_Community", "wka.hub/_life_hub//hub", "HUB_TOP_LEADERBOARD"},
-        {"bookshub", "Mini_Book_Club", "wka.hub/_life_hub//hub", "HUB_TOP_LEADERBOARD"},
-        {"bookshub", "Portal:YA_Society_Reads", "wka.hub/_life_hub//hub",
-         "HUB_TOP_LEADERBOARD"},
+        {"bookshub", "Mini_Book_Club", "wka.hub/_ent_hub//hub", "HUB_TOP_LEADERBOARD"},
+        {"bookshub", "Portal:YA_Society_Reads", "wka.hub/_ent_hub//hub", "HUB_TOP_LEADERBOARD"},
         {"movieshub", "Movies_Hub", "wka.hub/_ent_hub//hub", "HUB_TOP_LEADERBOARD"},
         {"movieshub", "From_the_Community", "wka.hub/_ent_hub//hub", "HUB_TOP_LEADERBOARD"},
     };


### PR DESCRIPTION
* changed data provider so it follows changes in https://github.com/Wikia/app/pull/8463,
* changed `Wait.forElementPresent()`, so it logs more clear message when test's failing, example:
![better-logging](https://cloud.githubusercontent.com/assets/1662451/9854539/840f4e0a-5b09-11e5-9d6b-1c4c8bfe2a76.png)

//cc @ludwikkazmierczak @drets @PiotrGackowski 