### PR TITLE
Proper local config overriding

### DIFF
--- a/config_default.yml
+++ b/config_default.yml
@@ -2,7 +2,7 @@
 # To localy override values, create config.yml file next to this one.
 # You can also override these values by specyfing a system property
 
-browser: FF #acceptable values: FF, CHROME, GHOST, ANDROID, CHROMEMOBILEMERCURY
+browser: FF #acceptable values: FF, CHROME, GHOST, ANDROID, CHROMEMOBILEMERCURY, HTMLUNIT
 wikiName: mediawiki119 #default testing wiki
 env: prod #acceptable values: prod, preview, sandbox-number dev-name
 credentialsPath: /selenium-config/config.xml #Path to your config.xml file

--- a/config_default.yml
+++ b/config_default.yml
@@ -1,5 +1,6 @@
-#THIS IS SAMPLE FILE
-#Copy its content to config.yml file
+# THIS IS A DEFAULT CONFIGURATION
+# To localy override values, create config.yml file next to this one.
+# You can also override these values by specyfing a system property
 
 browser: FF #acceptable values: FF, CHROME, GHOST, ANDROID, CHROMEMOBILEMERCURY
 wikiName: mediawiki119 #default testing wiki

--- a/config_default.yml
+++ b/config_default.yml
@@ -1,6 +1,5 @@
 #THIS IS SAMPLE FILE
 #Copy its content to config.yml file
-#It is used only when you run tests using IDE
 
 browser: FF #acceptable values: FF, CHROME, GHOST, ANDROID, CHROMEMOBILEMERCURY
 wikiName: mediawiki119 #default testing wiki

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
@@ -1,50 +1,66 @@
 package com.wikia.webdriver.common.core.configuration;
 
