### PR TITLE
ADEN-2604 Make Krux tests more stable

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsKruxObject.java
@@ -54,14 +54,17 @@ public class AdsKruxObject extends AdsBaseObject {
    */
   public void verifyKruxUserParam(String slotName) {
     String script = "return localStorage.kxuser;";
-    waitForKrux();
     String user1 = (String) ((JavascriptExecutor) driver).executeScript(script);
+
+    // Fourth page view
     refreshPage();
-    waitForKrux();
+
     String user2 = (String) ((JavascriptExecutor) driver).executeScript(script);
     String gptPageParams = getGptPageParams(slotName);
+
     PageObjectLogging.log("gpt page params", gptPageParams, true);
     PageObjectLogging.log("krux users", user1 + ", " + user2, true);
+
     // TODO: figure out why we get krux user id in GPT calls from localStorage.kxuser in current PV OR from previous PV
     if (!gptPageParams.contains("u\":\"" + user1) && !gptPageParams.contains("u\":\"" + user2)) {
       throw new AssertionError("Gpt page params don't have the krux users from localStorage");

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxIntegration.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxIntegration.java
@@ -31,7 +31,6 @@ public class TestAdsKruxIntegration extends TemplateNoFirstLoad {
       dataProvider = "kruxIntegration",
       groups = "AdsKruxIntegrationOasis"
   )
-  @UseUnstablePageLoadStrategy
   public void adsKruxIntegrationOasis(String wikiName, String article) {
     adsKruxIntegration(wikiName, article, KRUX_SITE_ID_DESKTOP, AdsContent.TOP_LB);
   }


### PR DESCRIPTION
* `@UseUnstablePageLoadStrategy` annotation removed.
   In this particular test the loading of the page is really matter since KRUX user appended to GPT slot parameters at least after 1st page view.

* `waitForKrux` method removed.
   After removing the `@UseUnstablePageLoadStrategy` annotation the execution time of the test increases more than in 3 times.
   Removing `waitForKrux` method fixes the execution time issue.
