### PR TITLE
ADEN-2636 Hide flite ad if present

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -35,11 +35,11 @@ import java.util.regex.Pattern;
  */
 public class AdsBaseObject extends WikiBasePageObject {
 
+  protected static final String FLITE_MASK_CSS_SELECTOR = ".flite-mask";
   // Constants
   private static final int MIN_MIDDLE_COLOR_PAGE_WIDTH = 1600;
   private static final int PROVIDER_CHAIN_TIMEOUT_SEC = 30;
   private static final String HOP_AD_TYPE = "AdEngine_adType='collapse';";
-
   private static final String[] GPT_DATA_ATTRIBUTES = {
       "data-gpt-line-item-id",
       "data-gpt-creative-id",
@@ -57,10 +57,10 @@ public class AdsBaseObject extends WikiBasePageObject {
       "RemnantGptMobile",
       "Liftium",
   };
-
   private static final String LIFTIUM_IFRAME_SELECTOR = "iframe[id*='Liftium']";
   private static final String GPT_DIV_SELECTOR = "[data-gpt-creative-size]";
   private static final String INCONTENT_BOXAD_SELECTOR = "div[id*='INCONTENT_1']";
+  private static final String ARTICLE_COMMENTS_CSS_SELECTOR = "#WikiaArticleFooter";
 
   protected String presentLeaderboardSelector = "div[id*='TOP_LEADERBOARD']";
   protected String presentHighImpactSlotSelector = "div[id*='INVISIBLE_HIGH_IMPACT']";
@@ -280,9 +280,7 @@ public class AdsBaseObject extends WikiBasePageObject {
 
   public void verifySpotlights() {
     // Removing comments section as it expands content downwards
-    JavascriptExecutor js = (JavascriptExecutor) driver;
-    js.executeScript("arguments[0].parentNode.removeChild(arguments[0]);",
-                     wait.forElementVisible(By.cssSelector("#WikiaArticleFooter")));
+    hideElementIfPresent(ARTICLE_COMMENTS_CSS_SELECTOR);
 
     AdsComparison adsComparison = new AdsComparison();
 
@@ -748,9 +746,22 @@ public class AdsBaseObject extends WikiBasePageObject {
   }
 
   public void clickOnArticleLink(String linkName) {
+    hideElementIfPresent(FLITE_MASK_CSS_SELECTOR);
+
     WebElement link = driver.findElement(
         By.cssSelector("a[title='" + linkName + "']"));
     link.click();
+
     waitTitleChangesTo(linkName);
+  }
+
+  protected void hideElementIfPresent(String cssSelector) {
+    if (isElementOnPage(By.cssSelector(cssSelector))) {
+      PageObjectLogging.log("Hiding element", cssSelector, true);
+      WebElement element = driver.findElement(By.cssSelector(cssSelector));
+      JavascriptExecutor js = (JavascriptExecutor) driver;
+      js.executeScript("$(arguments[0]).css('display', 'none')", element);
+      waitForElementNotVisibleByElement(element);
+    }
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -7,12 +7,10 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsBaseObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.helpers.AdsComparison;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 /**
@@ -21,7 +19,6 @@ import org.openqa.selenium.WebElement;
 public class MobileAdsBaseObject extends AdsBaseObject {
 
   private static final String SMART_BANNER_SELECTOR = ".android.smartbanner";
-  private static final String FLITE_MASK_SELECTOR = ".flite-mask";
   private static final String CELTRA_MASK_SELECTOR = "body > div[style*=position][style*=z-index]" +
                                                      "[style*='left: 0'][style*='bottom: auto'][style*='right: auto']";
   private static final String MERCURY_ARTICLE_CONTAINER_SELECTOR = "#ember-container";
@@ -42,7 +39,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
 
   public void verifyMobileTopLeaderboard() {
     // Only works for WikiaMobile
-    removeElementIfPresent(SMART_BANNER_SELECTOR);
+    hideElementIfPresent(SMART_BANNER_SELECTOR);
 
     wait.forElementVisible(presentLeaderboard);
     if (isElementOnPage(By.cssSelector(INTERSTITIAL_AD_OPENED_SELECTOR))) {
@@ -60,7 +57,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
         return;
       }
 
-      if (isElementOnPage(By.cssSelector(FLITE_MASK_SELECTOR))) {
+      if (isElementOnPage(By.cssSelector(FLITE_MASK_CSS_SELECTOR))) {
         PageObjectLogging.logWarning("Special ad", "Flite ad detected");
         return;
       }
@@ -138,16 +135,6 @@ public class MobileAdsBaseObject extends AdsBaseObject {
           "mercuryNavigateToAnArticle()",
           "Could not find the link to: /wiki/" + articleLinkName
       );
-    }
-  }
-
-  private void removeElementIfPresent(String cssSelector) {
-    if (isElementOnPage(By.cssSelector(cssSelector))) {
-      PageObjectLogging.log("Removing element", cssSelector, true);
-      WebElement element = driver.findElement(By.cssSelector(cssSelector));
-      JavascriptExecutor js = (JavascriptExecutor) driver;
-      js.executeScript("$(arguments[0]).css('display', 'none')", element);
-      waitForElementNotVisibleByElement(element);
     }
   }
 


### PR DESCRIPTION
The tracking pixels test fails due to flite ad on the page. 
This changes hide flite ad before clicking on article link.