### PR TITLE
ADEN-3427 Changed pattern for a wiki without recovery enabled

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsDetection.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsDetection.java
@@ -10,9 +10,9 @@ import org.testng.annotations.Test;
 public class TestAdsDetection extends TemplateNoFirstLoad {
 
   public static final String PIXEL_PATTERN_WITH_ADBLOCK =
-      "http://www\\.fallingfalcon\\.com/bcn.*deo=1.*";
+      "http://www\\..*\\.com/bcn.*deo=1.*";
   public static final String PIXEL_PATTERN_WITHOUT_ADBLOCK =
-      "http://www\\.fallingfalcon\\.com/bcn.*deo=0.*";
+      "http://www\\..*\\.com/bcn.*deo=0.*";
 
   public static final String PIXEL_PATTERN_WITH_ADBLOCK_AND_RECOVERY =
       ".*\\.wikia\\.com/__are\\?.*deo=1.*";


### PR DESCRIPTION
The detection domain changes from time to time and there is no reason to check exactly the domain. We just want to be sure the request was sent at all with the right param. The modification below do that.