### PR TITLE
DAT-4568: Fix verifyReordering test in Infobox Builder

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -350,6 +350,8 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dragging");
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
 
+    component = driver.findElements(By.cssSelector(".portable-infobox .sortable-item"));
+
     return component.get(0);
   }
 

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -2,6 +2,7 @@ package com.wikia.webdriver.elements.mercury.pages;
 
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.elements.oasis.pages.TemplateEditPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialPageObject;
 
@@ -340,6 +341,8 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     Point location = component.get(component.size() - 1).getLocation();
     Dimension size = component.get(component.size() - 1).getSize();
     Integer targetY = location.getY() + size.getHeight();
+
+    PageObjectLogging.log("TargetY", String.valueOf(targetY), true);
 
     new Actions(driver)
         .clickAndHold(draggedElement)

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -331,10 +331,6 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     return this;
   }
 
-  public WebElement getInfoboxElement(int index) {
-    return component.get(index);
-  }
-
   public WebElement dragAndDropToTheTop(WebElement draggedElement) {
     this.wait.forElementClickable(draggedElement);
 
@@ -351,6 +347,10 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
 
     return component.get(0);
+  }
+
+  public WebElement getInfoboxComponent(int index) {
+    return component.get(index);
   }
 
   public void hoverOverSectionChevron(int index) {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -2,12 +2,10 @@ package com.wikia.webdriver.elements.mercury.pages;
 
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.elements.oasis.pages.TemplateEditPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.SpecialPageObject;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -344,6 +344,7 @@ public class InfoboxBuilderPage extends SpecialPageObject {
         .release(draggedElement)
         .perform();
 
+    wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dragging");
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
 
     Assertion.assertEquals(componentToBeMovedText, component.get(0).getText());

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -330,10 +330,13 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     return this;
   }
 
-  public InfoboxBuilderPage dragAndDropToTheTop(int index) {
-    WebElement draggedElement = component.get(index);
+  public WebElement getInfoboxElement(int index) {
+    return component.get(index);
+  }
+
+  public WebElement dragAndDropToTheTop(WebElement draggedElement) {
     this.wait.forElementClickable(draggedElement);
-    String componentToBeMovedText = draggedElement.getText();
+
     Point location = component.get(component.size() - 1).getLocation();
     Dimension size = component.get(component.size() - 1).getSize();
     Integer targetY = location.getY() + size.getHeight();
@@ -347,9 +350,7 @@ public class InfoboxBuilderPage extends SpecialPageObject {
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dragging");
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
 
-    Assertion.assertEquals(componentToBeMovedText, component.get(0).getText());
-
-    return this;
+    return component.get(0);
   }
 
   public void hoverOverSectionChevron(int index) {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -338,11 +338,8 @@ public class InfoboxBuilderPage extends SpecialPageObject {
   public WebElement dragAndDropToTheTop(WebElement draggedElement) {
     this.wait.forElementClickable(draggedElement);
 
-    Point location = component.get(component.size() - 1).getLocation();
-    Dimension size = component.get(component.size() - 1).getSize();
-    Integer targetY = location.getY() + size.getHeight();
-
-    PageObjectLogging.log("TargetY", String.valueOf(targetY), true);
+    Point location = component.get(0).getLocation();
+    Integer targetY = draggedElement.getLocation().getY() - location.getY() + 10;
 
     new Actions(driver)
         .clickAndHold(draggedElement)
@@ -352,8 +349,6 @@ public class InfoboxBuilderPage extends SpecialPageObject {
 
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dragging");
     wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
-
-    component = driver.findElements(By.cssSelector(".portable-infobox .sortable-item"));
 
     return component.get(0);
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -331,20 +331,21 @@ public class InfoboxBuilderPage extends SpecialPageObject {
   }
 
   public InfoboxBuilderPage dragAndDropToTheTop(int index) {
-    this.wait.forElementClickable(component.get(index));
-    String componentToBeMovedText = component.get(index).getText();
+    WebElement draggedElement = component.get(index);
+    this.wait.forElementClickable(draggedElement);
+    String componentToBeMovedText = draggedElement.getText();
     Point location = component.get(component.size() - 1).getLocation();
     Dimension size = component.get(component.size() - 1).getSize();
     Integer targetY = location.getY() + size.getHeight();
 
     new Actions(driver)
-        .clickAndHold(component.get(index))
+        .clickAndHold(draggedElement)
         .moveByOffset(0, targetY)
-        .release(component.get(index))
+        .release(draggedElement)
         .perform();
 
-    wait.forElementClickable(component.get(component.size() - 1));
-    component.get(component.size() - 1).click();
+    wait.forValueToBeNotPresentInElementsAttribute(draggedElement, "class", "is-dropping");
+
     Assertion.assertEquals(componentToBeMovedText, component.get(0).getText());
 
     return this;

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -304,19 +304,16 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     builderSidebar.typeInInputField("Third Label");
 
     WebElement element = infoboxBuilder.getInfoboxElement(2);
-    String elementText = element.getText();
     WebElement topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(elementText, topElement.getText());
+    Assertion.assertEquals(element.getText(), topElement.getText());
 
     element = infoboxBuilder.getInfoboxElement(3);
-    elementText = element.getText();
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(elementText, topElement.getText());
+    Assertion.assertEquals(element.getText(), topElement.getText());
 
     element = infoboxBuilder.getInfoboxElement(1);
-    elementText = element.getText();
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(elementText, topElement.getText());
+    Assertion.assertEquals(element.getText(), topElement.getText());
   }
 
   @Execute(asUser = User.USER)

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -287,6 +287,7 @@ public class InfoboxBuilderTests extends NewTestTemplate {
   }
 
   @Execute(asUser = User.STAFF)
+  @Test(groups = "InfoboxBuilderFailing")
   public void verifyReordering() {
     Sidebar builderSidebar = new Sidebar();
     InfoboxBuilderPage infoboxBuilder =
@@ -294,13 +295,13 @@ public class InfoboxBuilderTests extends NewTestTemplate {
 
     builderSidebar.addRowComponent();
     infoboxBuilder.selectRowWithIndex(0);
-    builderSidebar.typeInInputField("Label 1");
+    builderSidebar.typeInInputField("First Label");
 
     infoboxBuilder.selectRowWithIndex(1);
-    builderSidebar.typeInInputField("Label 2");
+    builderSidebar.typeInInputField("Second Label");
 
     infoboxBuilder.selectRowWithIndex(2);
-    builderSidebar.typeInInputField("Label 3");
+    builderSidebar.typeInInputField("Third Label");
 
     WebElement element = infoboxBuilder.getInfoboxElement(2);
     WebElement topElement = infoboxBuilder.dragAndDropToTheTop(element);
@@ -464,6 +465,7 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     Assertion.assertTrue(template.isPermissionErrorDisplayed());
   }
 
+  @Test(groups = "InfoboxBuilderFailing")
   public void verifyOtherContentIsNotChanged() {
     Sidebar builderSidebar = new Sidebar();
     final String templateName = "Infobox_other_content";

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -303,15 +303,15 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     infoboxBuilder.selectRowWithIndex(2);
     builderSidebar.typeInInputField("Third Label");
 
-    WebElement element = infoboxBuilder.getInfoboxElement(2);
+    WebElement element = infoboxBuilder.getInfoboxComponent(2);
     WebElement topElement = infoboxBuilder.dragAndDropToTheTop(element);
     Assertion.assertEquals(element.getText(), topElement.getText());
 
-    element = infoboxBuilder.getInfoboxElement(3);
+    element = infoboxBuilder.getInfoboxComponent(3);
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
     Assertion.assertEquals(element.getText(), topElement.getText());
 
-    element = infoboxBuilder.getInfoboxElement(1);
+    element = infoboxBuilder.getInfoboxComponent(1);
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
     Assertion.assertEquals(element.getText(), topElement.getText());
   }

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -304,16 +304,19 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     builderSidebar.typeInInputField("Third Label");
 
     WebElement element = infoboxBuilder.getInfoboxElement(2);
+    String elementText = element.getText();
     WebElement topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(element.getText(), topElement.getText());
+    Assertion.assertEquals(elementText, topElement.getText());
 
     element = infoboxBuilder.getInfoboxElement(3);
+    elementText = element.getText();
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(element.getText(), topElement.getText());
+    Assertion.assertEquals(elementText, topElement.getText());
 
     element = infoboxBuilder.getInfoboxElement(1);
+    elementText = element.getText();
     topElement = infoboxBuilder.dragAndDropToTheTop(element);
-    Assertion.assertEquals(element.getText(), topElement.getText());
+    Assertion.assertEquals(elementText, topElement.getText());
   }
 
   @Execute(asUser = User.USER)

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -287,7 +287,6 @@ public class InfoboxBuilderTests extends NewTestTemplate {
   }
 
   @Execute(asUser = User.STAFF)
-  @Test(groups = "InfoboxBuilderFailing")
   public void verifyReordering() {
     Sidebar builderSidebar = new Sidebar();
     InfoboxBuilderPage infoboxBuilder =
@@ -465,7 +464,6 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     Assertion.assertTrue(template.isPermissionErrorDisplayed());
   }
 
-  @Test(groups = "InfoboxBuilderFailing")
   public void verifyOtherContentIsNotChanged() {
     Sidebar builderSidebar = new Sidebar();
     final String templateName = "Infobox_other_content";

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -286,8 +286,21 @@ public class InfoboxBuilderTests extends NewTestTemplate {
 
   @Execute(asUser = User.STAFF)
   public void verifyReordering() {
-    new InfoboxBuilderPage().openNew("InfoboxBuilderVerifyReordering")
-        .dragAndDropToTheTop(2)
+    Sidebar builderSidebar = new Sidebar();
+    InfoboxBuilderPage infoboxBuilder =
+        new InfoboxBuilderPage().openNew("InfoboxBuilderVerifyReordering");
+
+    builderSidebar.addRowComponent();
+    infoboxBuilder.selectRowWithIndex(0);
+    builderSidebar.typeInInputField("Label 1");
+
+    infoboxBuilder.selectRowWithIndex(1);
+    builderSidebar.typeInInputField("Label 2");
+
+    infoboxBuilder.selectRowWithIndex(2);
+    builderSidebar.typeInInputField("Label 3");
+
+   infoboxBuilder.dragAndDropToTheTop(2)
         .dragAndDropToTheTop(3)
         .dragAndDropToTheTop(1);
   }

--- a/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/infoboxbuilder/InfoboxBuilderTests.java
@@ -11,6 +11,8 @@ import com.wikia.webdriver.elements.oasis.pages.TemplatePage;
 import com.wikia.webdriver.elements.oasis.pages.WikiFeatures;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.PortableInfobox;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.special.themedesigner.SpecialThemeDesignerPageObject;
+
+import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -300,9 +302,17 @@ public class InfoboxBuilderTests extends NewTestTemplate {
     infoboxBuilder.selectRowWithIndex(2);
     builderSidebar.typeInInputField("Label 3");
 
-   infoboxBuilder.dragAndDropToTheTop(2)
-        .dragAndDropToTheTop(3)
-        .dragAndDropToTheTop(1);
+    WebElement element = infoboxBuilder.getInfoboxElement(2);
+    WebElement topElement = infoboxBuilder.dragAndDropToTheTop(element);
+    Assertion.assertEquals(element.getText(), topElement.getText());
+
+    element = infoboxBuilder.getInfoboxElement(3);
+    topElement = infoboxBuilder.dragAndDropToTheTop(element);
+    Assertion.assertEquals(element.getText(), topElement.getText());
+
+    element = infoboxBuilder.getInfoboxElement(1);
+    topElement = infoboxBuilder.dragAndDropToTheTop(element);
+    Assertion.assertEquals(element.getText(), topElement.getText());
   }
 
   @Execute(asUser = User.USER)


### PR DESCRIPTION
Problem here was the distance to move element to the top was calculated wrong. In IE if offset Y was negative, dragging action was cancelled.

cc @Wikia/west-wing 