### PR TITLE
adding ticket to interactive map tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/EmbedMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/EmbedMapTests.java
@@ -2,6 +2,7 @@ package com.wikia.webdriver.testcases.interactivemapstests;
 
 import com.wikia.webdriver.common.contentpatterns.InteractiveMapsContent;
 import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.properties.Credentials;
@@ -43,6 +44,8 @@ public class EmbedMapTests extends NewTestTemplate {
   }
 
   @Test(groups = {"EmbedMapTests_002", "EmbedMapTests", "InteractiveMaps"})
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+                                                 "monitor the issue to find out resolution")
   public void EmbedMapTests_002_VerifyEmbedMapElements() {
     ArticlePageObject article = new ArticlePageObject();
     article.open(InteractiveMapsContent.EMBED_MAP_ARTICLE_NAME);

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/NonSpecificMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/NonSpecificMapTests.java
@@ -24,6 +24,8 @@ public class NonSpecificMapTests extends NewTestTemplate {
 
   @Test(groups = {"NonSpecificMapTests_001", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void NonSpecificMapTests_001_ClickMapAndVerifyCorrectRedirect() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);
@@ -77,6 +79,8 @@ public class NonSpecificMapTests extends NewTestTemplate {
 
   @Test(groups = {"NonSpecificMapTests_005", "NonSpecificMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void NonSpecificMapTests_005_VerifyMapListElements() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);
@@ -109,6 +113,8 @@ public class NonSpecificMapTests extends NewTestTemplate {
   }
 
   @Test(groups = {"NonSpecificMapTests_008", "NonSpecificMapTests", "InteractiveMaps"})
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void NonSpecificMapTests_008_VerifyMapIsDisplayedForAnons() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);
@@ -138,6 +144,8 @@ public class NonSpecificMapTests extends NewTestTemplate {
   }
 
   @Test(groups = {"NonSpecificMapTests_011", "NonSpecificMapTests", "InteractiveMaps"})
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void NonSpecificMapTests_011_VerifyEscapedFragmentPageContent() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);

--- a/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/PinTypeMapTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/interactivemapstests/PinTypeMapTests.java
@@ -3,6 +3,7 @@ package com.wikia.webdriver.testcases.interactivemapstests;
 import com.wikia.webdriver.common.contentpatterns.InteractiveMapsContent;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.properties.Credentials;
@@ -20,6 +21,8 @@ public class PinTypeMapTests extends NewTestTemplate {
 
   @Test(groups = {"PinTypeMapTests_001", "PinTypeMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void PinTypeMapTests_001_VerifyImageValidationInPinTypeModal() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);
@@ -38,6 +41,8 @@ public class PinTypeMapTests extends NewTestTemplate {
 
   @Test(groups = {"PinTypeMapTests_002", "PinTypeMapTests", "InteractiveMaps"})
   @Execute(asUser = User.USER)
+  @RelatedIssue(issueID = "QAART-690", comment = "functionality status is deprecated, " +
+          "monitor the issue to find out resolution")
   public void PinTypeMapTests_002_VerifyClickingAddAnotherPinType() {
     WikiBasePageObject base = new WikiBasePageObject();
     InteractiveMapsPageObject specialMap = base.openSpecialInteractiveMaps(wikiURL);


### PR DESCRIPTION
During Jenkins Duty on preview for failure of 7 map tests I reopened an issue to handle the maps tests, that has been recently closed as resolved without giving specific information on what the resolution was. I ticketed the tests to the issue and my proposition is don’t dedicate you time to test this deprecated feature as long as there is no official resolution.
https://wikia-inc.atlassian.net/browse/QAART-690