### PR TITLE
HtmlTitleTests updates

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -89,12 +89,20 @@ import javax.json.JsonReader;
 public class WikiBasePageObject extends BasePageObject {
 
   protected static final By LOGIN_BUTTON_CSS = By.cssSelector("a[data-id='login']");
+  private static final String LOGGED_IN_USER_SELECTOR_CHAT = "#ChatHeader .User span.username";
+  // No way to verify if user is logged in on Fandom, just assuming it's OK
+  private static final String LOGGED_IN_USER_SELECTOR_FANDOM = "a.home-fandom";
+  private static final String LOGGED_IN_USER_SELECTOR_MERCURY = ".avatar img[alt*=\"%userName%\"]";
+  private static final String LOGGED_IN_USER_SELECTOR_MONOBOOK = "#pt-userpage a[href*=\"%userName%\"]";
   private static final String LOGGED_IN_USER_SELECTOR_OASIS =
-      ".AccountNavigation a[title*=%userName%]";
-  private static final String LOGGED_IN_USER_SELECTOR_MONOBOOK = "#pt-userpage a[href*=%userName%]";
-  private static final String LOGGED_IN_USER_SELECTOR_MERCURY = ".avatar img[alt*=%userName%]";
-  private static final String LOGGED_IN_USER_SELECTOR = LOGGED_IN_USER_SELECTOR_MERCURY + ","
-      + LOGGED_IN_USER_SELECTOR_OASIS + "," + LOGGED_IN_USER_SELECTOR_MONOBOOK;
+      ".AccountNavigation a[title*=\"%userName%\"]";
+  private static final String LOGGED_IN_USER_SELECTOR_WIKIAMOBILE = "img.avatar[alt*=\"%userName%\"]";
+  private static final String LOGGED_IN_USER_SELECTOR = LOGGED_IN_USER_SELECTOR_CHAT + ","
+                                                        + LOGGED_IN_USER_SELECTOR_FANDOM + ","
+                                                        + LOGGED_IN_USER_SELECTOR_MERCURY + ","
+                                                        + LOGGED_IN_USER_SELECTOR_MONOBOOK + ","
+                                                        + LOGGED_IN_USER_SELECTOR_OASIS + ","
+                                                        + LOGGED_IN_USER_SELECTOR_WIKIAMOBILE;
   @FindBy(css = "body")
   protected WebElement body;
   @FindBy(css = ".UserLoginModal input[type='submit']")

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -96,7 +96,6 @@ public class WikiBasePageObject extends BasePageObject {
       ".AccountNavigation a[title*=\"%userName%\"]";
   private static final String LOGGED_IN_USER_SELECTOR_WIKIAMOBILE = "img.avatar[alt*=\"%userName%\"]";
   private static final String LOGGED_IN_USER_SELECTOR = LOGGED_IN_USER_SELECTOR_CHAT + ","
-                                                        + LOGGED_IN_USER_SELECTOR_FANDOM + ","
                                                         + LOGGED_IN_USER_SELECTOR_MERCURY + ","
                                                         + LOGGED_IN_USER_SELECTOR_MONOBOOK + ","
                                                         + LOGGED_IN_USER_SELECTOR_OASIS + ","

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -90,8 +90,6 @@ public class WikiBasePageObject extends BasePageObject {
 
   protected static final By LOGIN_BUTTON_CSS = By.cssSelector("a[data-id='login']");
   private static final String LOGGED_IN_USER_SELECTOR_CHAT = "#ChatHeader .User span.username";
-  // No way to verify if user is logged in on Fandom, just assuming it's OK
-  private static final String LOGGED_IN_USER_SELECTOR_FANDOM = "a.home-fandom";
   private static final String LOGGED_IN_USER_SELECTOR_MERCURY = ".avatar img[alt*=\"%userName%\"]";
   private static final String LOGGED_IN_USER_SELECTOR_MONOBOOK = "#pt-userpage a[href*=\"%userName%\"]";
   private static final String LOGGED_IN_USER_SELECTOR_OASIS =

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -2,8 +2,7 @@ package com.wikia.webdriver.testcases.seotests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.configuration.Configuration;
-import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.common.core.annotations.User;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 
@@ -12,14 +11,6 @@ import org.testng.annotations.Test;
 
 @Test(groups = {"Seo", "SeoHtmlTitle"})
 public class HtmlTitleTests extends NewTestTemplate {
-
-  private static final int VARIANT_ALL = 0;
-  private static final int VARIANT_ONLY_DESKTOP = 1;
-  private static final int VARIANT_ONLY_MOBILE = 2;
-  private static final int VARIANT_ONLY_ANONYMOUS = 3;
-  private static final int VARIANT_ONLY_ANONYMOUS_MOBILE = 4;
-  private static final int VARIANT_ONLY_LOGGED_IN = 5;
-  private static final int VARIANT_ONLY_LOGGED_IN_DESKTOP = 6;
 
   private static final String TEST_WIKI_CORPORATE = "www";
   private static final String TEST_WIKI_CORPORATE_FR = "fr";
@@ -37,206 +28,206 @@ public class HtmlTitleTests extends NewTestTemplate {
             "wiki/Sktest123_Wiki",
             "Sktest123 Wiki - Wikia",
             // SEO-194
-            VARIANT_ONLY_DESKTOP,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_DESKTOP),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Style-5H2",
             "Style-5H2 - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Style-5H2?action=edit",
             "Editing Style-5H2 - Sktest123 Wiki - Wikia",
-            VARIANT_ONLY_ANONYMOUS,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_ANONYMOUS),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Style-5H3?vaction=edit",
             "Style-5H3 - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Style-5H2?action=history",
             "Revision history of \"Style-5H2\" - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:Version",
             "Version - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:Videos",
             "Videos on this wiki - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:NewFiles",
             "New files on this wiki - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Blog:Recent_posts",
             "Blog:Recent posts - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/User_blog:Sktest/test_blog_1",
             "User blog:Sktest/test blog 1 - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:Forum",
             "Forum - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Board:General_Discussion",
             "General Discussion board - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Thread:2610",
             "Test post - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Category:Premium_Videos",
             "Category:Premium Videos - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Message_Wall:Sktest",
             "Message Wall:Sktest - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Thread:2160",
             "Welcome to Sktest123 Wiki! - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:Maps",
             "Maps - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Template:Welcome",
             "Template:Welcome - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/MediaWiki:Common.css",
             "MediaWiki:Common.css - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/MediaWiki:Edit",
             "MediaWiki:Edit - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/User:Sktest",
             "User:Sktest - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/File:THE_HOBBIT_Trailer_-_2012_Movie_-_Official_HD",
             "Video - THE HOBBIT Trailer - 2012 Movie - Official HD - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/File:Giant_prominence_on_the_sun_erupted.jpg",
             "Image - Giant prominence on the sun erupted.jpg - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_ENGLISH,
             "wiki/Special:NonExistingSpecialPage",
             "Error - Sktest123 Wiki - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_NON_ENGLISH,
             "wiki/WikiDex",
             "WikiDex - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_NON_ENGLISH,
             "wiki/Lista_de_Pokémon",
             "Lista de Pokémon - WikiDex - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_NON_ENGLISH,
             "wiki/Special:UnusedVideos",
             "Unused videos - WikiDex - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_NON_ENGLISH,
             "wiki/Categoría:Regiones",
             "Categoría:Regiones - WikiDex - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         // Corporate pages
         {
             TEST_WIKI_CORPORATE,
             "",
             "Wikia - The Home of Fandom",
-            VARIANT_ONLY_ANONYMOUS,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_ANONYMOUS),
         },
         {
             TEST_WIKI_CORPORATE,
             "WAM",
             "Wikia Activity Monitor (WAM) - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_CORPORATE,
             "About",
             "About - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_CORPORATE_FR,
             "À_propos",
             "À propos - Wikia",
-            VARIANT_ALL,
+            new TestSkipper(TestSkipper.VARIANT_ALL),
         },
         {
             TEST_WIKI_CURATED_CONTENT,
             "wiki/Main_Page",
             "Wookieepedia - Wikia",
-            VARIANT_ONLY_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_MOBILE),
         },
         {
             TEST_WIKI_CURATED_CONTENT,
             "wiki/Droid_starfighter",
             "Droid starfighter - Wookieepedia - Wikia",
-            VARIANT_ONLY_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_MOBILE),
         },
         {
             TEST_WIKI_CURATED_CONTENT,
@@ -244,7 +235,7 @@ public class HtmlTitleTests extends NewTestTemplate {
             // SEO-198: Future films - Wookieepedia - Wikia
             "http://starwars.wikia.com/main/category/Future_films",
             // XW-868
-            VARIANT_ONLY_ANONYMOUS_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_ANONYMOUS_MOBILE),
         },
         {
             TEST_WIKI_CURATED_CONTENT,
@@ -252,56 +243,28 @@ public class HtmlTitleTests extends NewTestTemplate {
             // SEO-198: "Films - Wookieepedia - Wikia",
             "http://starwars.wikia.com/main/section/Films",
             // XW-868
-            VARIANT_ONLY_ANONYMOUS_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_ANONYMOUS_MOBILE),
         },
         {
             TEST_WIKI_DISCUSSION,
             "d/f/3035/latest",
             "Fallout Wiki - Wikia",
-            VARIANT_ONLY_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_MOBILE),
         },
         {
             TEST_WIKI_DISCUSSION,
             "d/p/2594243417559008375",
             "Fallout Wiki - Wikia",
-            VARIANT_ONLY_MOBILE,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_MOBILE),
         },
         {
             TEST_WIKI_CHAT,
             "wiki/Special:Chat",
             // Starting from January 2016: "Chat - Sktest123 Wiki - Wikia",
             "Sktest123 Wiki: Welcome to the Sktest123 Wiki chat - Wikia",
-            VARIANT_ONLY_LOGGED_IN_DESKTOP,
+            new TestSkipper(TestSkipper.VARIANT_ONLY_LOGGED_IN_DESKTOP),
         }
     };
