### PR TITLE
HTML title updates

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -159,22 +159,22 @@ public class HtmlTitleTests extends NewTestTemplate {
         {
             TEST_WIKI_ES_POKEMON,
             "WikiDex",
-            "WikiDex, la enciclopedia Pokémon - Wikia",
+            "WikiDex - Wikia",
         },
         {
             TEST_WIKI_ES_POKEMON,
             "Lista_de_Pokémon",
-            "Lista de Pokémon - WikiDex, la enciclopedia Pokémon - Wikia",
+            "Lista de Pokémon - WikiDex - Wikia",
         },
         {
             TEST_WIKI_ES_POKEMON,
             "Special:UnusedVideos",
-            "Unused videos - WikiDex, la enciclopedia Pokémon - Wikia",
+            "Unused videos - WikiDex - Wikia",
         },
         {
             TEST_WIKI_ES_POKEMON,
             "Categoría:Regiones",
-            "Categoría:Regiones - WikiDex, la enciclopedia Pokémon - Wikia",
+            "Categoría:Regiones - WikiDex - Wikia",
         },
         // Corporate pages
         {

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -25,7 +25,6 @@ public class HtmlTitleTests extends NewTestTemplate {
   @DataProvider
   private Object[][] dataHtmlTitleTest() {
     return new Object[][]{
-        TEST_WIKI_CORPORATE_FROriginal title
         {
             TEST_WIKI_ENGLISH,
             "Sktest123_Wiki",

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -14,14 +14,14 @@ import org.testng.annotations.Test;
 public class HtmlTitleTests extends NewTestTemplate {
 
   // TODO: QAART-681 Sonar should not report duplicate strings warnings for data providers
-  private static final String TEST_WIKI_CORPORATE_FR = "fr";
-  private static final String TEST_WIKI_CORPORATE_PL = "pl";
-  private static final String TEST_WIKI_CORPORATE = "www";
-  private static final String TEST_WIKI_CUSTOM_TITLE = "es.pokemon";
-  private static final String TEST_WIKI_ORIGINAL_TITLE = "sktest123";
-  private static final String TEST_WIKI_ORIGINAL_TITLE_WITH_- = "poznan";
-  private static final String TEST_WIKI_CURATED_CONTENT = "starwars";
-  private static final String TEST_WIKI_DISCUSSION = "fallout";
+  private static final String TEST_WIKI_FR = "fr";
+  private static final String TEST_WIKI_PL = "pl";
+  private static final String TEST_WIKI_WWW = "www";
+  private static final String TEST_WIKI_ES_POKEMON = "es.pokemon";
+  private static final String TEST_WIKI_SKTEST123 = "sktest123";
+  private static final String TEST_WIKI_POZNAN = "poznan";
+  private static final String TEST_WIKI_STARWARS = "starwars";
+  private static final String TEST_WIKI_FALLOUT = "fallout";
 
   Credentials credentials = Configuration.getCredentials();
 
@@ -30,175 +30,175 @@ public class HtmlTitleTests extends NewTestTemplate {
     return new Object[][]{
         // Original title
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Sktest123_Wiki",
             "Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Style-5H2",
             "Style-5H2 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Style-5H2?action=edit",
             "Editing Style-5H2 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Style-5H3?vaction=edit",
             "Style-5H3 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Style-5H2?action=history",
             "Revision history of \"Style-5H2\" - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:Version",
             "Version - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:Videos",
             "Videos on this wiki - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:NewFiles",
             "New files on this wiki - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Blog:Recent_posts",
             "Blog:Recent posts - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "User_blog:Sktest/test_blog_1",
             "User blog:Sktest/test blog 1 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:Forum",
             "Forum - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Board:General_Discussion",
             "General Discussion board - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Thread:2610",
             "Test post - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Category:Premium_Videos",
             "Category:Premium Videos - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Message_Wall:Sktest",
             "Message Wall:Sktest - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Thread:2160",
             "Welcome to Sktest123 Wiki! - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:Maps",
             "Maps - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Template:Welcome",
             "Template:Welcome - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "MediaWiki:Common.css",
             "MediaWiki:Common.css - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "MediaWiki:Edit",
             "MediaWiki:Edit - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "User:Sktest",
             "User:Sktest - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "File:THE_HOBBIT_Trailer_-_2012_Movie_-_Official_HD",
             "Video - THE HOBBIT Trailer - 2012 Movie - Official HD - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "File:Giant_prominence_on_the_sun_erupted.jpg",
             "Image - Giant prominence on the sun erupted.jpg - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_ORIGINAL_TITLE,
+            TEST_WIKI_SKTEST123,
             "Special:NonExistingSpecialPage",
             "Error - Sktest123 Wiki - Wikia",
         },
         // Em-dash instead of regular dash for some languages
         {
-            TEST_WIKI_ORIGINAL_TITLE_WITH_-,
+            TEST_WIKI_POZNAN,
             "Ulica_Kazimierza_Wielkiego",
             "Ulica Kazimierza Wielkiego - Poznańska Wiki - Wikia",
         },
         // Custom title
         {
-            TEST_WIKI_CUSTOM_TITLE,
+            TEST_WIKI_ES_POKEMON,
             "WikiDex",
             "WikiDex, la enciclopedia Pokémon - Wikia",
         },
         {
-            TEST_WIKI_CUSTOM_TITLE,
+            TEST_WIKI_ES_POKEMON,
             "Lista_de_Pokémon",
             "Lista de Pokémon - WikiDex, la enciclopedia Pokémon - Wikia",
         },
         {
-            TEST_WIKI_CUSTOM_TITLE,
+            TEST_WIKI_ES_POKEMON,
             "Special:UnusedVideos",
             "Unused videos - WikiDex, la enciclopedia Pokémon - Wikia",
         },
         {
-            TEST_WIKI_CUSTOM_TITLE,
+            TEST_WIKI_ES_POKEMON,
             "Categoría:Regiones",
             "Categoría:Regiones - WikiDex, la enciclopedia Pokémon - Wikia",
         },
         // Corporate pages
         {
-            TEST_WIKI_CORPORATE,
+            TEST_WIKI_WWW,
             "",
             "Wikia",
         },
         /* MAIN-5823 {
-            TEST_WIKI_CORPORATE,
+            TEST_WIKI_WWW,
             "WAM",
             "Wikia Activity Monitor (WAM) - Wikia",
         },*/
         {
-            TEST_WIKI_CORPORATE,
+            TEST_WIKI_WWW,
             "About",
             "About - Wikia",
         },
         {
-            TEST_WIKI_CORPORATE_FR,
+            TEST_WIKI_FR,
             "À_propos",
             "À propos - Wikia",
         },
         {
-            TEST_WIKI_CORPORATE_PL,
+            TEST_WIKI_PL,
             "",
             "Wikia",
         },
@@ -209,32 +209,32 @@ public class HtmlTitleTests extends NewTestTemplate {
     private Object[][] dataHtmlTitleMercuryTest() {
         return new Object[][]{
             {
-                TEST_WIKI_CURATED_CONTENT,
+                TEST_WIKI_STARWARS,
                 "wiki/Main_Page",
                 "Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_CURATED_CONTENT,
+                TEST_WIKI_STARWARS,
                 "wiki/Droid_starfighter",
                 "Droid starfighter - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_CURATED_CONTENT,
+                TEST_WIKI_STARWARS,
                 "main/category/Future_films",
                 "Future films - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_CURATED_CONTENT,
+                TEST_WIKI_STARWARS,
                 "main/section/Films",
                 "Films - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_DISCUSSION,
+                TEST_WIKI_FALLOUT,
                 "d/f/3035/latest",
                 "The Fallout wiki - Fallout: New Vegas and more - Wikia",
             },
             {
-                TEST_WIKI_DISCUSSION,
+                TEST_WIKI_FALLOUT,
                 "d/p/2594243417559008375",
                 "The Fallout wiki - Fallout: New Vegas and more - Wikia",
             },

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -13,194 +13,179 @@ import org.testng.annotations.Test;
 @Test(groups = {"Seo", "SeoHtmlTitle"})
 public class HtmlTitleTests extends NewTestTemplate {
 
-  // TODO: QAART-681 Sonar should not report duplicate strings warnings for data providers
-  private static final String TEST_WIKI_FR = "fr";
-  private static final String TEST_WIKI_PL = "pl";
-  private static final String TEST_WIKI_WWW = "www";
-  private static final String TEST_WIKI_ES_POKEMON = "es.pokemon";
-  private static final String TEST_WIKI_SKTEST123 = "sktest123";
-  private static final String TEST_WIKI_POZNAN = "poznan";
-  private static final String TEST_WIKI_STARWARS = "starwars";
-  private static final String TEST_WIKI_FALLOUT = "fallout";
+  private static final String TEST_WIKI_CORPORATE = "www";
+  private static final String TEST_WIKI_CORPORATE_FR = "fr";
+  private static final String TEST_WIKI_ENGLISH = "sktest123";
+  private static final String TEST_WIKI_NON_ENGLISH = "es.pokemon";
+  private static final String TEST_WIKI_CURATED_CONTENT = "starwars";
+  private static final String TEST_WIKI_DISCUSSION = "fallout";
 
   Credentials credentials = Configuration.getCredentials();
 
   @DataProvider
   private Object[][] dataHtmlTitleTest() {
     return new Object[][]{
-        // Original title
+        TEST_WIKI_CORPORATE_FROriginal title
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Sktest123_Wiki",
             "Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Style-5H2",
             "Style-5H2 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Style-5H2?action=edit",
             "Editing Style-5H2 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Style-5H3?vaction=edit",
             "Style-5H3 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Style-5H2?action=history",
             "Revision history of \"Style-5H2\" - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:Version",
             "Version - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:Videos",
             "Videos on this wiki - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:NewFiles",
             "New files on this wiki - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Blog:Recent_posts",
             "Blog:Recent posts - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "User_blog:Sktest/test_blog_1",
             "User blog:Sktest/test blog 1 - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:Forum",
             "Forum - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Board:General_Discussion",
             "General Discussion board - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Thread:2610",
             "Test post - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Category:Premium_Videos",
             "Category:Premium Videos - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Message_Wall:Sktest",
             "Message Wall:Sktest - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Thread:2160",
             "Welcome to Sktest123 Wiki! - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:Maps",
             "Maps - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Template:Welcome",
             "Template:Welcome - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "MediaWiki:Common.css",
             "MediaWiki:Common.css - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "MediaWiki:Edit",
             "MediaWiki:Edit - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "User:Sktest",
             "User:Sktest - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "File:THE_HOBBIT_Trailer_-_2012_Movie_-_Official_HD",
             "Video - THE HOBBIT Trailer - 2012 Movie - Official HD - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "File:Giant_prominence_on_the_sun_erupted.jpg",
             "Image - Giant prominence on the sun erupted.jpg - Sktest123 Wiki - Wikia",
         },
         {
-            TEST_WIKI_SKTEST123,
+            TEST_WIKI_ENGLISH,
             "Special:NonExistingSpecialPage",
             "Error - Sktest123 Wiki - Wikia",
         },
-        // Em-dash instead of regular dash for some languages
         {
-            TEST_WIKI_POZNAN,
-            "Ulica_Kazimierza_Wielkiego",
-            "Ulica Kazimierza Wielkiego - Poznańska Wiki - Wikia",
-        },
-        // Custom title
-        {
-            TEST_WIKI_ES_POKEMON,
+            TEST_WIKI_NON_ENGLISH,
             "WikiDex",
             "WikiDex - Wikia",
         },
         {
-            TEST_WIKI_ES_POKEMON,
+            TEST_WIKI_NON_ENGLISH,
             "Lista_de_Pokémon",
             "Lista de Pokémon - WikiDex - Wikia",
         },
         {
-            TEST_WIKI_ES_POKEMON,
+            TEST_WIKI_NON_ENGLISH,
             "Special:UnusedVideos",
             "Unused videos - WikiDex - Wikia",
         },
         {
-            TEST_WIKI_ES_POKEMON,
+            TEST_WIKI_NON_ENGLISH,
             "Categoría:Regiones",
             "Categoría:Regiones - WikiDex - Wikia",
         },
         // Corporate pages
         {
-            TEST_WIKI_WWW,
+            TEST_WIKI_CORPORATE,
             "",
             "Wikia",
         },
         /* MAIN-5823 {
-            TEST_WIKI_WWW,
+            TEST_WIKI_CORPORATE,
             "WAM",
             "Wikia Activity Monitor (WAM) - Wikia",
         },*/
         {
-            TEST_WIKI_WWW,
+            TEST_WIKI_CORPORATE,
             "About",
             "About - Wikia",
         },
         {
-            TEST_WIKI_FR,
+            TEST_WIKI_CORPORATE_FR,
             "À_propos",
             "À propos - Wikia",
-        },
-        {
-            TEST_WIKI_PL,
-            "",
-            "Wikia",
         },
     };
   }
@@ -209,32 +194,32 @@ public class HtmlTitleTests extends NewTestTemplate {
     private Object[][] dataHtmlTitleMercuryTest() {
         return new Object[][]{
             {
-                TEST_WIKI_STARWARS,
+                TEST_WIKI_CURATED_CONTENT,
                 "wiki/Main_Page",
                 "Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_STARWARS,
+                TEST_WIKI_CURATED_CONTENT,
                 "wiki/Droid_starfighter",
                 "Droid starfighter - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_STARWARS,
+                TEST_WIKI_CURATED_CONTENT,
                 "main/category/Future_films",
                 "Future films - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_STARWARS,
+                TEST_WIKI_CURATED_CONTENT,
                 "main/section/Films",
                 "Films - Wookieepedia, the Star Wars Wiki - Wikia",
             },
             {
-                TEST_WIKI_FALLOUT,
+                TEST_WIKI_DISCUSSION,
                 "d/f/3035/latest",
                 "The Fallout wiki - Fallout: New Vegas and more - Wikia",
             },
             {
-                TEST_WIKI_FALLOUT,
+                TEST_WIKI_DISCUSSION,
                 "d/p/2594243417559008375",
                 "The Fallout wiki - Fallout: New Vegas and more - Wikia",
             },

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -19,7 +19,7 @@ public class HtmlTitleTests extends NewTestTemplate {
   private static final String TEST_WIKI_CORPORATE = "www";
   private static final String TEST_WIKI_CUSTOM_TITLE = "es.pokemon";
   private static final String TEST_WIKI_ORIGINAL_TITLE = "sktest123";
-  private static final String TEST_WIKI_ORIGINAL_TITLE_WITH_EM_DASH = "poznan";
+  private static final String TEST_WIKI_ORIGINAL_TITLE_WITH_- = "poznan";
   private static final String TEST_WIKI_CURATED_CONTENT = "starwars";
   private static final String TEST_WIKI_DISCUSSION = "fallout";
 
@@ -151,9 +151,9 @@ public class HtmlTitleTests extends NewTestTemplate {
         },
         // Em-dash instead of regular dash for some languages
         {
-            TEST_WIKI_ORIGINAL_TITLE_WITH_EM_DASH,
+            TEST_WIKI_ORIGINAL_TITLE_WITH_-,
             "Ulica_Kazimierza_Wielkiego",
-            "Ulica Kazimierza Wielkiego – Poznańska Wiki – Wikia",
+            "Ulica Kazimierza Wielkiego - Poznańska Wiki - Wikia",
         },
         // Custom title
         {
@@ -180,7 +180,7 @@ public class HtmlTitleTests extends NewTestTemplate {
         {
             TEST_WIKI_CORPORATE,
             "",
-            "Collaborative communities for everyone! - Wikia",
+            "Wikia",
         },
         /* MAIN-5823 {
             TEST_WIKI_CORPORATE,
@@ -200,7 +200,7 @@ public class HtmlTitleTests extends NewTestTemplate {
         {
             TEST_WIKI_CORPORATE_PL,
             "",
-            "Wikia po polsku – Wikia",
+            "Wikia",
         },
     };
   }


### PR DESCRIPTION
* Always use dashes (no more em dashes for some languages)
* Just "Wikia" for corporate home pages