### PR TITLE
Image serving rename file fix

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/imageservingtests/ImageStorageTests.java
@@ -82,7 +82,7 @@ public class ImageStorageTests extends NewTestTemplate {
     renamePage.rename(imageNewName, true);
     file.verifyNotificationMessage();
     file.verifyHeader(imageNewName);
-    file = new FilePagePageObject(driver).open(fileName, true);
+    file = new FilePagePageObject(driver).open(imageNewName, true);
     renamePage = file.renameUsingDropdown();
     renamePage.rename(fileName, true);
     file.verifyNotificationMessage();


### PR DESCRIPTION
Just one line fix, but I created PR for you to check if I understand what test should check correctly.

Previously:
Test was uploading image A, then renaming it to B, then trying to open not existing image A and rename it to A again.

Now:
Test is uploading image A, then renaming it to B, then opens image B and renames it to A again.