-import com.wikia.webdriver.common.core.exceptions.TestEnvInitFailedException;
-import com.wikia.webdriver.common.properties.Credentials;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import com.wikia.webdriver.common.core.exceptions.TestEnvInitFailedException;
+import com.wikia.webdriver.common.properties.Credentials;
 
 /**
  * Configuration handler. This Class should handle run configuration and global properties.
- * Configuration handling: 1. If there is a System Property specified - return value of this
- * property 2. If no System Property is found - value is provided from configuration files
- * (config_sample.yml if no config.yml provided) NOTE: system property should override ANY property
- * specified in config files
+ * Configuration handling:
+ * <ol>
+ * <li>Look for the property key in testConfig map, if key is present, return the value</li>
+ * <li>Look for the property key in system properties - return value of this property if key present
+ * </li>
+ * <li>If no System Property is found - value is provided from configuration files
+ * (config_default.yml and config.yml). Values provided in config.yml, are overriding values from
+ * config_default.yml</li>
+ * NOTE: system property should override ANY property specified in config files
+ * </ol>
  */
 public class Configuration {
 
-  private static Map<String, String> config;
+  private static final String DEFAULT_CONFIG_FILE_NAME = "config_default.yml";
+  private static final String LOCAL_CONFIG_FILE_NAME = "config.yml";
+  private static final Logger LOGGER = Logger.getLogger(Configuration.class.getName());
+
+  private static Map<String, String> defaultConfig;
+  private static Map<String, String> localConfig = new HashMap<>();
   private static Map<String, String> testConfig = new HashMap<>();
 
-  private Configuration() {
-  }
+  private Configuration() {}
 
   private static Map<String, String> readConfiguration() {
-    if (config == null) {
+    if (defaultConfig == null) {
       Yaml yaml = new Yaml();
-      InputStream input = null;
+
       try {
-        input = new FileInputStream(new File("config.yml"));
-      } catch (FileNotFoundException ex) {
-        try {
-          input = new FileInputStream(new File("config_sample.yml"));
-        } catch (FileNotFoundException ex2) {
-          throw new TestEnvInitFailedException("CAN'T LOCATE CONFIG FILE");
-        }
+        defaultConfig =
+            (Map<String, String>) yaml
+                .load(new FileInputStream(new File(DEFAULT_CONFIG_FILE_NAME)));
+      } catch (FileNotFoundException e) {
+        throw new TestEnvInitFailedException(String.format("CANNOT FIND DEFAULT CONFIG FILE : %s",
+            DEFAULT_CONFIG_FILE_NAME));
       }
-      config = (Map<String, String>) yaml.load(input);
+
+      try {
+        defaultConfig.putAll((Map<String, String>) yaml.load(new FileInputStream(new File(
+            LOCAL_CONFIG_FILE_NAME))));
+      } catch (FileNotFoundException e) {
+        LOGGER.info("local config file not found");
+      }
     }
-    return config;
+
+    return defaultConfig;
   }
 
   private static String getPropertyFromFile(String propertyName) {
@@ -55,7 +71,7 @@ public class Configuration {
   private static String getProp(String propertyName) {
     if (testConfig.get(propertyName) == null) {
       return System.getProperty(propertyName) != null ? System.getProperty(propertyName)
-                                                      : getPropertyFromFile(propertyName);
+          : getPropertyFromFile(propertyName);
     } else {
       return testConfig.get(propertyName);
     }
@@ -140,14 +156,14 @@ public class Configuration {
     String exts = getProp("extensions");
 
     if (StringUtils.isEmpty(exts)) {
-      return new String[]{};
+      return new String[] {};
     }
 
     ArrayList<String> res = new ArrayList<>();
     for (String ext : exts.replace("[", "").replace("]", "").split(",")) {
       res.add(ext.trim());
     }
-    
+
     return res.toArray(new String[res.size()]);
   }
 }

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
@@ -48,14 +49,14 @@ public class Configuration {
                 .load(new FileInputStream(new File(DEFAULT_CONFIG_FILE_NAME)));
       } catch (FileNotFoundException e) {
         throw new TestEnvInitFailedException(String.format("CANNOT FIND DEFAULT CONFIG FILE : %s",
-            DEFAULT_CONFIG_FILE_NAME));
+            DEFAULT_CONFIG_FILE_NAME), e);
       }
 
       try {
         defaultConfig.putAll((Map<String, String>) yaml.load(new FileInputStream(new File(
             LOCAL_CONFIG_FILE_NAME))));
       } catch (FileNotFoundException e) {
-        LOGGER.info("local config file not found");
+        LOGGER.log(Level.INFO, "local config file not found", e);
       }
     }
 

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/Configuration.java
@@ -24,9 +24,8 @@ import com.wikia.webdriver.common.properties.Credentials;
  * <li>If no System Property is found - value is provided from configuration files
  * (config_default.yml and config.yml). Values provided in config.yml, are overriding values from
  * config_default.yml</li>
- * NOTE: system property should override ANY property specified in config files
  * </ol>
- */
+ * */
 public class Configuration {
 
   private static final String DEFAULT_CONFIG_FILE_NAME = "config_default.yml";

--- a/src/test/java/com/wikia/webdriver/common/core/exceptions/TestEnvInitFailedException.java
+++ b/src/test/java/com/wikia/webdriver/common/core/exceptions/TestEnvInitFailedException.java
@@ -9,4 +9,8 @@ public class TestEnvInitFailedException extends RuntimeException {
   public TestEnvInitFailedException(String message) {
     super(message);
   }
+
+  public TestEnvInitFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
Configuration handling:
<ol>
<li>Look for the property key in testConfig map, if key is present, return the value</li>
<li>Look for the property key in system properties - return value of this property if key present
</li>
<li>If no System Property is found - value is provided from configuration files
(config_default.yml and config.yml). Values provided in config.yml, are overriding values from
 config_default.yml</li><ol>

<b>ALSO: config_sample.yml becomes config_default.yml</b>

Before the change, you had to copy all the values to config.yml, now you can specify only values that you want to overrride