### PR TITLE
adjusting test to the recent sort option change

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/discussions/PostsListPage.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/discussions/PostsListPage.java
@@ -24,10 +24,10 @@ public class PostsListPage extends WikiBasePageObject {
   @FindBy(css = ".pop-over-container")
   private WebElement sortOptionsMobile;
 
-  @FindBy(css = ".sort-options li:nth-child(1) label")
+  @FindBy(css = "label[for='sort-button-main.sort-by-trending']")
   private WebElement trendingOptionInSortMenu;
 
-  @FindBy(css = ".sort-options li:nth-child(2) label")
+  @FindBy(css = "label[for='sort-button-main.sort-by-latest']")
   private WebElement latestOptionInSortMenu;
 
   @FindBy(css = ".filters-apply")

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/discussions/PostsListPage.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/discussions/PostsListPage.java
@@ -21,14 +21,17 @@ public class PostsListPage extends WikiBasePageObject {
   @FindBy(css = ".sort span")
   private WebElement labelInSortEntryPointMobile;
 
-  @FindBy(css = ".discussion-sort")
+  @FindBy(css = ".pop-over-container")
   private WebElement sortOptionsMobile;
 
-  @FindBy(xpath = "//li[text()='Latest']")
-  private WebElement latestLinkOnListMobile;
+  @FindBy(css = ".sort-options li:nth-child(1) label")
+  private WebElement trendingOptionInSortMenu;
 
-  @FindBy(xpath = "//li[text()='Trending']")
-  private WebElement trendingLinkOnListMobile;
+  @FindBy(css = ".sort-options li:nth-child(2) label")
+  private WebElement latestOptionInSortMenu;
+
+  @FindBy(css = ".filters-apply")
+  private WebElement applyButtonInSortMenu;
 
   @FindBy(xpath = "//li[text()='Latest']")
   private WebElement latestTabOnDesktop;
@@ -100,17 +103,21 @@ public class PostsListPage extends WikiBasePageObject {
   }
 
   public PostsListPage clickLatestLinkOnMobile() {
-    latestLinkOnListMobile.click();
+    wait.forElementClickable(latestOptionInSortMenu);
+    latestOptionInSortMenu.click();
     return this;
   }
 
-  public PostsListPage clickTrendingLinkOnMobile() {
-    trendingLinkOnListMobile.click();
+  public PostsListPage clickTrendingOptionInSortMenu() {
+    wait.forElementClickable(trendingOptionInSortMenu);
+    trendingOptionInSortMenu.click();
     return this;
   }
 
-  public String getSortButtonLabel() {
-    return labelInSortEntryPointMobile.getText();
+  public PostsListPage clickApplyButton() {
+    wait.forElementClickable(applyButtonInSortMenu);
+    applyButtonInSortMenu.click();
+    return this;
   }
 
   public PostsListPage clickLatestTabOnDesktop() {
@@ -147,11 +154,6 @@ public class PostsListPage extends WikiBasePageObject {
     avatarUsername.click();
     return this;
   }
-
-  public boolean isUserPageHeaderVisible() {
-    return userPageHeader.isDisplayed();
-  }
-
 
   public boolean isUpvoteButtonVisible(int index) {
     WebElement button = replyUpvoteButton.get(index);
@@ -225,4 +227,5 @@ public class PostsListPage extends WikiBasePageObject {
   public void clickGooglePlayLinkInAppPromotion() {
     googlePlayAppLink.click();
   }
+
 }

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/Sorting.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/Sorting.java
@@ -33,7 +33,7 @@ public class Sorting extends NewTestTemplate {
    * ANONS ON DESKTOP SECTION
    */
 
-  @Test(groups = "discussions-anonUserOnDesktopCanSortPostList", enabled = false)
+  @Test(groups = "discussions-anonUserOnDesktopCanSortPostList")
   @RelatedIssue(issueID = "XW-1047")
   @Execute(asUser = User.ANONYMOUS)
   @InBrowser(browserSize = DESKTOP_RESOLUTION)
@@ -71,10 +71,13 @@ public class Sorting extends NewTestTemplate {
   public void userCanSwitchBetweenLatestAndTrendingInDropdown() {
     PostsListPage postsList = new PostsListPage(driver).open();
     Assertion.assertTrue(postsList.clickSortButtonOnMobile().isSortListVisibleMobile());
-    Assertion.assertEquals(postsList.clickTrendingLinkOnMobile().getSortButtonLabel(), "Trending");
+    postsList.clickLatestLinkOnMobile();
+    postsList.clickApplyButton();
     new com.wikia.webdriver.elements.mercury.Loading(driver).handleAsyncPageReload();
-    Assertion.assertTrue(postsList.clickSortButtonOnMobile().isSortListVisibleMobile());
-    Assertion.assertEquals(postsList.clickLatestLinkOnMobile().getSortButtonLabel(), "Latest");
+    postsList.clickSortButtonOnMobile();
+    postsList.clickTrendingOptionInSortMenu();
+    postsList.clickApplyButton();
+    new com.wikia.webdriver.elements.mercury.Loading(driver).handleAsyncPageReload();
   }
 
   public void userCanSwitchBetweenLatestAndTrendingTab() {


### PR DESCRIPTION
I've removed the check for "trending" and "latest" label as this is not the goal of the functional test. The functional test goal is to check if user can switch between tabs. It doesn't include a test of a "copies".

Both tests were stable in 20 times run verification:
http://jenkins:8080/view/Mercury/job/Mercury-TESTS-Stability/365/
http://jenkins:8080/view/Mercury/job/Mercury-TESTS-Stability/366/