### PR TITLE
ADEN-3173 Exlude test case on non supported page by mercury

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -41,6 +41,14 @@ public class MobileAdsDataProvider {
   }
 
   @DataProvider
+  public static Object[][] kruxIntegration() {
+    return new Object[][]{
+        {"elderscrolls", "Skyrim"},
+        {"wowwiki", "Portal:Main"}
+    };
+  }
+
+  @DataProvider
   public static Object[][] dfpParamsSynthetic() {
     return new Object[][]{
         {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxIntegration.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxIntegration.java
@@ -2,6 +2,7 @@ package com.wikia.webdriver.testcases.adstests;
 
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
+import com.wikia.webdriver.common.dataprovider.mobile.MobileAdsDataProvider;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
 import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsKruxObject;
@@ -14,7 +15,7 @@ public class TestAdsKruxIntegration extends TemplateNoFirstLoad {
   private static final String KRUX_SITE_ID_MOBILE = "JTKzTN3f";
 
   @Test(
-      dataProviderClass = AdsDataProvider.class,
+      dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "kruxIntegration",
       groups = "AdsKruxIntegrationMercury"
   )


### PR DESCRIPTION
Because of disabling mercury skin on non supported namespaces (e.g. Special:Videos)