### PR TITLE
DAT-4565: Mock ads for anon naviagates to RWA from menu test

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/annotations/Execute.java
+++ b/src/test/java/com/wikia/webdriver/common/core/annotations/Execute.java
@@ -17,5 +17,7 @@ public @interface Execute {
 
   String disableFlash() default "";
 
+  String mockAds() default "";
+
   String disableCommunityPageSalesPitchDialog() default "";
 }

--- a/src/test/java/com/wikia/webdriver/common/templates/core/CoreTestTemplate.java
+++ b/src/test/java/com/wikia/webdriver/common/templates/core/CoreTestTemplate.java
@@ -89,6 +89,7 @@ public abstract class CoreTestTemplate {
     if (declaringClass.isAnnotationPresent(Execute.class)) {
       setTestProperty("wikiName", declaringClass.getAnnotation(Execute.class).onWikia());
       setTestProperty("disableFlash", declaringClass.getAnnotation(Execute.class).disableFlash());
+      setTestProperty("mockAds", declaringClass.getAnnotation(Execute.class).mockAds());
       setTestProperty("disableCommunityPageSalesPitchDialog",
           declaringClass.getAnnotation(Execute.class).disableCommunityPageSalesPitchDialog());
     }
@@ -104,6 +105,7 @@ public abstract class CoreTestTemplate {
     if (method.isAnnotationPresent(Execute.class)) {
       setTestProperty("wikiName", method.getAnnotation(Execute.class).onWikia());
       setTestProperty("disableFlash", method.getAnnotation(Execute.class).disableFlash());
+      setTestProperty("mockAds", method.getAnnotation(Execute.class).mockAds());
       setTestProperty("disableCommunityPageSalesPitchDialog",
           method.getAnnotation(Execute.class).disableCommunityPageSalesPitchDialog());
     }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsInterstitialObject.java
@@ -33,6 +33,9 @@ public class AdsInterstitialObject extends AdsBaseObject {
   @FindBy(css = "div#ext-wikia-adEngine-template-modal, div.lightbox-content-inner > div")
   private WebElement interstitialAdWrapper;
 
+  @FindBy(css = ".lightbox-close-wrapper, #ext-wikia-adEngine-template-modal .close")
+  private WebElement interstitialCloseButton;
+
   public AdsInterstitialObject(WebDriver driver, String testedPage,
                                Dimension resolution) {
     super(driver, testedPage, resolution);
@@ -72,6 +75,15 @@ public class AdsInterstitialObject extends AdsBaseObject {
             SIZE_DIFFERENCE_TOLERANCE
         )
     );
+  }
+
+  public void closeInterstitial() {
+    wait.forElementClickable(interstitialCloseButton);
+    interstitialCloseButton.click();
+  }
+
+  public void verifyInterstitialIsClosed() {
+    waitForElementNotVisibleByElement(interstitialAdWrapper);
   }
 
   private boolean isSizeCorrect(int actualSize, int expectedSize) {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
@@ -54,5 +54,7 @@ public class TestAdsInterstitial extends TemplateNoFirstLoad {
     if (shouldAdBeScaled) {
       adsInterstitial.verifyAdRatio();
     }
+    adsInterstitial.closeInterstitial();
+    adsInterstitial.verifyInterstitialIsClosed();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/RecentWikiActivityTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/RecentWikiActivityTest.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 public class RecentWikiActivityTest extends NewTestTemplate {
 
   @Test(groups = "mercury_recentWikiActivity_anonNavigateToRWAfromMenu")
+  @Execute(mockAds = "true")
   public void mercury_recentWikiActivity_anonNavigateToRWAfromMenu() {
     new MainPage()
         .open()


### PR DESCRIPTION
Ad covers whole screen so it's not possible to click menu entry point

cc @Wikia/west-wing @drets @PiotrGackowski @ludwikkazmierczak 