### PR TITLE
Moving lightbox test 004 to chromemobile mercury

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/MercuryMessages.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/MercuryMessages.java
@@ -5,6 +5,8 @@ public class MercuryMessages {
   public static final String VISIBLE_MSG = "element is visible";
   public static final String INVISIBLE_MSG = "element is not visible";
 
+  public static final String IMAGE_INVISIBLE_MSG = "Image is not visible";
+
   public static final String COLLAPSED_MSG = "element is collapsed";
   public static final String EXPANDED_MSG = "element is expanded";
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/GalleryComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/GalleryComponentObject.java
@@ -1,0 +1,33 @@
+package com.wikia.webdriver.pageobjectsfactory.componentobject.mercury;
+
+import com.wikia.webdriver.pageobjectsfactory.pageobject.mercury.BasePageObject;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import java.util.List;
+
+/**
+ * @ownership Content X-Wing Wikia
+ */
+public class GalleryComponentObject extends BasePageObject {
+
+  @FindBy(css = ".article-gallery img")
+  private List<WebElement> galleryImagesArray;
+
+  public GalleryComponentObject(WebDriver driver) {
+    super(driver);
+  }
+
+  public LightboxComponentObject clickGalleryImage(int index) {
+    wait.forElementVisible(galleryImagesArray.get(index));
+    scrollToElement(galleryImagesArray.get(index));
+    galleryImagesArray.get(index).click();
+    return new LightboxComponentObject(driver);
+  }
+
+
+
+
+}

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/GalleryComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/GalleryComponentObject.java
@@ -26,8 +26,4 @@ public class GalleryComponentObject extends BasePageObject {
     galleryImagesArray.get(index).click();
     return new LightboxComponentObject(driver);
   }
-
-
-
-
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/LightboxComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/mercury/LightboxComponentObject.java
@@ -11,47 +11,25 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-import java.util.List;
-
 /**
  * @ownership Content X-Wing Wikia
  */
 public class LightboxComponentObject extends BasePageObject {
 
-  @FindBy(css = ".lightbox-close-wrapper")
-  private WebElement closeLightboxButton;
-  @FindBy(css = ".current")
-  private WebElement currentImage;
   @FindBy(css = ".lightbox-content")
   private WebElement lightboxContent;
-  @FindBy(css = ".lightbox-header")
-  private WebElement lightboxHeader;
+  @FindBy(css = ".current")
+  private WebElement currentImage;
   @FindBy(css = ".lightbox-footer")
   private WebElement lightboxFooter;
-  @FindBy(css = ".article-gallery img")
-  private List<WebElement> galleryImagesArray;
+  @FindBy(css = ".lightbox-header")
+  private WebElement lightboxHeader;
+  @FindBy(css = ".lightbox-close-wrapper")
+  private WebElement closeLightboxButton;
+
 
   public LightboxComponentObject(WebDriver driver) {
     super(driver);
-  }
-
-  public void clickCloseButton() {
-    wait.forElementVisible(closeLightboxButton);
-    closeLightboxButton.click();
-  }
-
-  public void clickGalleryImage(int index) {
-    wait.forElementVisible(galleryImagesArray.get(index));
-    scrollToElement(galleryImagesArray.get(index));
-    galleryImagesArray.get(index).click();
-  }
-
-  public String getCurrentImagePath() throws WebDriverException {
-    wait.forElementVisible(currentImage);
-    if (currentImage.getAttribute("src") == null) {
-      throw new WebDriverException("Expected String but got null");
-    }
-    return currentImage.getAttribute("src");
   }
 
   public boolean isLightboxOpened() {
@@ -75,5 +53,23 @@ public class LightboxComponentObject extends BasePageObject {
 
   public boolean isLightboxFooterDisplayed() {
     return !lightboxFooter.getCssValue("display").contains("none");
+  }
+
+  public String getCurrentImagePath() throws WebDriverException {
+    wait.forElementVisible(currentImage);
+    if (currentImage.getAttribute("src") == null) {
+      throw new WebDriverException("Expected String but got null");
+    }
+    return currentImage.getAttribute("src");
+  }
+
+  public void clickCloseButton() {
+    wait.forElementVisible(closeLightboxButton);
+    closeLightboxButton.click();
+  }
+
+  public void clickOnImage() {
+    waitForLoadingOverlayToDisappear();
+    waitAndClick(currentImage);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
@@ -34,6 +34,9 @@ public class LightboxTests extends NewTestTemplate {
   private static final String DIRECTION_DOWN = "down";
   private static final double ACCURACY = 0.83;
 
+  private static final String IMAGE_NOT_VISIBLE_MESSAGE = "Image is not visible";
+  private static final String IMAGE_VISIBLE_MESSAGE = "Image is visible";
+
   @BeforeMethod(alwaysRun = true)
   public void prepareTest() {
     driver.manage().timeouts().pageLoadTimeout(100, TimeUnit.SECONDS);
@@ -91,7 +94,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -129,7 +132,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -191,7 +194,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -228,7 +231,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -335,7 +338,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -375,7 +378,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -415,7 +418,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(
@@ -455,7 +458,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        "Image is not visible"
+        IMAGE_NOT_VISIBLE_MESSAGE
     );
 
     PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.testcases.mercurytests;
 
+import com.wikia.webdriver.common.contentpatterns.MercuryMessages;
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
 import com.wikia.webdriver.common.core.Assertion;
@@ -34,9 +35,6 @@ public class LightboxTests extends NewTestTemplate {
   private static final String DIRECTION_DOWN = "down";
   private static final double ACCURACY = 0.83;
 
-  private static final String IMAGE_NOT_VISIBLE_MESSAGE = "Image is not visible";
-  private static final String IMAGE_VISIBLE_MESSAGE = "Image is visible";
-
   @BeforeMethod(alwaysRun = true)
   public void prepareTest() {
     driver.manage().timeouts().pageLoadTimeout(100, TimeUnit.SECONDS);
@@ -45,6 +43,7 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT01
   @Test(groups = {"MercuryLightboxTest_001", "MercuryLightboxTests", "Mercury"})
+  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_001_Open_Close() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;
@@ -84,6 +83,7 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT02
   @Test(groups = {"MercuryLightboxTest_002", "MercuryLightboxTests", "Mercury"})
+  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_002_TapOnEdgesChangeImages_SwipeChangeImages() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;
@@ -94,7 +94,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -132,7 +132,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -184,6 +184,7 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT03
   @Test(groups = {"MercuryLightboxTest_003", "MercuryLightboxTests", "Mercury"})
+  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_003_ZoomByGesture_ZoomByDoubleTap() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;
@@ -194,7 +195,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -231,7 +232,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -268,7 +269,6 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT04
   @Test(groups = {"MercuryLightboxTest_004", "MercuryLightboxTests", "Mercury"})
-  @Execute(allowedDriver = Driver.ChromeMobileMercury)
   public void MercuryLightboxTest_004_UIShow_UIHide() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;
@@ -292,6 +292,7 @@ public class LightboxTests extends NewTestTemplate {
   // MT05
   @RelatedIssue(issueID = "HG-730")
   @Test(groups = {"MercuryLightboxTest_005", "MercuryLightboxTests", "Mercury"}, enabled = false)
+  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_005_BackButtonCloseLightbox() {
     AndroidDriver mobileDriver = NewDriverProvider.getMobileDriver();
     LightboxComponentObject lightbox;
@@ -327,6 +328,7 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT06
   @Test(groups = {"MercuryLightboxTest_006", "MercuryLightboxTests", "Mercury"})
+  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_006_MovingOnZoomedImage() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;
@@ -338,7 +340,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -378,7 +380,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -418,7 +420,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(
@@ -458,7 +460,7 @@ public class LightboxTests extends NewTestTemplate {
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
-        IMAGE_NOT_VISIBLE_MESSAGE
+        MercuryMessages.IMAGE_INVISIBLE_MSG
     );
 
     PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
@@ -9,6 +9,7 @@ import com.wikia.webdriver.common.core.imageutilities.Shooter;
 import com.wikia.webdriver.common.driverprovider.NewDriverProvider;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.mercury.GalleryComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.mercury.LightboxComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.mercury.PerformTouchAction;
 
@@ -40,10 +41,11 @@ public class LightboxTests extends NewTestTemplate {
   // MT01
   @Test(groups = {"MercuryLightboxTest_001", "MercuryLightboxTests", "Mercury"})
   public void MercuryLightboxTest_001_Open_Close() {
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    LightboxComponentObject lightbox;
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
 
-    lightbox.clickGalleryImage(0);
+    lightbox = gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isLightboxOpened(),
@@ -78,11 +80,12 @@ public class LightboxTests extends NewTestTemplate {
   // MT02
   @Test(groups = {"MercuryLightboxTest_002", "MercuryLightboxTests", "Mercury"})
   public void MercuryLightboxTest_002_TapOnEdgesChangeImages_SwipeChangeImages() {
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    LightboxComponentObject lightbox;
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
     PerformTouchAction touchAction = new PerformTouchAction(driver);
 
-    lightbox.clickGalleryImage(0);
+    lightbox = gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
@@ -120,7 +123,7 @@ public class LightboxTests extends NewTestTemplate {
     );
 
     lightbox.clickCloseButton();
-    lightbox.clickGalleryImage(0);
+    gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
@@ -177,11 +180,12 @@ public class LightboxTests extends NewTestTemplate {
   // MT03
   @Test(groups = {"MercuryLightboxTest_003", "MercuryLightboxTests", "Mercury"})
   public void MercuryLightboxTest_003_ZoomByGesture_ZoomByDoubleTap() {
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    LightboxComponentObject lightbox;
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
     PerformTouchAction touchAction = new PerformTouchAction(driver);
 
-    lightbox.clickGalleryImage(0);
+    lightbox = gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
@@ -218,7 +222,7 @@ public class LightboxTests extends NewTestTemplate {
     );
 
     lightbox.clickCloseButton();
-    lightbox.clickGalleryImage(0);
+    gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isCurrentImageVisible(),
@@ -260,45 +264,23 @@ public class LightboxTests extends NewTestTemplate {
   // MT04
   @Test(groups = {"MercuryLightboxTest_004", "MercuryLightboxTests", "Mercury"})
   public void MercuryLightboxTest_004_UIShow_UIHide() {
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
-    PerformTouchAction touchAction = new PerformTouchAction(driver);
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    LightboxComponentObject lightbox;
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    lightbox = gallery.clickGalleryImage(0);
 
-    lightbox.clickGalleryImage(0);
+    Assertion.assertTrue(lightbox.isLightboxHeaderDisplayed(), "Lightbox header isn't displayed");
+    Assertion.assertTrue(lightbox.isLightboxFooterDisplayed(), "Lightbox footer isn't displayed");
 
-    Assertion.assertTrue(
-        lightbox.isLightboxHeaderDisplayed(),
-        "Lightbox header isn't displayed"
-    );
+    lightbox.clickOnImage();
 
-    Assertion.assertTrue(
-        lightbox.isLightboxFooterDisplayed(),
-        "Lightbox footer isn't displayed"
-    );
+    Assertion.assertFalse(lightbox.isLightboxHeaderDisplayed(), "Lightbox header is displayed");
+    Assertion.assertFalse(lightbox.isLightboxFooterDisplayed(), "Lightbox footer is displayed");
 
-    touchAction.tapOnPointXY(50, 50, 500, 5000);
+    lightbox.clickOnImage();
 
-    Assertion.assertFalse(
-        lightbox.isLightboxHeaderDisplayed(),
-        "Lightbox header is displayed"
-    );
-
-    Assertion.assertFalse(
-        lightbox.isLightboxFooterDisplayed(),
-        "Lightbox footer is displayed"
-    );
-
-    touchAction.tapOnPointXY(50, 50, 500, 5000);
-
-    Assertion.assertTrue(
-        lightbox.isLightboxHeaderDisplayed(),
-        "Lightbox header isn't displayed"
-    );
-
-    Assertion.assertTrue(
-        lightbox.isLightboxFooterDisplayed(),
-        "Lightbox footer isn't displayed"
-    );
+    Assertion.assertTrue(lightbox.isLightboxHeaderDisplayed(), "Lightbox header isn't displayed");
+    Assertion.assertTrue(lightbox.isLightboxFooterDisplayed(), "Lightbox footer isn't displayed");
   }
 
   // MT05
@@ -306,11 +288,12 @@ public class LightboxTests extends NewTestTemplate {
   @Test(groups = {"MercuryLightboxTest_005", "MercuryLightboxTests", "Mercury"}, enabled = false)
   public void MercuryLightboxTest_005_BackButtonCloseLightbox() {
     AndroidDriver mobileDriver = NewDriverProvider.getMobileDriver();
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    LightboxComponentObject lightbox;
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
 
     String oldUrl = driver.getCurrentUrl();
-    lightbox.clickGalleryImage(0);
+    lightbox = gallery.clickGalleryImage(0);
 
     Assertion.assertTrue(
         lightbox.isLightboxOpened(),
@@ -339,11 +322,12 @@ public class LightboxTests extends NewTestTemplate {
   // MT06
   @Test(groups = {"MercuryLightboxTest_006", "MercuryLightboxTests", "Mercury"})
   public void MercuryLightboxTest_006_MovingOnZoomedImage() {
-    LightboxComponentObject lightbox = new LightboxComponentObject(driver);
-    lightbox.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
+    GalleryComponentObject gallery = new GalleryComponentObject(driver);
+    LightboxComponentObject lightbox;
+    gallery.openMercuryArticleByName(wikiURL, MercurySubpages.GALLERY);
     PerformTouchAction touchAction = new PerformTouchAction(driver);
 
-    lightbox.clickGalleryImage(0);
+    lightbox = gallery.clickGalleryImage(0);
     String direction = DIRECTION_LEFT;
 
     Assertion.assertTrue(
@@ -383,7 +367,7 @@ public class LightboxTests extends NewTestTemplate {
     );
 
     lightbox.clickCloseButton();
-    lightbox.clickGalleryImage(0);
+    gallery.clickGalleryImage(0);
     direction = DIRECTION_RIGHT;
 
     Assertion.assertTrue(
@@ -423,7 +407,7 @@ public class LightboxTests extends NewTestTemplate {
     );
 
     lightbox.clickCloseButton();
-    lightbox.clickGalleryImage(0);
+    gallery.clickGalleryImage(0);
     direction = DIRECTION_UP;
 
     Assertion.assertTrue(
@@ -463,7 +447,7 @@ public class LightboxTests extends NewTestTemplate {
     );
 
     lightbox.clickCloseButton();
-    lightbox.clickGalleryImage(0);
+    gallery.clickGalleryImage(0);
     direction = DIRECTION_DOWN;
 
     Assertion.assertTrue(

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
@@ -43,7 +43,6 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT01
   @Test(groups = {"MercuryLightboxTest_001", "MercuryLightboxTests", "Mercury"})
-  @Execute(allowedDriver = Driver.Android)
   public void MercuryLightboxTest_001_Open_Close() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/LightboxTests.java
@@ -3,6 +3,8 @@ package com.wikia.webdriver.testcases.mercurytests;
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
 import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Driver;
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.imageutilities.ImageComparison;
 import com.wikia.webdriver.common.core.imageutilities.Shooter;
@@ -263,6 +265,7 @@ public class LightboxTests extends NewTestTemplate {
 
   // MT04
   @Test(groups = {"MercuryLightboxTest_004", "MercuryLightboxTests", "Mercury"})
+  @Execute(allowedDriver = Driver.ChromeMobileMercury)
   public void MercuryLightboxTest_004_UIShow_UIHide() {
     GalleryComponentObject gallery = new GalleryComponentObject(driver);
     LightboxComponentObject lightbox;


### PR DESCRIPTION
Refactoring of lightbox test 004 so that it can be runned on chromemobile mercury.
Adding Gallery Component Object, which should have been used in the test when the driver clicks on gallery image, and then lightbox opens.