### PR TITLE
ADEN-2846 Update special page for videos name

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -156,7 +156,7 @@ public class AdsDataProvider {
   @DataProvider
   public static Object[][] specialPages() {
     return new Object[][]{
-        {"adtest", "Special:Video", "126608052", "wka.life/_adtest//special", "TOP_LEADERBOARD",
+        {"adtest", "Special:Videos", "126608052", "wka.life/_adtest//special", "TOP_LEADERBOARD",
          "PREFOOTER_LEFT_BOXAD", new Dimension(1292, 1000)},
         {"adtest", "Special:NewFiles", "126608052", "wka.life/_adtest//special",
          "TOP_LEADERBOARD",


### PR DESCRIPTION
`Special:Video` works but it's a redirect to `Special:Videos`. Let's remove the redirect and go straight to the right page.