### PR TITLE
Added a check for current email NOT equals to new email

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
@@ -19,6 +19,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.Pre
 import com.wikia.webdriver.pageobjectsfactory.pageobject.visualeditor.VisualEditorPageObject;
 
 import org.joda.time.DateTime;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = {"EditingPreferencesTest"})
@@ -81,7 +82,8 @@ public class EditingPreferencesTests extends NewTestTemplate {
     MailFunctions.deleteAllEmails(Configuration.getCredentials().emailQaart2,
                                   Configuration.getCredentials().emailPasswordQaart2);
 
-    Assertion.assertNotEquals(newEmailAddress, editPrefPage.getEmailAdress());
+    Assertion.assertNotEquals(newEmailAddress, editPrefPage.getEmailAdress(),
+                           "New email and old email SHOULD NOT be the same");
 
     editPrefPage.changeEmail(newEmailAddress);
     PreferencesPageObject prefPage = editPrefPage.clickSaveButton();

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
@@ -19,7 +19,6 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.Pre
 import com.wikia.webdriver.pageobjectsfactory.pageobject.visualeditor.VisualEditorPageObject;
 
 import org.joda.time.DateTime;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = {"EditingPreferencesTest"})

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
@@ -81,6 +81,8 @@ public class EditingPreferencesTests extends NewTestTemplate {
     MailFunctions.deleteAllEmails(Configuration.getCredentials().emailQaart2,
                                   Configuration.getCredentials().emailPasswordQaart2);
 
+    Assertion.assertNotEquals(newEmailAddress, editPrefPage.getEmailAdress());
+
     editPrefPage.changeEmail(newEmailAddress);
     PreferencesPageObject prefPage = editPrefPage.clickSaveButton();
     prefPage.verifyNotificationMessage();


### PR DESCRIPTION
Added a simple check if 'new email' is not the same as 'current email' - in this situation change will not trigger the mail change confirmation e-mail, and that what was causing the QAART-703 issue.