### PR TITLE
Remove metacafe provider check

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/VideoUrlProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/VideoUrlProvider.java
@@ -39,9 +39,6 @@ public class VideoUrlProvider {
             "http://www.hulu.com/watch/489169",
             "The Unnatural (Bob's Burgers)"
         }, {
-            "http://www.metacafe.com/watch/10859228/epic_tetris_algorithm_savor_meets_alien_love_on_tagged_node/",
-            "Epic Tetris Algorithm Savor Meets Alien Love on Tagged - NODE"
-        }, {
             "http://vimeo.com/channels/staffpicks/58024671",
             "Melt Yourself Down - Fix My Life"
         }, {


### PR DESCRIPTION
According to https://wikia-inc.atlassian.net/browse/SUS-170 we're retiring support for videos from metacafe.com provider, so I removed it from tests.