-  }
-
-  private boolean shouldSkipTestCase(int variant, boolean loggedIn) {
-    boolean isMobile = Configuration.getBrowser().contains("MOBILE");
-
-    // Check logged in / logged out
-    if (loggedIn) {
-      if (variant == VARIANT_ONLY_ANONYMOUS || variant == VARIANT_ONLY_ANONYMOUS_MOBILE) {
-        return true;
-      }
-    } else {
-      if (variant == VARIANT_ONLY_LOGGED_IN || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP) {
-        return true;
-      }
-    }
-
-    // Check mobile / desktop
-    if (isMobile) {
-      if (variant == VARIANT_ONLY_DESKTOP || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP) {
-        return true;
-      }
-    } else {
-      if (variant == VARIANT_ONLY_MOBILE || variant == VARIANT_ONLY_ANONYMOUS_MOBILE) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**
@@ -311,9 +274,9 @@ public class HtmlTitleTests extends NewTestTemplate {
       dataProvider = "dataHtmlTitleTest",
       groups = "SeoHtmlTitleLoggedOut"
   )
-  public void HtmlTitleLoggedOutTest(String wiki, String path, String expectedTitle, int variant) {
-    if (shouldSkipTestCase(variant, false)) {
-      PageObjectLogging.log("SKIP", "Test case skipped", true);
+  public void HtmlTitleLoggedOutTest(String wiki, String path, String expectedTitle,
+                                     TestSkipper skipper) {
+    if (skipper.shouldSkip(false)) {
       return;
     }
 
@@ -331,9 +294,8 @@ public class HtmlTitleTests extends NewTestTemplate {
       groups = "SeoHtmlTitleLoggedIn"
   )
   @Execute(asUser = User.USER)
-  public void HtmlTitleLoggedInTest(String wiki, String path, String expectedTitle, int variant) {
-    if (shouldSkipTestCase(variant, true)) {
-      PageObjectLogging.log("SKIP", "Test case skipped", true);
+  public void HtmlTitleLoggedInTest(String wiki, String path, String expectedTitle, TestSkipper skipper) {
+    if (skipper.shouldSkip(true)) {
       return;
     }
 

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -4,7 +4,7 @@ import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
-import com.wikia.webdriver.common.properties.Credentials;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 
 import org.testng.annotations.DataProvider;
@@ -13,217 +13,296 @@ import org.testng.annotations.Test;
 @Test(groups = {"Seo", "SeoHtmlTitle"})
 public class HtmlTitleTests extends NewTestTemplate {
 
+  private static final int VARIANT_ALL = 0;
+  private static final int VARIANT_ONLY_DESKTOP = 1;
+  private static final int VARIANT_ONLY_MOBILE = 2;
+  private static final int VARIANT_ONLY_ANONYMOUS = 3;
+  private static final int VARIANT_ONLY_ANONYMOUS_MOBILE = 4;
+  private static final int VARIANT_ONLY_LOGGED_IN = 5;
+  private static final int VARIANT_ONLY_LOGGED_IN_DESKTOP = 6;
+
   private static final String TEST_WIKI_CORPORATE = "www";
   private static final String TEST_WIKI_CORPORATE_FR = "fr";
   private static final String TEST_WIKI_ENGLISH = "sktest123";
   private static final String TEST_WIKI_NON_ENGLISH = "es.pokemon";
   private static final String TEST_WIKI_CURATED_CONTENT = "starwars";
   private static final String TEST_WIKI_DISCUSSION = "fallout";
-
-  Credentials credentials = Configuration.getCredentials();
+  private static final String TEST_WIKI_CHAT = "sktest123";
 
   @DataProvider
   private Object[][] dataHtmlTitleTest() {
     return new Object[][]{
         {
             TEST_WIKI_ENGLISH,
-            "Sktest123_Wiki",
+            "wiki/Sktest123_Wiki",
             "Sktest123 Wiki - Wikia",
+            // SEO-194
+            VARIANT_ONLY_DESKTOP,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Style-5H2",
+            "wiki/Style-5H2",
             "Style-5H2 - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Style-5H2?action=edit",
+            "wiki/Style-5H2?action=edit",
             "Editing Style-5H2 - Sktest123 Wiki - Wikia",
+            VARIANT_ONLY_ANONYMOUS,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Style-5H3?vaction=edit",
+            "wiki/Style-5H3?vaction=edit",
             "Style-5H3 - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Style-5H2?action=history",
+            "wiki/Style-5H2?action=history",
             "Revision history of \"Style-5H2\" - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:Version",
+            "wiki/Special:Version",
             "Version - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:Videos",
+            "wiki/Special:Videos",
             "Videos on this wiki - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:NewFiles",
+            "wiki/Special:NewFiles",
             "New files on this wiki - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Blog:Recent_posts",
+            "wiki/Blog:Recent_posts",
             "Blog:Recent posts - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "User_blog:Sktest/test_blog_1",
+            "wiki/User_blog:Sktest/test_blog_1",
             "User blog:Sktest/test blog 1 - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:Forum",
+            "wiki/Special:Forum",
             "Forum - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Board:General_Discussion",
+            "wiki/Board:General_Discussion",
             "General Discussion board - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Thread:2610",
+            "wiki/Thread:2610",
             "Test post - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Category:Premium_Videos",
+            "wiki/Category:Premium_Videos",
             "Category:Premium Videos - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Message_Wall:Sktest",
+            "wiki/Message_Wall:Sktest",
             "Message Wall:Sktest - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Thread:2160",
+            "wiki/Thread:2160",
             "Welcome to Sktest123 Wiki! - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:Maps",
+            "wiki/Special:Maps",
             "Maps - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Template:Welcome",
+            "wiki/Template:Welcome",
             "Template:Welcome - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "MediaWiki:Common.css",
+            "wiki/MediaWiki:Common.css",
             "MediaWiki:Common.css - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "MediaWiki:Edit",
+            "wiki/MediaWiki:Edit",
             "MediaWiki:Edit - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "User:Sktest",
+            "wiki/User:Sktest",
             "User:Sktest - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "File:THE_HOBBIT_Trailer_-_2012_Movie_-_Official_HD",
+            "wiki/File:THE_HOBBIT_Trailer_-_2012_Movie_-_Official_HD",
             "Video - THE HOBBIT Trailer - 2012 Movie - Official HD - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "File:Giant_prominence_on_the_sun_erupted.jpg",
+            "wiki/File:Giant_prominence_on_the_sun_erupted.jpg",
             "Image - Giant prominence on the sun erupted.jpg - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_ENGLISH,
-            "Special:NonExistingSpecialPage",
+            "wiki/Special:NonExistingSpecialPage",
             "Error - Sktest123 Wiki - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_NON_ENGLISH,
-            "WikiDex",
+            "wiki/WikiDex",
             "WikiDex - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_NON_ENGLISH,
-            "Lista_de_Pokémon",
+            "wiki/Lista_de_Pokémon",
             "Lista de Pokémon - WikiDex - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_NON_ENGLISH,
-            "Special:UnusedVideos",
+            "wiki/Special:UnusedVideos",
             "Unused videos - WikiDex - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_NON_ENGLISH,
-            "Categoría:Regiones",
+            "wiki/Categoría:Regiones",
             "Categoría:Regiones - WikiDex - Wikia",
+            VARIANT_ALL,
         },
         // Corporate pages
         {
             TEST_WIKI_CORPORATE,
             "",
             "Wikia - The Home of Fandom",
+            VARIANT_ALL,
         },
-        /* MAIN-5823 {
+        {
             TEST_WIKI_CORPORATE,
             "WAM",
             "Wikia Activity Monitor (WAM) - Wikia",
-        },*/
+            VARIANT_ALL,
+        },
         {
             TEST_WIKI_CORPORATE,
             "About",
             "About - Wikia",
+            VARIANT_ALL,
         },
         {
             TEST_WIKI_CORPORATE_FR,
             "À_propos",
             "À propos - Wikia",
+            VARIANT_ALL,
         },
+        {
+            TEST_WIKI_CURATED_CONTENT,
+            "wiki/Main_Page",
+            "Wookieepedia - Wikia",
+            VARIANT_ONLY_MOBILE,
+        },
+        {
+            TEST_WIKI_CURATED_CONTENT,
+            "wiki/Droid_starfighter",
+            "Droid starfighter - Wookieepedia - Wikia",
+            VARIANT_ONLY_MOBILE,
+        },
+        {
+            TEST_WIKI_CURATED_CONTENT,
+            "main/category/Future_films",
+            // SEO-198: Future films - Wookieepedia - Wikia
+            "http://starwars.wikia.com/main/category/Future_films",
+            // XW-868
+            VARIANT_ONLY_ANONYMOUS_MOBILE,
+        },
+        {
+            TEST_WIKI_CURATED_CONTENT,
+            "main/section/Films",
+            // SEO-198: "Films - Wookieepedia - Wikia",
+            "http://starwars.wikia.com/main/section/Films",
+            // XW-868
+            VARIANT_ONLY_ANONYMOUS_MOBILE,
+        },
+        {
+            TEST_WIKI_DISCUSSION,
+            "d/f/3035/latest",
+            "Fallout Wiki - Wikia",
+            VARIANT_ONLY_MOBILE,
+        },
+        {
+            TEST_WIKI_DISCUSSION,
+            "d/p/2594243417559008375",
+            "Fallout Wiki - Wikia",
+            VARIANT_ONLY_MOBILE,
+        },
+        {
+            TEST_WIKI_CHAT,
+            "wiki/Special:Chat",
+            // Starting from January 2016: "Chat - Sktest123 Wiki - Wikia",
+            "Sktest123 Wiki: Welcome to the Sktest123 Wiki chat - Wikia",
+            VARIANT_ONLY_LOGGED_IN_DESKTOP,
+        }
     };
   }
 
-    @DataProvider
-    private Object[][] dataHtmlTitleMercuryTest() {
-        return new Object[][]{
-            {
-                TEST_WIKI_CURATED_CONTENT,
-                "wiki/Main_Page",
-                "Wookieepedia, the Star Wars Wiki - Wikia",
-            },
-            {
-                TEST_WIKI_CURATED_CONTENT,
-                "wiki/Droid_starfighter",
-                "Droid starfighter - Wookieepedia, the Star Wars Wiki - Wikia",
-            },
-            {
-                TEST_WIKI_CURATED_CONTENT,
-                "main/category/Future_films",
-                "Future films - Wookieepedia, the Star Wars Wiki - Wikia",
-            },
-            {
-                TEST_WIKI_CURATED_CONTENT,
-                "main/section/Films",
-                "Films - Wookieepedia, the Star Wars Wiki - Wikia",
-            },
-            {
-                TEST_WIKI_DISCUSSION,
-                "d/f/3035/latest",
-                "The Fallout wiki - Fallout: New Vegas and more - Wikia",
-            },
-            {
-                TEST_WIKI_DISCUSSION,
-                "d/p/2594243417559008375",
-                "The Fallout wiki - Fallout: New Vegas and more - Wikia",
-            },
-        };
+  private boolean shouldSkipTestCase(int variant, boolean loggedIn) {
+    boolean isMobile = Configuration.getBrowser().contains("MOBILE");
+
+    // Check logged in / logged out
+    if (loggedIn) {
+      if (variant == VARIANT_ONLY_ANONYMOUS || variant == VARIANT_ONLY_ANONYMOUS_MOBILE) {
+        return true;
+      }
+    } else {
+      if (variant == VARIANT_ONLY_LOGGED_IN || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP) {
+        return true;
+      }
     }
+
+    // Check mobile / desktop
+    if (isMobile) {
+      if (variant == VARIANT_ONLY_DESKTOP || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP) {
+        return true;
+      }
+    } else {
+      if (variant == VARIANT_ONLY_MOBILE || variant == VARIANT_ONLY_ANONYMOUS_MOBILE) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   /**
    * Check HTML title (the contents of <title>) for anon users
@@ -232,8 +311,13 @@ public class HtmlTitleTests extends NewTestTemplate {
       dataProvider = "dataHtmlTitleTest",
       groups = "SeoHtmlTitleLoggedOut"
   )
-  public void HtmlTitleLoggedOutTest(String wiki, String path, String expectedTitle) {
-    wikiURL = urlBuilder.getUrlForPath(wiki, path);
+  public void HtmlTitleLoggedOutTest(String wiki, String path, String expectedTitle, int variant) {
+    if (shouldSkipTestCase(variant, false)) {
+      PageObjectLogging.log("SKIP", "Test case skipped", true);
+      return;
+    }
+
+    wikiURL = urlBuilder.getUrlForPathWithoutWiki(wiki, path);
     driver.get(wikiURL);
     String actualTitle = driver.getTitle();
     Assertion.assertEquals(actualTitle, expectedTitle);
@@ -247,24 +331,15 @@ public class HtmlTitleTests extends NewTestTemplate {
       groups = "SeoHtmlTitleLoggedIn"
   )
   @Execute(asUser = User.USER)
-  public void HtmlTitleLoggedInTest(String wiki, String path, String expectedTitle) {
-    wikiURL = urlBuilder.getUrlForPath(wiki, path);
+  public void HtmlTitleLoggedInTest(String wiki, String path, String expectedTitle, int variant) {
+    if (shouldSkipTestCase(variant, true)) {
+      PageObjectLogging.log("SKIP", "Test case skipped", true);
+      return;
+    }
+
+    wikiURL = urlBuilder.getUrlForPathWithoutWiki(wiki, path);
     driver.get(wikiURL);
     String actualTitle = driver.getTitle();
     Assertion.assertEquals(actualTitle, expectedTitle);
-  }
-
-  /**
-   * Check HTML title (the contents of <title>) for Mercury
-   */
-  @Test(
-      dataProvider = "dataHtmlTitleMercuryTest",
-      groups = "SeoHtmlTitleMercury"
-  )
-  public void HtmlTitleMercuryTest(String wiki, String path, String expected) {
-    wikiURL = urlBuilder.getUrlForPathWithoutWiki(wiki, path);
-    driver.get(wikiURL);
-    String title = driver.getTitle();
-    Assertion.assertEquals(title, expected);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -206,7 +206,7 @@ public class HtmlTitleTests extends NewTestTemplate {
             TEST_WIKI_CORPORATE,
             "",
             "Wikia - The Home of Fandom",
-            VARIANT_ALL,
+            VARIANT_ONLY_ANONYMOUS,
         },
         {
             TEST_WIKI_CORPORATE,

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/HtmlTitleTests.java
@@ -2,7 +2,7 @@ package com.wikia.webdriver.testcases.seotests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.User;
+import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 

--- a/src/test/java/com/wikia/webdriver/testcases/seotests/TestSkipper.java
+++ b/src/test/java/com/wikia/webdriver/testcases/seotests/TestSkipper.java
@@ -1,0 +1,61 @@
+package com.wikia.webdriver.testcases.seotests;
+
+import com.wikia.webdriver.common.core.configuration.Configuration;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
+
+public class TestSkipper {
+  public static final int VARIANT_ALL = 0;
+  public static final int VARIANT_ONLY_DESKTOP = 1;
+  public static final int VARIANT_ONLY_MOBILE = 2;
+  public static final int VARIANT_ONLY_ANONYMOUS = 3;
+  public static final int VARIANT_ONLY_ANONYMOUS_MOBILE = 4;
+  public static final int VARIANT_ONLY_LOGGED_IN = 5;
+  public static final int VARIANT_ONLY_LOGGED_IN_DESKTOP = 6;
+  public static final String LOG_NAME = "Test Skipper";
+
+  private int variant;
+
+  public TestSkipper(int variant) {
+    this.variant = variant;
+  }
+
+  private boolean isMobile() {
+    return Configuration.getBrowser().contains("MOBILE");
+  }
+
+  private boolean canRunForLoggedIn() {
+    return !(variant == VARIANT_ONLY_ANONYMOUS || variant == VARIANT_ONLY_ANONYMOUS_MOBILE);
+  }
+
+  private boolean canRunForAnonymous() {
+    return !(variant == VARIANT_ONLY_LOGGED_IN || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP);
+  }
+
+  private boolean canRunOnMobile() {
+    return !(variant == VARIANT_ONLY_DESKTOP || variant == VARIANT_ONLY_LOGGED_IN_DESKTOP);
+  }
+
+  private boolean canRunOnDesktop() {
+    return !(variant == VARIANT_ONLY_MOBILE || variant == VARIANT_ONLY_ANONYMOUS_MOBILE);
+  }
+
+  public boolean shouldSkip(boolean loggedIn) {
+    if (isMobile() && !canRunOnMobile()) {
+      PageObjectLogging.log(LOG_NAME, "This testcase should not run on mobile", true);
+      return true;
+    }
+    if (!isMobile() && !canRunOnDesktop()) {
+      PageObjectLogging.log(LOG_NAME, "This testcase should not run on desktop", true);
+      return true;
+    }
+    if (loggedIn && !canRunForLoggedIn()) {
+      PageObjectLogging.log(LOG_NAME, "This testcase should not run for logged in users", true);
+      return true;
+    }
+    if (!loggedIn && !canRunForAnonymous()) {
+      PageObjectLogging.log(LOG_NAME, "This testcase should not run for anonymous users", true);
+      return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
This pull request does two things:

* Improves verifyUserLoggedIn method by adding support for verifying user logged in in Chat (unfortunately this doesn't check the user name, just if the user is logged or not) in WikiaMobile (still used on all of the special pages!)

* Updates the HTML title tests adding a notion of variants to them. Most of the cases we want to run the test on all skins and for users both logged in and out, but for some features are not supported on given combinations and we want to skip the case if that's the case.