### PR TITLE
ADEN-2724 Fix Ooyala selector

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsOoyalaObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsOoyalaObject.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AdsOoyalaObject extends AdsBaseObject {
 
-  @FindBy(css = "object[data^='http://player.ooyala.com/player.swf']")
+  @FindBy(css = "div[id^='ooyalaplayer'] > .innerWrapper")
   private WebElement lightbox;
 
   public AdsOoyalaObject(WebDriver driver, String page) {


### PR DESCRIPTION
Due to last update of Chrome browser we can't easily get `object` DOM elements.