### PR TITLE
(CE-3667) Require login for all GlobalShortcuts tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/globalshortcuts/ActionExplorerTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalshortcuts/ActionExplorerTest.java
@@ -6,10 +6,11 @@ import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePageObject;
 
-@Execute(onWikia = "globalshortcuts-en")
+@Execute(asUser = User.USER, onWikia = "globalshortcuts-en")
 @InBrowser(browser = Browser.CHROME)
 public class ActionExplorerTest extends NewTestTemplate {
 

--- a/src/test/java/com/wikia/webdriver/testcases/globalshortcuts/KeyboardShortcutsTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalshortcuts/KeyboardShortcutsTest.java
@@ -9,12 +9,11 @@ import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePageObject;
 
-@Execute(onWikia = "globalshortcuts-en")
+@Execute(asUser = User.USER, onWikia = "globalshortcuts-en")
 @InBrowser(browser = Browser.CHROME)
 public class KeyboardShortcutsTest extends NewTestTemplate {
 
   @Test(groups = "globalShortcuts_keyboardShortcuts_openModalByLinkInWikiaBar_CloseModalByCloseButton")
-  @Execute(asUser = User.USER)
   public void globalShortcuts_keyboardShortcuts_openModalByLinkInWikiaBar_CloseModalByCloseButton() {
     new HomePageObject()
         .open()


### PR DESCRIPTION
GlobalShortcuts no longer loads for anon users, as such we need to ensure
the tests are run as a logged in user.

/cc @Wikia/spitfires 