### PR TITLE
ADEN-3148 Move interstitial ads tests from adtest wiki to project43 wiki

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -860,28 +860,28 @@ public class AdsDataProvider {
   public static Object[][] interstitialOasis() {
     return new Object[][]{
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial",
             new Dimension(1920, 1080),
             new Dimension(600, 590),
             true
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(1920, 1080),
             new Dimension(300, 343),
             false
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial",
             new Dimension(800, 800),
             new Dimension(569, 564),
             true
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(800, 800),
             new Dimension(300, 343),

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -894,28 +894,28 @@ public class AdsDataProvider {
   public static Object[][] interstitialMercury() {
     return new Object[][]{
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial",
             new Dimension(600, 800),
             new Dimension(590, 491),
             true
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(600, 800),
             new Dimension(300, 258),
             false
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial",
             new Dimension(800, 500),
             new Dimension(405, 338),
             true
         },
         {
-            "adtest",
+            "project43",
             "SyntheticTests/Interstitial/NotScalable",
             new Dimension(800, 500),
             new Dimension(300, 258),


### PR DESCRIPTION
In order to make our synthetic tests more stable we want to run them on project43 wiki.