### PR TITLE
ADEN-2239 Make adType collapse to pass screenshot comparison tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsAmazonObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsAmazonObject.java
@@ -81,14 +81,6 @@ public class AdsAmazonObject extends AdsBaseObject {
     }
   }
 
-  public void verifyCallToAmazonIssued() {
-    if (networkTrafficInterceptor.searchRequestUrlInHar(AMAZON_SCRIPT_URL)) {
-      PageObjectLogging.log("RequestToAmazonIssued", "Request to Amazon issued", true);
-    } else {
-      throw new NoSuchElementException("Request to Amazon not issued");
-    }
-  }
-
   public AdsAmazonObject verifyAdsFromAmazonPresent() {
     driver.switchTo().frame(getAmazonIframe(slotWithAmazon));
     Assertion.assertTrue(isElementOnPage(By.cssSelector(AMAZON_IFRAME)));

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -618,7 +618,8 @@ public class AdsBaseObject extends WikiBasePageObject {
   }
 
   private boolean checkIfGptSlotHasCreativeContent(WebElement element, String hopAdType) {
-    String iframeSelector = "iframe[id*='" + element.getAttribute("id") + "_0']";
+    String slotName = element.getAttribute("id").replace("wikia_gpt","google_ads_iframe_");
+    String iframeSelector = "iframe[id*='" + slotName + "_0']";
     String adTypeScriptXpath = String.format("//script[contains(text(), '%s')]", hopAdType);
     WebElement iframe = element.findElement(By.cssSelector(iframeSelector));
     driver.switchTo().frame(iframe);

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -3,13 +3,13 @@ package com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase;
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.CommonExpectedConditions;
-import com.wikia.webdriver.common.core.networktrafficinterceptor.NetworkTrafficInterceptor;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.helpers.AdsComparison;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.helpers.SkinHelper;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
@@ -31,7 +31,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @author Bogna 'bognix' Knychala
  * @ownership AdEngineering
  */
 public class AdsBaseObject extends WikiBasePageObject {
@@ -39,6 +38,7 @@ public class AdsBaseObject extends WikiBasePageObject {
   // Constants
   private static final int MIN_MIDDLE_COLOR_PAGE_WIDTH = 1600;
   private static final int PROVIDER_CHAIN_TIMEOUT_SEC = 30;
+  private static final String HOP_AD_TYPE = "AdEngine_adType='collapse';";
 
   private static final String[] GPT_DATA_ATTRIBUTES = {
       "data-gpt-line-item-id",
@@ -57,21 +57,19 @@ public class AdsBaseObject extends WikiBasePageObject {
       "RemnantGptMobile",
       "Liftium",
   };
+
   private static final String LIFTIUM_IFRAME_SELECTOR = "iframe[id*='Liftium']";
-  private static final String LEADERBOARD_GPT_SELECTOR = "div[id*='gpt/TOP_LEADERBOARD']";
   private static final String GPT_DIV_SELECTOR = "[data-gpt-creative-size]";
   private static final String INCONTENT_BOXAD_SELECTOR = "div[id*='INCONTENT_1']";
   private static final String FLITE_TAG_SELECTOR = ".flite-tag-extension";
   private static final String FLITE_TAG_BROKEN_SELECTOR = "#mw-content-text .error";
 
+  protected String presentLeaderboardSelector = "div[id*='TOP_LEADERBOARD']";
 
   @FindBy(css = "div[id*='TOP_LEADERBOARD']")
   protected WebElement presentLeaderboard;
-  protected String presentLeaderboardSelector = "div[id*='TOP_LEADERBOARD']";
-  protected NetworkTrafficInterceptor networkTrafficInterceptor;
   @FindBy(css = "div[id*='TOP_RIGHT_BOXAD']")
   private WebElement presentMedrec;
-  private String presentMedrecSelector = "div[id*='TOP_RIGHT_BOXAD']";
   @FindBy(css = INCONTENT_BOXAD_SELECTOR)
   private WebElement incontentBoxad;
   @FindBy(css = FLITE_TAG_SELECTOR)
@@ -81,23 +79,13 @@ public class AdsBaseObject extends WikiBasePageObject {
   @FindBy(css = LIFTIUM_IFRAME_SELECTOR)
   private List<WebElement> liftiumIframes;
 
+  public AdsBaseObject(WebDriver driver) {
+    super(driver);
+  }
+
   public AdsBaseObject(WebDriver driver, String page) {
     super(driver);
     getUrl(page, true);
-  }
-
-  public AdsBaseObject(
-      WebDriver driver, String page,
-      NetworkTrafficInterceptor networkTrafficInterceptor
-  ) {
-    super(driver);
-    networkTrafficInterceptor.startIntercepting(page);
-    getUrl(page, true);
-    this.networkTrafficInterceptor = networkTrafficInterceptor;
-  }
-
-  public AdsBaseObject(WebDriver driver) {
-    super(driver);
   }
 
   public AdsBaseObject(WebDriver driver, String testedPage, Dimension resolution) {
@@ -120,7 +108,7 @@ public class AdsBaseObject extends WikiBasePageObject {
       String adDriverForcedSuccessFormatted = String.format(
           AdsContent.AD_DRIVER_FORCED_STATUS_SUCCESS_SCRIPT, slot
       );
-      if (isScriptPresentInElement(iframeHtml, adDriverForcedSuccessFormatted)) {
+      if (checkScriptPresentInElement(iframeHtml, adDriverForcedSuccessFormatted)) {
         PageObjectLogging.log(
             "AdDriver2ForceStatus script",
             "adDriverForcedSuccess script found in slot " + slot,
@@ -135,51 +123,32 @@ public class AdsBaseObject extends WikiBasePageObject {
     }
   }
 
-  public void checkMedrec() {
-    checkAdVisibleInSlot(presentMedrecSelector, presentMedrec);
+  public void verifyMedrec() {
+    verifyAdVisibleInSlot("div[id*='TOP_RIGHT_BOXAD']", presentMedrec);
   }
 
-  public void checkTopLeaderboard() {
+  public void verifyTopLeaderboard() {
     if (!checkIfSlotExpanded(presentLeaderboard) && isElementOnPage(
         By.cssSelector("#jpsuperheader"))) {
-      PageObjectLogging.log("checkTopLeaderboard",
+      PageObjectLogging.log("verifyTopLeaderboard",
                             "Page has Gotham campaign.", true);
       return;
     }
-    checkAdVisibleInSlot(presentLeaderboardSelector, presentLeaderboard);
+    verifyAdVisibleInSlot(presentLeaderboardSelector, presentLeaderboard);
   }
 
-  public void checkIncontentBoxad() {
-    checkAdVisibleInSlot(INCONTENT_BOXAD_SELECTOR, incontentBoxad);
+  public void verifyIncontentBoxad() {
+    verifyAdVisibleInSlot(INCONTENT_BOXAD_SELECTOR, incontentBoxad);
   }
 
-  public void checkFliteTag() {
+  public void verifyFliteTag() {
     scrollToElement(wait.forElementVisible(By.cssSelector(FLITE_TAG_SELECTOR)));
     verifySlotExpanded(fliteTag);
   }
 
-  public void checkFliteTagBroken(String error) {
+  public void verifyFliteTagBroken(String error) {
     scrollToElement(wait.forElementVisible(By.cssSelector(FLITE_TAG_BROKEN_SELECTOR)));
     Assertion.assertEquals(fliteTagBroken.getText(), error);
-  }
-
-  private void checkAdVisibleInSlot(String slotSelector, WebElement slot) {
-    verifySlotExpanded(slot);
-    boolean adVisible = new AdsComparison().isAdVisible(slot, slotSelector, driver);
-    extractLiftiumTagId(slotSelector);
-    extractGptInfo(slotSelector);
-    if (!adVisible) {
-      throw new NoSuchElementException(
-          "Ad is not present in " + slotSelector
-      );
-    }
-    PageObjectLogging.log("ScreenshotsComparison", "Ad is present in " + slotSelector, true);
-  }
-
-  private void verifySlotExpanded(WebElement element) {
-    if (!checkIfSlotExpanded(element)) {
-      throw new NoSuchElementException(element.getAttribute("id") + " is collapsed");
-    }
   }
 
   public void verifyHubTopLeaderboard() throws Exception {
@@ -187,7 +156,7 @@ public class AdsBaseObject extends WikiBasePageObject {
     WebElement
         hubLB =
         driver.findElement(By.cssSelector(AdsContent.getSlotSelector(hubLBName)));
-    checkScriptPresentInSlotScripts(hubLBName, hubLB);
+    verifyScriptPresentInSlotScripts(hubLBName, hubLB);
     PageObjectLogging.log("HUB_TOP_LEADERBOARD found", "HUB_TOP_LEADERBOARD found", true);
 
     WebElement
@@ -247,157 +216,6 @@ public class AdsBaseObject extends WikiBasePageObject {
         true,
         driver
     );
-
-  }
-
-  protected boolean isScriptPresentInElement(WebElement element, String scriptText) {
-    String formattedScriptText = scriptText.replaceAll("\\s", "");
-
-    for (WebElement scriptNode : element.findElements(By.tagName("script"))) {
-      String result = scriptNode.getAttribute("innerHTML");
-      if (result.replaceAll("\\s", "").contains(formattedScriptText)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void checkScriptPresentInSlotScripts(String slotName, WebElement slotElement) {
-    String scriptExpectedResult = AdsContent.ADS_PUSHSLOT_SCRIPT.replace(
-        "%slot%", slotName
-    );
-    if (isScriptPresentInElement(slotElement, scriptExpectedResult)) {
-      PageObjectLogging.log(
-          "PushSlotsScriptFound",
-          "Script " + scriptExpectedResult + " found",
-          true
-      );
-    } else {
-      PageObjectLogging.log(
-          "PushSlotsScriptNotFound",
-          "Script " + scriptExpectedResult + " not found",
-          false,
-          driver
-      );
-      throw new NoSuchElementException("Script for pushing ads not found in element");
-    }
-  }
-
-  private void verifyNoAds() {
-    Collection<String> slotsSelectors = AdsContent.SLOTS_SELECTORS.values();
-    for (String selector : slotsSelectors) {
-      if (isElementOnPage(By.cssSelector(selector))) {
-        WebElement element = driver.findElement(By.cssSelector(selector));
-        if (
-            element.isDisplayed()
-            && element.getSize().getHeight() > 1
-            && element.getSize().getWidth() > 1
-            ) {
-          throw new WebDriverException("Ads found on page in selector: " + selector);
-        } else {
-          PageObjectLogging.log(
-              "AdsFoundButNotVisible",
-              "Ads found on page with selector: "
-              + selector
-              + " but is smaller then 1x1 or hidden",
-              true
-          );
-        }
-      } else {
-        PageObjectLogging.log(
-            "AdNotFound",
-            "Ad with selector: "
-            + selector
-            + " not found on page",
-            true
-        );
-      }
-    }
-  }
-
-  private void extractLiftiumTagId(String slotSelector) {
-    String liftiumTagId = null;
-    WebElement slot = driver.findElement(By.cssSelector(slotSelector));
-    if (isElementInContext(LIFTIUM_IFRAME_SELECTOR, slot)) {
-      JavascriptExecutor js = (JavascriptExecutor) driver;
-      WebElement currentLiftiumIframe = (WebElement) js.executeScript(
-          "return $(arguments[0] + ' iframe[id*=\\'Liftium\\']:visible')[0];",
-          slotSelector
-      );
-      String liftiumAdSrc = currentLiftiumIframe.getAttribute("src");
-      Pattern pattern = Pattern.compile("tag_id=\\d*");
-      Matcher matcher = pattern.matcher(liftiumAdSrc);
-      if (matcher.find()) {
-        liftiumTagId = matcher.group().replaceAll("[^\\d]", "");
-      }
-    }
-
-    if (liftiumTagId != null) {
-      PageObjectLogging.log(
-          "LiftiumTagId",
-          "Present liftium tag id is: "
-          + liftiumTagId + "; in slot: " + slotSelector,
-          true
-      );
-    } else {
-      PageObjectLogging.log(
-          "LiftiumTagId",
-          "Liftium not present in slot: " + slotSelector,
-          true
-      );
-    }
-  }
-
-  protected void extractGptInfo(String slotSelector) {
-    WebElement slot = driver.findElement(By.cssSelector(slotSelector));
-    String log = "GPT ad not found in slot: " + slotSelector;
-    if (isElementInContext(GPT_DIV_SELECTOR, slot)) {
-      List<WebElement> gptDivs = slot.findElements(By.cssSelector(GPT_DIV_SELECTOR));
-      WebElement lastGptDiv = gptDivs.get(gptDivs.size() - 1);
-      log = "GPT ad found in slot: " + lastGptDiv.getAttribute("id");
-      for (String attribute : GPT_DATA_ATTRIBUTES) {
-        log += "; " + attribute + " = " + lastGptDiv.getAttribute(attribute);
-      }
-    }
-    PageObjectLogging.log("extractGptInfo", log, true, driver);
-  }
-
-  protected String getSlotImageAd(WebElement slot) {
-    WebElement iframeWithAd = slot.findElement(
-        By.cssSelector("div > iframe:not([id*='hidden'])")
-    );
-    driver.switchTo().frame(iframeWithAd);
-    String imageAd = driver.findElement(
-        By.cssSelector("img")
-    ).getAttribute("src");
-    driver.switchTo().defaultContent();
-    return imageAd;
-  }
-
-  protected boolean checkIfSlotExpanded(WebElement slot) {
-    return slot.getSize().getHeight() > 1 && slot.getSize().getWidth() > 1;
-  }
-
-  public void waitForSlotCollapsed(WebElement slot) {
-    waitForElementToHaveSize(0, 0, slot);
-  }
-
-  public void waitForSlotExpanded(final WebElement slot) {
-    waitFor.until(new ExpectedCondition<Object>() {
-      @Override
-      public Object apply(WebDriver webDriver) {
-        return checkIfSlotExpanded(slot);
-      }
-    });
-  }
-
-  private void waitForElementToHaveSize(int width, int height, WebElement element) {
-    changeImplicitWait(250, TimeUnit.MILLISECONDS);
-    try {
-      waitFor.until(CommonExpectedConditions.elementToHaveSize(element, width, height));
-    } finally {
-      restoreDeaultImplicitWait();
-    }
   }
 
   public void verifyNoLiftiumAdsInSlots(List<String> slots) {
@@ -409,50 +227,6 @@ public class AdsBaseObject extends WikiBasePageObject {
         PageObjectLogging.log("LiftiumNotFound", "Liftium not found in slot " + slot, true);
       }
     }
-  }
-
-  private void waitForIframeLoaded(WebElement iframe) {
-    PageObjectLogging.log("waitForIframeLoaded", "Switching to adslot iframe", true);
-    driver.switchTo().frame(iframe);
-    waitForPageLoaded();
-    PageObjectLogging.log("waitForIframeLoaded", "Switching back to the page", true);
-    driver.switchTo().defaultContent();
-  }
-
-  /**
-   * Test whether the correct GPT ad unit is called
-   *
-   * @param adUnit the ad unit passed to GPT, like wka.wikia/_wikiaglobal//home
-   */
-  public void verifyGptIframe(String adUnit, String slotName, String src) {
-    String iframeId = "google_ads_iframe_/5441/" + adUnit + "/" + src + "/" + slotName + "_0";
-    By cssSelector = By.cssSelector("iframe[id^='" + iframeId + "']");
-
-    wait.forElementPresent(cssSelector);
-
-    String msg = "GPT iframe #" + iframeId + " found in slot " + slotName;
-    PageObjectLogging.log("verifyGptIframe", msg, true, driver);
-
-    waitForIframeLoaded(driver.findElement(cssSelector));
-
-    msg = "Received \"load\" event from GPT iframe #" + iframeId + "  in slot " + slotName;
-    PageObjectLogging.log("verifyGptIframe", msg, true, driver);
-  }
-
-  public String getGptParams(String slotName, String attr) {
-    WebElement
-        adsDiv =
-        driver.findElement(
-            By.cssSelector("div[id*='wikia_gpt'][id*='" + slotName + "'][" + attr + "]"));
-    return adsDiv.getAttribute(attr);
-  }
-
-  public String getGptPageParams(String slotName) {
-    return getGptParams(slotName, "data-gpt-page-params");
-  }
-
-  private WebElement getIframe(String slotName, String src) {
-    return driver.findElement(By.cssSelector("iframe[id*='" + src + "/" + slotName + "']"));
   }
 
   /**
@@ -507,7 +281,7 @@ public class AdsBaseObject extends WikiBasePageObject {
     );
   }
 
-  public void checkSpotlights() {
+  public void verifySpotlights() {
     // Removing comments section as it expands content downwards
     JavascriptExecutor js = (JavascriptExecutor) driver;
     js.executeScript("arguments[0].parentNode.removeChild(arguments[0]);",
@@ -526,12 +300,12 @@ public class AdsBaseObject extends WikiBasePageObject {
   }
 
   public AdsBaseObject verifySize(String slotName, String src, int slotWidth, int slotHeight) {
-    WebElement element = getIframe(slotName, src);
-    waitForElementToHaveSize(slotWidth, slotHeight, element);
-    Dimension size = element.getSize();
-    Assertion.assertEquals(size.getWidth(), slotWidth);
-    Assertion.assertEquals(size.getHeight(), slotHeight);
-    PageObjectLogging.log("verifySize", slotName + " has size " + size, true, driver);
+    waitForElementToHaveSize(slotWidth, slotHeight, getIframe(slotName, src));
+
+    PageObjectLogging.log("verifySize",
+                          slotName + " has width: " + slotWidth + ";height: " + slotHeight,
+                          true,
+                          driver);
     return this;
   }
 
@@ -556,6 +330,185 @@ public class AdsBaseObject extends WikiBasePageObject {
     PageObjectLogging.log("SlotName", slotName, true);
     waitForProvidersChain(slotName, providers, PROVIDER_CHAIN_TIMEOUT_SEC);
     return this;
+  }
+
+  /**
+   * Test whether the correct GPT ad unit is called
+   *
+   * @param adUnit the ad unit passed to GPT, like wka.wikia/_wikiaglobal//home
+   */
+  public void verifyGptIframe(String adUnit, String slotName, String src) {
+    String iframeId = "google_ads_iframe_/5441/" + adUnit + "/" + src + "/" + slotName + "_0";
+    By cssSelector = By.cssSelector("iframe[id^='" + iframeId + "']");
+
+    wait.forElementPresent(cssSelector);
+
+    String msg = "GPT iframe #" + iframeId + " found in slot " + slotName;
+    PageObjectLogging.log("verifyGptIframe", msg, true, driver);
+
+    waitForIframeLoaded(driver.findElement(cssSelector));
+
+    msg = "Received \"load\" event from GPT iframe #" + iframeId + "  in slot " + slotName;
+    PageObjectLogging.log("verifyGptIframe", msg, true, driver);
+  }
+
+  public AdsBaseObject refresh(int times) {
+    for (int i = 0; i < times; i++) {
+      refreshPage();
+    }
+    return this;
+  }
+
+  public void waitForSlotCollapsed(WebElement slot) {
+    waitForElementToHaveSize(0, 0, slot);
+  }
+
+  public void waitForSlotExpanded(final WebElement slot) {
+    waitFor.until(new ExpectedCondition<Object>() {
+      @Override
+      public Object apply(WebDriver webDriver) {
+        return checkIfSlotExpanded(slot);
+      }
+    });
+  }
+
+  public String getGptParams(String slotName, String attr) {
+    WebElement
+        adsDiv =
+        driver.findElement(
+            By.cssSelector("div[id*='wikia_gpt'][id*='" + slotName + "'][" + attr + "]"));
+    return adsDiv.getAttribute(attr);
+  }
+
+  public String getGptPageParams(String slotName) {
+    return getGptParams(slotName, "data-gpt-page-params");
+  }
+
+  public void verifyMonocolorAd(String slotName) {
+    String slotSelector = AdsContent.getSlotSelector(slotName);
+    WebElement slot = driver.findElement(By.cssSelector(slotSelector));
+    waitForSlotExpanded(slot);
+    Assertion.assertFalse(new AdsComparison().isAdVisible(slot, slotSelector, driver));
+  }
+
+  public AdsBaseObject waitForPageLoaded() {
+    waitForJavaScriptTruthy("document.readyState === 'complete'");
+    return this;
+  }
+
+  /**
+   * Mercury is a single page application (SPA) and if you want to test navigating between different
+   * pages in the application you might want to use this method after clicking anything which is not
+   * on the first page.
+   *
+   * First page in Mercury loads just as a regular web page but next articles in Mercury just change
+   * part of loaded DOM. We tried few things but waiting for the page title to change was so far the
+   * best way to make sure we can move on with our tests.
+   */
+  public void waitTitleChangesTo(String desiredArticleTitle) {
+    driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
+    try {
+      waitFor.until(
+          ExpectedConditions.titleContains(desiredArticleTitle)
+      );
+    } finally {
+      restoreDeaultImplicitWait();
+    }
+  }
+
+  public String getCountry() {
+    waitForJavaScriptTruthy("Wikia.geo");
+    return (String) ((JavascriptExecutor) driver).executeScript(
+        "return Wikia.geo.getCountryCode();"
+    );
+  }
+
+  public AdsBaseObject addToUrl(String param) {
+    appendToUrl(param);
+    waitForPageLoaded();
+    return this;
+  }
+
+  public void verifySkin(String adSkinLeftPath,
+                         String adSkinRightPath,
+                         String backgroundColor,
+                         String middleColor) {
+    SkinHelper skinHelper = new SkinHelper(adSkinLeftPath, adSkinRightPath, driver);
+    Assertion.assertTrue(skinHelper.skinPresent());
+    PageObjectLogging.log("SKIN", "SKIN presents on the page", true);
+
+    if (!Strings.isNullOrEmpty(backgroundColor)) {
+      Assertion.assertEquals(skinHelper.getBackgroundColor(), backgroundColor);
+      PageObjectLogging.log("SKIN", "SKIN has correct background color", true);
+    }
+
+    if (!Strings.isNullOrEmpty(middleColor) &&
+        getWindowSize().getWidth() > MIN_MIDDLE_COLOR_PAGE_WIDTH) {
+      Assertion.assertEquals(skinHelper.getMiddleColor(), middleColor);
+      PageObjectLogging.log("SKIN", "SKIN has correct middle color", true);
+    }
+  }
+
+  /**
+   * Check if AdEngine loaded the ad web elements inside slot.
+   */
+  public boolean checkSlotOnPageLoaded(String slotName) {
+    changeImplicitWait(250, TimeUnit.MILLISECONDS);
+    try {
+      String slotSelector = AdsContent.getSlotSelector(slotName);
+      WebElement slot = driver.findElement(By.cssSelector(slotSelector));
+      if (slotName.equals(AdsContent.FLOATING_MEDREC)) {
+        tryTriggerFloatingMedrec(slot);
+      }
+      List<WebElement> adWebElements = slot.findElements(By.cssSelector("div"));
+      return adWebElements.size() > 1;
+    } finally {
+      restoreDeaultImplicitWait();
+    }
+  }
+
+  private Optional<WebElement> getLastGptDiv(String slotSelector) {
+    WebElement slot = driver.findElement(By.cssSelector(slotSelector));
+
+    if (isElementInContext(GPT_DIV_SELECTOR, slot)) {
+      List<WebElement> gptDivs = slot.findElements(By.cssSelector(GPT_DIV_SELECTOR));
+      return Optional.of(gptDivs.get(gptDivs.size() - 1));
+    }
+
+    return Optional.absent();
+  }
+
+  protected String getSlotImageAd(WebElement slot) {
+    WebElement iframeWithAd = slot.findElement(
+        By.cssSelector("div > iframe:not([id*='hidden'])")
+    );
+    driver.switchTo().frame(iframeWithAd);
+    String imageAd = driver.findElement(
+        By.cssSelector("img")
+    ).getAttribute("src");
+    driver.switchTo().defaultContent();
+    return imageAd;
+  }
+
+  protected boolean checkIfSlotExpanded(WebElement slot) {
+    return slot.getSize().getHeight() > 1 && slot.getSize().getWidth() > 1;
+  }
+
+  private void waitForElementToHaveSize(int width, int height, WebElement element) {
+    changeImplicitWait(250, TimeUnit.MILLISECONDS);
+    try {
+      waitFor.until(CommonExpectedConditions.elementToHaveSize(element, width, height));
+    } finally {
+      restoreDeaultImplicitWait();
+    }
+  }
+
+  private void waitForIframeLoaded(WebElement iframe) {
+    PageObjectLogging.log("waitForIframeLoaded", "Switching to adslot iframe", true);
+    driver.switchTo().frame(iframe);
+    waitForPageLoaded();
+    PageObjectLogging.log("waitForIframeLoaded", "Switching back to the page", true);
+    driver.switchTo().defaultContent();
   }
 
   private void waitForProvidersChain(final String slotName,
@@ -600,16 +553,8 @@ public class AdsBaseObject extends WikiBasePageObject {
     return providersChain;
   }
 
-  public AdsBaseObject refresh(int times) {
-    for (int i = 0; i < times; i++) {
-      refreshPage();
-    }
-    return this;
-  }
-
-  public AdsBaseObject waitForPageLoaded() {
-    waitForJavaScriptTruthy("document.readyState === 'complete'");
-    return this;
+  private WebElement getIframe(String slotName, String src) {
+    return driver.findElement(By.cssSelector("iframe[id*='" + src + "/" + slotName + "']"));
   }
 
   private void waitForJavaScriptTruthy(final String script) {
@@ -631,77 +576,6 @@ public class AdsBaseObject extends WikiBasePageObject {
     }
   }
 
-  /**
-   * Mercury is a single page application (SPA) and if you want to test navigating between different
-   * pages in the application you might want to use this method after clicking anything which is not
-   * on the first page.
-   *
-   * First page in Mercury loads just as a regular web page but next articles in Mercury just change
-   * part of loaded DOM. We tried few things but waiting for the page title to change was so far the
-   * best way to make sure we can move on with our tests.
-   */
-  public void waitTitleChangesTo(String desiredArticleTitle) {
-    driver.manage().timeouts().implicitlyWait(250, TimeUnit.MILLISECONDS);
-    try {
-      waitFor.until(
-          ExpectedConditions.titleContains(desiredArticleTitle)
-      );
-    } finally {
-      restoreDeaultImplicitWait();
-    }
-  }
-
-  public String getCountry() {
-    waitForJavaScriptTruthy("Wikia.geo");
-    return (String) ((JavascriptExecutor) driver).executeScript(
-        "return Wikia.geo.getCountryCode();"
-    );
-  }
-
-  public AdsBaseObject addToUrl(String param) {
-    appendToUrl(param);
-    waitForPageLoaded();
-    return this;
-  }
-
-  public void checkSkin(String adSkinLeftPath,
-                        String adSkinRightPath,
-                        String backgroundColor,
-                        String middleColor) {
-    SkinHelper skinHelper = new SkinHelper(adSkinLeftPath, adSkinRightPath, driver);
-    Assertion.assertTrue(skinHelper.skinPresent());
-    PageObjectLogging.log("SKIN", "SKIN presents on the page", true);
-
-    if (!Strings.isNullOrEmpty(backgroundColor)) {
-      Assertion.assertEquals(skinHelper.getBackgroundColor(), backgroundColor);
-      PageObjectLogging.log("SKIN", "SKIN has correct background color", true);
-    }
-
-    if (!Strings.isNullOrEmpty(middleColor) &&
-        getWindowSize().getWidth() > MIN_MIDDLE_COLOR_PAGE_WIDTH) {
-      Assertion.assertEquals(skinHelper.getMiddleColor(), middleColor);
-      PageObjectLogging.log("SKIN", "SKIN has correct middle color", true);
-    }
-  }
-
-  /**
-   * Check if AdEngine loaded the ad web elements inside slot.
-   */
-  public boolean isSlotOnPageLoaded(String slotName) {
-    changeImplicitWait(250, TimeUnit.MILLISECONDS);
-    try {
-      String slotSelector = AdsContent.getSlotSelector(slotName);
-      WebElement slot = driver.findElement(By.cssSelector(slotSelector));
-      if (slotName.equals(AdsContent.FLOATING_MEDREC)) {
-        tryTriggerFloatingMedrec(slot);
-      }
-      List<WebElement> adWebElements = slot.findElements(By.cssSelector("div"));
-      return adWebElements.size() > 1;
-    } finally {
-      restoreDeaultImplicitWait();
-    }
-  }
-
   private void tryTriggerFloatingMedrec(final WebElement slot) {
     try {
       new WebDriverWait(driver, 5).until(new ExpectedCondition<Object>() {
@@ -717,11 +591,160 @@ public class AdsBaseObject extends WikiBasePageObject {
     }
   }
 
-  public void verifyMonocolorAd(String slotName) {
-    String slotSelector = AdsContent.getSlotSelector(slotName);
+  private void verifyAdVisibleInSlot(String slotSelector, WebElement slot) {
+
+    if (!checkIfSlotExpanded(slot)) {
+
+      Optional<WebElement> lastGptDiv = getLastGptDiv(slotSelector);
+      if (lastGptDiv.isPresent() &&
+          checkIfGptSlotHasCreativeContent(lastGptDiv.get(), HOP_AD_TYPE)) {
+        PageObjectLogging.log("verifyAdVisibleInSlot", "Slot has " + HOP_AD_TYPE, true);
+        return;
+      }
+
+      throw new WebDriverException(slot.getAttribute("id") + " is collapsed");
+    }
+
+    boolean adVisible = new AdsComparison().isAdVisible(slot, slotSelector, driver);
+
+    extractLiftiumTagId(slotSelector);
+    extractGptInfo(slotSelector);
+
+    if (!adVisible) {
+      throw new WebDriverException("Ad is not present in " + slotSelector);
+    }
+
+    PageObjectLogging.log("ScreenshotsComparison", "Ad is present in " + slotSelector, true);
+  }
+
+  private boolean checkIfGptSlotHasCreativeContent(WebElement element, String hopAdType) {
+    String iframeSelector = "iframe[id*='" + element.getAttribute("id") + "_0']";
+    String adTypeScriptXpath = String.format("//script[contains(text(), '%s')]", hopAdType);
+    WebElement iframe = element.findElement(By.cssSelector(iframeSelector));
+    driver.switchTo().frame(iframe);
+    List<WebElement> adTypeScripts = driver.findElements(By.xpath(adTypeScriptXpath));
+    driver.switchTo().defaultContent();
+    return !adTypeScripts.isEmpty();
+  }
+
+  private void verifySlotExpanded(WebElement element) {
+    if (!checkIfSlotExpanded(element)) {
+      throw new WebDriverException(element.getAttribute("id") + " is collapsed");
+    }
+  }
+
+  private void verifyScriptPresentInSlotScripts(String slotName, WebElement slotElement) {
+    String scriptExpectedResult = AdsContent.ADS_PUSHSLOT_SCRIPT.replace(
+        "%slot%", slotName
+    );
+    if (checkScriptPresentInElement(slotElement, scriptExpectedResult)) {
+      PageObjectLogging.log(
+          "PushSlotsScriptFound",
+          "Script " + scriptExpectedResult + " found",
+          true
+      );
+    } else {
+      PageObjectLogging.log(
+          "PushSlotsScriptNotFound",
+          "Script " + scriptExpectedResult + " not found",
+          false,
+          driver
+      );
+      throw new NoSuchElementException("Script for pushing ads not found in element");
+    }
+  }
+
+  private void verifyNoAds() {
+    Collection<String> slotsSelectors = AdsContent.SLOTS_SELECTORS.values();
+    for (String selector : slotsSelectors) {
+      if (isElementOnPage(By.cssSelector(selector))) {
+        WebElement element = driver.findElement(By.cssSelector(selector));
+        if (
+            element.isDisplayed()
+            && element.getSize().getHeight() > 1
+            && element.getSize().getWidth() > 1
+            ) {
+          throw new WebDriverException("Ads found on page in selector: " + selector);
+        } else {
+          PageObjectLogging.log(
+              "AdsFoundButNotVisible",
+              "Ads found on page with selector: "
+              + selector
+              + " but is smaller then 1x1 or hidden",
+              true
+          );
+        }
+      } else {
+        PageObjectLogging.log(
+            "AdNotFound",
+            "Ad with selector: "
+            + selector
+            + " not found on page",
+            true
+        );
+      }
+    }
+  }
+
+
+  private void extractLiftiumTagId(String slotSelector) {
+    String liftiumTagId = null;
     WebElement slot = driver.findElement(By.cssSelector(slotSelector));
-    waitForSlotExpanded(slot);
-    Assertion.assertFalse(new AdsComparison().isAdVisible(slot, slotSelector, driver));
+    if (isElementInContext(LIFTIUM_IFRAME_SELECTOR, slot)) {
+      JavascriptExecutor js = (JavascriptExecutor) driver;
+      WebElement currentLiftiumIframe = (WebElement) js.executeScript(
+          "return $(arguments[0] + ' iframe[id*=\\'Liftium\\']:visible')[0];",
+          slotSelector
+      );
+      String liftiumAdSrc = currentLiftiumIframe.getAttribute("src");
+      Pattern pattern = Pattern.compile("tag_id=\\d*");
+      Matcher matcher = pattern.matcher(liftiumAdSrc);
+      if (matcher.find()) {
+        liftiumTagId = matcher.group().replaceAll("[^\\d]", "");
+      }
+    }
+
+    if (liftiumTagId != null) {
+      PageObjectLogging.log(
+          "LiftiumTagId",
+          "Present liftium tag id is: "
+          + liftiumTagId + "; in slot: " + slotSelector,
+          true
+      );
+    } else {
+      PageObjectLogging.log(
+          "LiftiumTagId",
+          "Liftium not present in slot: " + slotSelector,
+          true
+      );
+    }
+  }
+
+  protected void extractGptInfo(String slotSelector) {
+    Optional<WebElement> lastGptDiv = getLastGptDiv(slotSelector);
+
+    String log = "GPT ad not found in slot: " + slotSelector;
+
+    if (lastGptDiv.isPresent()) {
+      log = "GPT ad found in slot: " + lastGptDiv.get().getAttribute("id");
+      for (String attribute : GPT_DATA_ATTRIBUTES) {
+        log += "; " + attribute + " = " + lastGptDiv.get().getAttribute(attribute);
+      }
+    }
+
+    PageObjectLogging.log("extractGptInfo", log, true, driver);
+  }
+
+  protected boolean checkScriptPresentInElement(WebElement element, String scriptText) {
+    String formattedScriptText = scriptText.replaceAll("\\s", "");
+
+    for (WebElement scriptNode : element.findElements(By.tagName("script"))) {
+      String result = scriptNode.getAttribute("innerHTML");
+      if (result.replaceAll("\\s", "").contains(formattedScriptText)) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -620,7 +620,7 @@ public class AdsBaseObject extends WikiBasePageObject {
   private boolean checkIfGptSlotHasCreativeContent(WebElement element, String hopAdType) {
     String slotName = element.getAttribute("id").replace("wikia_gpt","google_ads_iframe_");
     String iframeSelector = "iframe[id*='" + slotName + "_0']";
-    String adTypeScriptXpath = String.format("//script[contains(text(), '%s')]", hopAdType);
+    String adTypeScriptXpath = String.format("//script[contains(text(), \"%s\")]", hopAdType);
     WebElement iframe = element.findElement(By.cssSelector(iframeSelector));
     driver.switchTo().frame(iframe);
     List<WebElement> adTypeScripts = driver.findElements(By.xpath(adTypeScriptXpath));

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsGermanObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsGermanObject.java
@@ -157,7 +157,7 @@ public class AdsGermanObject extends AdsBaseObject {
   }
 
   private boolean hasSkin(WebElement element, String elementSelector) {
-    if (isScriptPresentInElement(element, JS_SKIN_CALL)) {
+    if (checkScriptPresentInElement(element, JS_SKIN_CALL)) {
       PageObjectLogging.log("Found skin call", "skin call found in " + elementSelector, true);
       return true;
     }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestATF.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestATF.java
@@ -32,22 +32,22 @@ public class TestATF extends TemplateNoFirstLoad {
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
     adsBaseObject.waitForPageLoaded();
 
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.MEDREC));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.TOP_LB));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.INVISIBLE_SKIN));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.INVISIBLE_SKIN));
 
     if (isWgVarOn) {
-      Assertion.assertFalse(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
-      Assertion.assertFalse(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
-      Assertion.assertFalse(adsBaseObject.isSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2));
-      Assertion.assertFalse(adsBaseObject.isSlotOnPageLoaded(AdsContent.FLOATING_MEDREC));
+      Assertion.assertFalse(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
+      Assertion.assertFalse(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
+      Assertion.assertFalse(adsBaseObject.checkSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2));
+      Assertion.assertFalse(adsBaseObject.checkSlotOnPageLoaded(AdsContent.FLOATING_MEDREC));
       Thread.sleep(1000 * delaySec);
     }
 
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.FLOATING_MEDREC));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.FLOATING_MEDREC));
   }
 
   @Test(
@@ -62,18 +62,18 @@ public class TestATF extends TemplateNoFirstLoad {
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
     adsBaseObject.waitForPageLoaded();
 
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.MEDREC));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.TOP_LB));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.INVISIBLE_SKIN));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.INVISIBLE_SKIN));
 
     Assertion.assertNotEquals(
-        adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT), isWgVarOn);
+        adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT), isWgVarOn);
     Assertion.assertNotEquals(
-        adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT), isWgVarOn);
+        adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT), isWgVarOn);
     Assertion.assertNotEquals(
-        adsBaseObject.isSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2), isWgVarOn);
+        adsBaseObject.checkSlotOnPageLoaded(AdsContent.LEFT_SKYSCRAPPER_2), isWgVarOn);
     Assertion.assertNotEquals(
-        adsBaseObject.isSlotOnPageLoaded(AdsContent.FLOATING_MEDREC), isWgVarOn);
+        adsBaseObject.checkSlotOnPageLoaded(AdsContent.FLOATING_MEDREC), isWgVarOn);
   }
 
   /**
@@ -92,9 +92,9 @@ public class TestATF extends TemplateNoFirstLoad {
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, TABLET_PAGE_SIZE);
     adsBaseObject.waitForPageLoaded();
 
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.TOP_LB));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
-    Assertion.assertTrue(adsBaseObject.isSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT));
+    Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_RIGHT));
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdSkinPresence.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdSkinPresence.java
@@ -36,10 +36,10 @@ public class TestAdSkinPresence extends TemplateNoFirstLoad {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     PageObjectLogging.log("Window resolution: ", String.valueOf(windowResolution.width), true);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, windowResolution);
-    adsBaseObject.checkSkin(expectedAdSkinLeftPath,
-                            expectedAdSkinRightPath,
-                            backgroundColor,
-                            middleColor);
+    adsBaseObject.verifySkin(expectedAdSkinLeftPath,
+                             expectedAdSkinRightPath,
+                             backgroundColor,
+                             middleColor);
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsFliteTagOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsFliteTagOasis.java
@@ -20,7 +20,7 @@ public class TestAdsFliteTagOasis extends TemplateNoFirstLoad {
   public void adsFliteTagOasis(String wikiName, String article) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage);
-    wikiPage.checkFliteTag();
+    wikiPage.verifyFliteTag();
   }
 
   @Test(
@@ -31,6 +31,6 @@ public class TestAdsFliteTagOasis extends TemplateNoFirstLoad {
   public void adsFliteTagBrokenOasis(String wikiName, String article, String error) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage);
-    wikiPage.checkFliteTagBroken(error);
+    wikiPage.verifyFliteTagBroken(error);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsMonitoringOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsMonitoringOasis.java
@@ -54,8 +54,8 @@ public class TestAdsMonitoringOasis extends TemplateNoFirstLoad {
       Assertion.assertEquals(wikiPage.getCountry(), countryCode);
     }
 
-    wikiPage.checkMedrec();
-    wikiPage.checkTopLeaderboard();
+    wikiPage.verifyMedrec();
+    wikiPage.verifyTopLeaderboard();
   }
 
   private void setProxy(String countryCode) {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
@@ -32,7 +32,7 @@ public class TestAdsSlotsOasis extends TemplateNoFirstLoad {
   }
 
   private void verifySlotIsLoaded(String slotName) {
-    Assertion.assertTrue(ads.isSlotOnPageLoaded(slotName));
+    Assertion.assertTrue(ads.checkSlotOnPageLoaded(slotName));
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSpotlights.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSpotlights.java
@@ -16,6 +16,6 @@ public class TestAdsSpotlights extends TemplateNoFirstLoad {
   public void adsSpotlightsOasis(String wikiName, String article) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage);
-    wikiPage.checkSpotlights();
+    wikiPage.verifySpotlights();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestIncontentBoxad.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestIncontentBoxad.java
@@ -22,6 +22,6 @@ public class TestIncontentBoxad extends TemplateNoFirstLoad {
                                                 Dimension windowResolution) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage, windowResolution);
-    wikiPage.checkIncontentBoxad();
+    wikiPage.verifyIncontentBoxad();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestRoadblocksAfterMultiplePageViews.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestRoadblocksAfterMultiplePageViews.java
@@ -34,12 +34,12 @@ public class TestRoadblocksAfterMultiplePageViews extends TemplateNoFirstLoad {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject wikiPage = new AdsBaseObject(driver, testedPage, windowResolution);
     for (int i = 0; i < PAGE_VIEWS_COUNT; i++) {
-      wikiPage.checkTopLeaderboard();
-      wikiPage.checkMedrec();
-      wikiPage.checkSkin(expectedAdSkinLeftPartPath,
-                         expectedAdSkinRightPartPath,
-                         backgroundColor,
-                         middleColor);
+      wikiPage.verifyTopLeaderboard();
+      wikiPage.verifyMedrec();
+      wikiPage.verifySkin(expectedAdSkinLeftPartPath,
+                          expectedAdSkinRightPartPath,
+                          backgroundColor,
+                          middleColor);
     }
   }
 


### PR DESCRIPTION
Except adaption of ads monitoring tests to creatives with `adType` equals `collapse` I did first small step for refactoring _old_ **awesome** AdsBaseObject:
* removed unused things
* reordered methods: public - up, private/protected - down
* renamed `check*` methods which return `void` to `verify*` for consistency
* and other small tweaks