### PR TITLE
Assert on lowercased strings

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/portableinfoboxtests/PortableInfoboxTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/portableinfoboxtests/PortableInfoboxTests.java
@@ -93,7 +93,7 @@ public class PortableInfoboxTests extends NewTestTemplate {
         .clickExternalLinkWithIndex(0)
         .getUrlAfterPageIsLoaded();
 
-    Assertion.assertEquals(externalLinkName, externalUrl);
+    Assertion.assertEquals(externalLinkName.toLowerCase(), externalUrl.toLowerCase());
   }
 
   public void verifyImagesInWhatLinksHerePage() {


### PR DESCRIPTION
Fix test by assertion on lowercased values of variables. Assertion failed when comparing links ".../fandom" with ".../Fandom".

Reviewers:
@Wikia/west-wing 