### PR TITLE
Disabled maps tests according to Rodrogo Molinero and Content team

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/EmbedMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/EmbedMapTests.java
@@ -22,7 +22,7 @@ public class EmbedMapTests extends NewTestTemplate {
 
   Credentials credentials = Configuration.getCredentials();
 
-  @Test(groups = {"EmbedMapTests_001", "EmbedMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"EmbedMapTests_001", "EmbedMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void EmbedMapTests_001_EmbedMapInWikiaPage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -54,7 +54,7 @@ public class EmbedMapTests extends NewTestTemplate {
     embedMapDialog.verifyBrandFooterNotVisible();
   }
 
-  @Test(groups = {"EmbedMapTests_003", "EmbedMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"EmbedMapTests_003", "EmbedMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void EmbedMapTests_003_VerifyEmbedMapCodeButton() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -73,7 +73,7 @@ public class EmbedMapTests extends NewTestTemplate {
     selectedMap.verifyEmbedMapCode(InteractiveMapPageObject.embedMapDialogButtons.LARGE);
   }
 
-  @Test(groups = {"EmbedMapTests_004", "EmbedMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"EmbedMapTests_004", "EmbedMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void EmbedMapTests_004_VerifyEmbedMapOutsideWikia() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -92,7 +92,7 @@ public class EmbedMapTests extends NewTestTemplate {
     outPage.verifyMapEmbed();
   }
 
-  @Test(groups = {"EmbedMapTests_005", "EmbedMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"EmbedMapTests_005", "EmbedMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void EmbedMapTests_005_VerifyEmbedMapContributeModals() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -107,7 +107,7 @@ public class EmbedMapTests extends NewTestTemplate {
     pinTypesDialog.verifyPinTypesDialog();
   }
 
-  @Test(groups = {"EmbedMapTests_006", "EmbedMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"EmbedMapTests_006", "EmbedMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void EmbedMapTests_006_VerifyEmbeddedMapAddPinType() {
     WikiBasePageObject base = new WikiBasePageObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/NonSpecificMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/NonSpecificMapTests.java
@@ -37,7 +37,7 @@ public class NonSpecificMapTests extends NewTestTemplate {
     selectedMap.verifyCreatedMapTitle(mapTitle);
   }
 
-  @Test(groups = {"NonSpecificMapTests_002", "NonSpecificMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"NonSpecificMapTests_002", "NonSpecificMapTests", "InteractiveMaps"})
   public void NonSpecificMapTests_002_VerifyLoginModalWhenAnon() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);
@@ -45,7 +45,7 @@ public class NonSpecificMapTests extends NewTestTemplate {
     map.verifyLoginModal();
   }
 
-  @Test(groups = {"NonSpecificMapTests_003", "NonSpecificMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"NonSpecificMapTests_003", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void NonSpecificMapTests_003_VerifyTemplateSearch() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -85,7 +85,7 @@ public class NonSpecificMapTests extends NewTestTemplate {
     specialMap.verifyCorrectPagination();
   }
 
-  @Test(groups = {"NonSpecificMapTests_006", "NonSpecificMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"NonSpecificMapTests_006", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void NonSpecificMapTests_006_VerifyLearnMoreLink() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -94,7 +94,7 @@ public class NonSpecificMapTests extends NewTestTemplate {
     createMapModal.verifyLearnMoreLinkRedirect(InteractiveMapsContent.LEARN_MORE_LINK);
   }
 
-  @Test(groups = {"NonSpecificMapTests_007", "NonSpecificMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"NonSpecificMapTests_007", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void NonSpecificMapTests_007_VerifyCreateCustomMapErrors() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -118,7 +118,7 @@ public class NonSpecificMapTests extends NewTestTemplate {
     selectedMap.verifyMapOpened();
   }
 
-  @Test(groups = {"NonSpecificMapTests_009", "NonSpecificMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"NonSpecificMapTests_009", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void NonSpecificMapTests_009_VerifyCreateMapButtonUnderContribution() {
     WikiBasePageObject base = new WikiBasePageObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/PinMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/PinMapTests.java
@@ -19,9 +19,7 @@ public class PinMapTests extends NewTestTemplate {
 
   Credentials credentials = Configuration.getCredentials();
 
-  @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
-  @Test(groups = {"PinMapTests_001", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_001", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_001_VerifyPinModalContent() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -39,10 +37,8 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap = pinDialog.clickCancelButton();
   }
 
-  @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
   @DontRun(env = {"dev", "sandbox", "preview"})
-  @Test(groups = {"PinMapTests_002", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_002", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_002_VerifySuggestionsAndAssociatedImage() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -63,9 +59,7 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap.verifyPinPopupImageIsVisible();
   }
 
-  @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
-  @Test(groups = {"PinMapTests_003", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_003", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_003_VerifyPinCreationErrors() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -86,7 +80,7 @@ public class PinMapTests extends NewTestTemplate {
   }
 
   @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
+      comment = "This maps test should not fail")
   @DontRun(env = {"dev", "sandbox", "preview"})
   @Test(groups = {"PinMapTests_004", "PinMapTests", "InteractiveMaps"},
       dependsOnMethods = "PinMapTests_006_VerifyChangePinData")
@@ -102,10 +96,8 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap.verifyPopUpVisible();
   }
 
-  @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
   @DontRun(env = {"dev", "sandbox", "preview"})
-  @Test(groups = {"PinMapTests_005", "PinMapTests", "InteractiveMaps"},
+  @Test(enabled = false, groups = {"PinMapTests_005", "PinMapTests", "InteractiveMaps"},
       dependsOnMethods = "PinMapTests_006_VerifyChangePinData")
   @Execute(asUser = User.USER)
   public void PinMapTests_005_VerifyDeletePin() {
@@ -124,10 +116,8 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap.verifyPinNotExists(pinName);
   }
 
-  @RelatedIssue(issueID = " ",
-      comment = "Functionality is being depracated NO need to test manually")
   @DontRun(env = {"dev", "sandbox", "preview"})
-  @Test(groups = {"PinMapTests_006", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_006", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_006_VerifyChangePinData() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -155,10 +145,8 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap.clickOnPin(0);
   }
 
-  @RelatedIssue(issueID = " ",
-          comment = "Functionality is being depracated NO need to test manually")
-  @DontRun(env = {"dev", "sandbox", "preview"})
-  @Test(groups = {"PinMapTests_007", "PinMapTests", "InteractiveMaps"})
+ @DontRun(env = {"dev", "sandbox", "preview"})
+  @Test(enabled = false, groups = {"PinMapTests_007", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_007_VerifyValidExternalUrlCanBeAdded() {
     WikiBasePageObject base = new WikiBasePageObject(driver);
@@ -177,7 +165,7 @@ public class PinMapTests extends NewTestTemplate {
     selectedMap.verifyUrlInNewWindow(InteractiveMapsContent.EXTERNAL_LINK);
   }
 
-  @Test(groups = {"PinMapTests_008", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_008", "PinMapTests", "InteractiveMaps"})
   @DontRun(env = {"dev", "sandbox", "preview"})
   @Execute(asUser = User.USER)
   public void PinMapTests_008_VerifyErrorMessageWhenAssociatedArticleNotExist() {
@@ -198,7 +186,7 @@ public class PinMapTests extends NewTestTemplate {
     ));
   }
 
-  @Test(groups = {"PinMapTests_009", "PinMapTests", "InteractiveMaps"})
+  @Test(enabled = false, groups = {"PinMapTests_009", "PinMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
   public void PinMapTests_009_VerifyArticlePlaceholder() {
     WikiBasePageObject base = new WikiBasePageObject(driver);


### PR DESCRIPTION
The tests are being disabled as the maps functionality will be deprecated. Until the feature is fully removed from Wikia then only the core maps functionality tests are required (the required tests being selected by the Content Team).