### PR TITLE
SUS-64

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
@@ -65,7 +65,7 @@ public class LightboxComponentObject extends WikiBasePageObject {
     PageObjectLogging.log("verifyLightboxPopup", "Lightbox appeared", true);
   }
 
-  public void   verifyLightboxVideo() {
+  public void verifyLightboxVideo() {
     wait.forElementVisible(videoContainer);
     PageObjectLogging.log("verifyLightboxVideo", "Lightbox video appeared", true);
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
@@ -56,7 +56,7 @@ public class VideoComponentObject extends WikiBasePageObject {
     WebElement container = videoEmbed.findElement(By.tagName("div"));
     String containerId = "ooyalaplayer-";
     Assertion.assertStringContains(container.getAttribute("id"), containerId);
-    wait.forElementVisible(container.findElement(By.cssSelector("video.video")));
+    wait.forElementVisible(container.findElement(By.cssSelector(".video.video")));
     PageObjectLogging.log("verifyVideoOoyalaEmbed", "Ooyala video is embedded", true);
   }
 
@@ -66,7 +66,7 @@ public class VideoComponentObject extends WikiBasePageObject {
   }
 
   public void verifyVideoObjectVisible() {
-    wait.forElementVisible(videoEmbed.findElement(By.cssSelector("video.video")));
+    wait.forElementVisible(videoEmbed.findElement(By.cssSelector(".video.video")));
     PageObjectLogging.log("verifyVideoObjectVisible", "Video object is visible", true);
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/media/VideoComponentObject.java
@@ -56,7 +56,7 @@ public class VideoComponentObject extends WikiBasePageObject {
     WebElement container = videoEmbed.findElement(By.tagName("div"));
     String containerId = "ooyalaplayer-";
     Assertion.assertStringContains(container.getAttribute("id"), containerId);
-    wait.forElementVisible(container.findElement(By.cssSelector(".video.video")));
+    wait.forElementVisible(container.findElement(By.cssSelector("object.video")));
     PageObjectLogging.log("verifyVideoOoyalaEmbed", "Ooyala video is embedded", true);
   }
 
@@ -66,7 +66,7 @@ public class VideoComponentObject extends WikiBasePageObject {
   }
 
   public void verifyVideoObjectVisible() {
-    wait.forElementVisible(videoEmbed.findElement(By.cssSelector(".video.video")));
+    wait.forElementVisible(videoEmbed.findElement(By.cssSelector("object.video")));
     PageObjectLogging.log("verifyVideoObjectVisible", "Video object is visible", true);
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/mediatests/lightboxtests/LightboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mediatests/lightboxtests/LightboxTests.java
@@ -143,7 +143,6 @@ public class LightboxTests extends NewTestTemplate {
    */
   @Test(groups = "LightboxTest_008")
   @Execute(asUser = User.USER, disableFlash = "false")
-  @RelatedIssue(issueID = "SUS-64", comment = "Test is unstable. Should pass locally.")
   @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void LightboxTest_008_filepage_video() {
     SpecialVideosPageObject specialVideos =

--- a/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
@@ -2,14 +2,12 @@ package com.wikia.webdriver.testcases.mediatests.providers;
 
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.lightbox.LightboxComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.media.VideoComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialVideosPageObject;
-
 import org.testng.annotations.Test;
 
 public class PlayingVideoTests extends NewTestTemplate {
@@ -17,7 +15,6 @@ public class PlayingVideoTests extends NewTestTemplate {
   private static final String BROWSER_SIZE = "1400x720";
 
   @Test(groups = {"Media", "ProviderTests", "PlayingVideoTests", "PlayingVideoTests_001"})
-  @RelatedIssue(issueID = "MAIN-6038", comment = "Test manually")
   @Execute(onWikia = "sktest123", disableFlash = "false")
   @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void PlayingVideoTests_001_ooyala() {
@@ -38,7 +35,6 @@ public class PlayingVideoTests extends NewTestTemplate {
   }
 
   @Test(groups = {"Media", "ProviderTests", "PlayingVideoTests", "PlayingVideoTests_002"})
-  @RelatedIssue(issueID = "SUS-64", comment = "Test manually")
   @Execute(disableFlash = "false", onWikia = "sktest123")
   @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void PlayingVideoTests_002_ooyala() {
@@ -77,8 +73,6 @@ public class PlayingVideoTests extends NewTestTemplate {
   }
 
   @Test(groups = {"Media", "ProviderTests", "PlayingVideoTests", "PlayingVideoTests_005"})
-  @RelatedIssue(issueID = "SUS-64", comment = "Make sure that anyclip video "
-                                                 + "autoplays in the lightbox")
   @Execute(disableFlash = "false", onWikia = "sktest123")
   @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void PlayingVideoTests_005_anyclip() {

--- a/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
@@ -38,7 +38,7 @@ public class PlayingVideoTests extends NewTestTemplate {
   }
 
   @Test(groups = {"Media", "ProviderTests", "PlayingVideoTests", "PlayingVideoTests_002"})
-  @RelatedIssue(issueID = "MAIN-6038", comment = "Test manually")
+  @RelatedIssue(issueID = "SUS-64", comment = "Test manually")
   @Execute(disableFlash = "false", onWikia = "sktest123")
   @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void PlayingVideoTests_002_ooyala() {

--- a/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/PlayingVideoTests.java
@@ -80,7 +80,7 @@ public class PlayingVideoTests extends NewTestTemplate {
   @RelatedIssue(issueID = "SUS-64", comment = "Make sure that anyclip video "
                                                  + "autoplays in the lightbox")
   @Execute(disableFlash = "false", onWikia = "sktest123")
-  @InBrowser(browserSize = BROWSER_SIZE)
+  @InBrowser(browser = Browser.FIREFOX, browserSize = BROWSER_SIZE)
   public void PlayingVideoTests_005_anyclip() {
     int itemNumber = 0;
     String providerName = "anyclip";


### PR DESCRIPTION
* PlayingVideoTests_001_ooyala - fixed css selector
* PlayingVideoTests_002_ooyala - fixed css selector
* PlayingVideoTests_005_anyclip - force to run test in Firefox browser. It's consistent with all tests in the class now. Test failed because lightbox css selector doesn't automatically appear in DOM in Chrome when video lightbox is opened. It's global issue which is not in the scope of SUS-64. 