### PR TITLE
Qaart 703

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
+++ b/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
@@ -1,9 +1,5 @@
 package com.wikia.webdriver.common.core;
 
-import com.wikia.webdriver.common.logging.PageObjectLogging;
-
-import org.openqa.selenium.WebDriverException;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -19,10 +15,14 @@ import javax.mail.NoSuchProviderException;
 import javax.mail.Session;
 import javax.mail.Store;
 
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.WebDriverException;
+
+import com.wikia.webdriver.common.logging.PageObjectLogging;
+
 public class MailFunctions {
 
-  private MailFunctions() {
-  }
+  private MailFunctions() {}
 
   public static String getFirstEmailContent(String userName, String password, String subject) {
     try {
@@ -134,6 +134,21 @@ public class MailFunctions {
       throw new WebDriverException("There was no match in the following content: \n" + content);
     }
 
+  }
+
+
+  /**
+   * Method generates a new "fake" email, by adding number of "+" characters before "@" symbol,
+   * this way, you can trick system that you changed email, but in fact,
+   * message will arrive to the same address
+   * @param emailAddress
+   * @return
+   */
+  public static String getEmail(String emailAddress) {
+
+    int specialsToAdd = 1 + StringUtils.countMatches(emailAddress, "+") % 3;
+    return emailAddress.replace("+", "").replace("@",
+        new String(new char[specialsToAdd]).replace("\0", "+") + "@");
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
+++ b/src/test/java/com/wikia/webdriver/common/core/MailFunctions.java
@@ -22,7 +22,8 @@ import com.wikia.webdriver.common.logging.PageObjectLogging;
 
 public class MailFunctions {
 
-  private MailFunctions() {}
+  private MailFunctions() {
+  }
 
   public static String getFirstEmailContent(String userName, String password, String subject) {
     try {
@@ -39,17 +40,20 @@ public class MailFunctions {
 
       boolean forgottenPasswordMessageFound = false;
       Message magicMessage = null;
+      
       for (int i = 0; !forgottenPasswordMessageFound; i++) {
         messages = inbox.getMessages();
 
         PageObjectLogging.log("Mail", "Waiting for the message", true);
         Thread.sleep(2000);
+        
         for (Message message : messages) {
           if (message.getSubject().contains(subject)) {
             forgottenPasswordMessageFound = true;
             magicMessage = message;
           }
         }
+        
         if (i > 15) {
           throw new WebDriverException("Mail timeout exceeded");
         }
@@ -90,6 +94,7 @@ public class MailFunctions {
       Folder inbox = store.getFolder("Inbox");
       inbox.open(Folder.READ_WRITE);
       Message messages[] = inbox.getMessages();
+      
       if (messages.length != 0) {
         for (int i = 0; i < messages.length; i++) {
           messages[i].setFlag(Flags.Flag.DELETED, true);
@@ -97,6 +102,7 @@ public class MailFunctions {
       } else {
         PageObjectLogging.log("Mail", "There are no messages in inbox", true);
       }
+      
       store.close();
     } catch (NoSuchProviderException e) {
       PageObjectLogging.log("Mail", e, false);
@@ -113,6 +119,7 @@ public class MailFunctions {
     Pattern p = Pattern.compile("button\" href3D\"http[\\s\\S]*?(?=\")"); // getting activation URL
     // from mail content
     Matcher m = p.matcher(content);
+    
     if (m.find()) {
       return m.group(0).replace("button\" href3D\"", "");
       // m.group(0) returns first match for the regexp
@@ -127,15 +134,14 @@ public class MailFunctions {
     Pattern p = Pattern.compile("below:[\\s\\S]*?(?=If)"); // getting new password
     // from mail content
     Matcher m = p.matcher(content);
+    
     if (m.find()) {
       return m.group(0).replace("below:", "");
       // m.group(0) returns first match for the regexp
     } else {
       throw new WebDriverException("There was no match in the following content: \n" + content);
     }
-
   }
-
 
   /**
    * Method generates a new "fake" email, by adding number of "+" characters before "@" symbol,
@@ -145,10 +151,9 @@ public class MailFunctions {
    * @return
    */
   public static String getEmail(String emailAddress) {
-
     int specialsToAdd = 1 + StringUtils.countMatches(emailAddress, "+") % 3;
+    
     return emailAddress.replace("+", "").replace("@",
         new String(new char[specialsToAdd]).replace("\0", "+") + "@");
   }
-
 }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
@@ -1,6 +1,5 @@
 package com.wikia.webdriver.testcases.specialpagestests;
 
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/EditingPreferencesTests.java
@@ -1,11 +1,14 @@
 package com.wikia.webdriver.testcases.specialpagestests;
 
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.MailFunctions;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -17,9 +20,6 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.ConfirmationPage
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.EditPreferencesPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.visualeditor.VisualEditorPageObject;
-
-import org.joda.time.DateTime;
-import org.testng.annotations.Test;
 
 @Test(groups = {"EditingPreferencesTest"})
 public class EditingPreferencesTests extends NewTestTemplate {
@@ -71,51 +71,30 @@ public class EditingPreferencesTests extends NewTestTemplate {
 
   @Test(groups = {"EditPreferences_004"})
   @Execute(asUser = User.USER_5)
-  @RelatedIssue(issueID = "QAART-703", comment = "Test manually")
   public void changeEmailAddress() {
-    final String newEmailAddress = Configuration.getCredentials().emailQaart2;
-    final String oldEmailAddress = Configuration.getCredentials().email;
-
     EditPreferencesPage editPrefPage = new EditPreferencesPage(driver).openEmailSection();
 
+    String newEmailAddress = MailFunctions.getEmail(editPrefPage.getEmailAdress());
+
     MailFunctions.deleteAllEmails(Configuration.getCredentials().emailQaart2,
-                                  Configuration.getCredentials().emailPasswordQaart2);
+        Configuration.getCredentials().emailPasswordQaart2);
 
     Assertion.assertNotEquals(newEmailAddress, editPrefPage.getEmailAdress(),
-                           "New email and old email SHOULD NOT be the same");
+        "New email and old email SHOULD NOT be the same");
 
     editPrefPage.changeEmail(newEmailAddress);
     PreferencesPageObject prefPage = editPrefPage.clickSaveButton();
     prefPage.verifyNotificationMessage();
 
-    ConfirmationPageObject confirmPageAlmostThere =
-        new AlmostTherePageObject(driver).enterEmailChangeLink(
-            Configuration.getCredentials().emailQaart2,
+    ConfirmationPageObject confirmPageAlmostThere = new AlmostTherePageObject(driver)
+        .enterEmailChangeLink(Configuration.getCredentials().emailQaart2,
             Configuration.getCredentials().emailPasswordQaart2);
     confirmPageAlmostThere.typeInUserName(User.USER_5.getUserName());
     confirmPageAlmostThere.typeInPassword(User.USER_5.getPassword());
-    confirmPageAlmostThere.clickSubmitButton(Configuration.getCredentials().emailQaart2,
-        Configuration.getCredentials().emailPasswordQaart2);
+    confirmPageAlmostThere.clickSubmitButton(Configuration.getCredentials().email,
+        Configuration.getCredentials().emailPassword);
 
     editPrefPage.openEmailSection();
     Assertion.assertEquals(editPrefPage.getEmailAdress(), newEmailAddress);
-
-    MailFunctions.deleteAllEmails(Configuration.getCredentials().email,
-        Configuration.getCredentials().emailPassword);
-
-    editPrefPage.changeEmail(oldEmailAddress);
-    editPrefPage.clickSaveButton();
-    prefPage.verifyNotificationMessage();
-
-    confirmPageAlmostThere =
-        new AlmostTherePageObject(driver).enterEmailChangeLink(
-            Configuration.getCredentials().email, Configuration.getCredentials().emailPassword);
-    confirmPageAlmostThere.typeInUserName(User.USER_5.getUserName());
-    confirmPageAlmostThere.typeInPassword(User.USER_5.getPassword());
-    confirmPageAlmostThere.clickSubmitButton(Configuration.getCredentials().email,
-                                             Configuration.getCredentials().emailPassword);
-
-    editPrefPage.openEmailSection();
-    Assertion.assertEquals(editPrefPage.getEmailAdress(), oldEmailAddress);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/UserAndRights.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/UserAndRights.java
@@ -56,11 +56,7 @@ public class UserAndRights extends NewTestTemplate {
   }
 
   @Test(groups = {"usersAndRights003"}, dependsOnMethods = {"staffCanBlockUser"})
-  @RelatedIssue(issueID = "QAART-703", comment = "Test Manually")
   public void blockedUserShouldBeAbleToChangeEmail() {
-    final String newEmailAddress = Configuration.getCredentials().emailQaart2;
-    final String oldEmailAddress = Configuration.getCredentials().email;
-
     EditPreferencesPage editPrefPage = new EditPreferencesPage(driver).openEmailSection();
     editPrefPage.getGlobalNavigation().openAccountNavigation().logIn(User.BLOCKED_USER);
     editPrefPage.verifyUserLoggedIn(User.BLOCKED_USER);
@@ -68,6 +64,8 @@ public class UserAndRights extends NewTestTemplate {
     editPrefPage.openEmailSection();
     MailFunctions.deleteAllEmails(Configuration.getCredentials().emailQaart2,
         Configuration.getCredentials().emailPasswordQaart2);
+
+    String newEmailAddress = MailFunctions.getEmail(editPrefPage.getEmailAdress());
 
     editPrefPage.changeEmail(newEmailAddress);
     PreferencesPageObject prefPage = editPrefPage.clickSaveButton();
@@ -84,34 +82,6 @@ public class UserAndRights extends NewTestTemplate {
 
     editPrefPage.openEmailSection();
     Assertion.assertEquals(editPrefPage.getEmailAdress(), newEmailAddress);
-
-    MailFunctions.deleteAllEmails(Configuration.getCredentials().email,
-        Configuration.getCredentials().emailPassword);
-
-    editPrefPage.changeEmail(oldEmailAddress);
-    editPrefPage.clickSaveButton();
-    prefPage.verifyNotificationMessage();
-
-    confirmPageAlmostThere =
-        new AlmostTherePageObject(driver).enterEmailChangeLink(
-            Configuration.getCredentials().email, Configuration.getCredentials().emailPassword);
-    confirmPageAlmostThere.typeInUserName(User.BLOCKED_USER.getUserName());
-    confirmPageAlmostThere.typeInPassword(User.BLOCKED_USER.getPassword());
-    confirmPageAlmostThere.clickSubmitButton(Configuration.getCredentials().email,
-        Configuration.getCredentials().emailPassword);
-
-    editPrefPage.openEmailSection();
-    Assertion.assertEquals(editPrefPage.getEmailAdress(), oldEmailAddress);
-  }
-
-  @Test(groups = {"usersAndRights003"}, dependsOnMethods = {"staffCanBlockUser"})
-  public void blockedUserShouldBeAbleToAccessSpecialContactPage() {
-    SpecialContactGeneralPage contactPage = new SpecialContactGeneralPage(driver).open();
-
-    contactPage.getGlobalNavigation().openAccountNavigation().logIn(User.BLOCKED_USER);
-    contactPage.verifyUserLoggedIn(User.BLOCKED_USER);
-
-    Assertion.assertTrue(contactPage.isLoggedInUserMessageVisible(User.BLOCKED_USER));
   }
 
   @Test(groups = {"usersAndRights004"}, dependsOnMethods = {"staffCanBlockUser"})

--- a/src/test/java/com/wikia/webdriver/testcases/specialpagestests/UserAndRights.java
+++ b/src/test/java/com/wikia/webdriver/testcases/specialpagestests/UserAndRights.java
@@ -1,10 +1,12 @@
 package com.wikia.webdriver.testcases.specialpagestests;
 
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.MailFunctions;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.properties.Credentials;
@@ -13,15 +15,11 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.editmode.VisualEditModePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.AlmostTherePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.signup.ConfirmationPageObject;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialContactGeneralPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.block.SpecialBlockListPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.block.SpecialBlockPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.block.SpecialUnblockPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.EditPreferencesPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.preferences.PreferencesPageObject;
-
-import org.joda.time.DateTime;
-import org.testng.annotations.Test;
 
 @Test(groups = {"UsersAndRights"})
 public class UserAndRights extends NewTestTemplate {


### PR DESCRIPTION
Changed test for email to use a single email box. Test is now faking email change, by putting "+" characters before "@" symbol. Tests are working stable, 10 times in a row. There is a slight change of a test crashing into each other while executing in parallel, but it should be fixed with another ticket.