### PR TITLE
Dat 4587 - global navigation bar tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
@@ -9,6 +9,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.SearchPageObject;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
@@ -22,7 +23,7 @@ public class GlobalNavigation extends BasePageObject {
   @FindBy(css = ".gamestar-logo")
   private WebElement gameStarLink;
 
-  @FindBy(css = ".wikia-logo")
+  @FindBy(css = ".wikia-logo-container .wikia-logo")
   private WebElement wikiaLogo;
 
   @FindBy(css = "#searchSelect")
@@ -51,14 +52,9 @@ public class GlobalNavigation extends BasePageObject {
   }
 
   public HomePage clickWikiaLogo() {
-    String environment = Configuration.getEnv();
-    if (!"prod".equals(environment) && !environment.contains("dev")) {
-      WebDriverWait wait = new WebDriverWait(driver, 5);
-      wait.until(CommonExpectedConditions.valueToBePresentInElementsAttribute(wikiaLogo, "href",
-          environment));
-    }
-
+    wait.forElementVisible(wikiaLogo);
     wikiaLogo.click();
+
     return new HomePage();
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
@@ -1,20 +1,14 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.globalnav;
 
-import com.wikia.webdriver.common.core.CommonExpectedConditions;
 import com.wikia.webdriver.common.core.ElementStateHelper;
-import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.dropdowncomponentobject.DropDownComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.BasePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.SearchPageObject;
-
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
-import org.openqa.selenium.support.ui.WebDriverWait;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 public class Navigating extends NewTestTemplate {
 
   private final String EN_COMMUNITY = "muppet";
-  private final String FANDOM_URL = "http://fandom.wikia.com/";
+  private final String FANDOM_URL = "http://www.wikia.com/fandom";
 
   @DataProvider
   public Object[][] getCentralWikiaUrlForWiki() {

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
@@ -1,6 +1,7 @@
 package com.wikia.webdriver.testcases.globalnavigationbar;
 
 import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePage;
@@ -14,39 +15,18 @@ import org.testng.annotations.Test;
 @Test(groups = {"globalnavigationbar", "globalnavigationbarNavigating"})
 public class Navigating extends NewTestTemplate {
 
-  private final String EN_COMMUNITY = "muppet";
   private final String FANDOM_URL = "http://www.wikia.com/fandom";
 
-  @DataProvider
-  public Object[][] getCentralWikiaUrlForWiki() {
-    return new Object[][]{{"de.gta", "de.wikia"},
-            {"ru.elderscrolls", "ru.wikia"}, {"zh.pad", "zh-tw.wikia"}};
-  }
-
-  @Test(groups = {"wikiaLogoClickOpensCentralWiki"},
-          dataProvider = "getCentralWikiaUrlForWiki")
-  public void wikiaLogoClickOpensCentralWiki(String wikiName,
-                                             String expectedCentralUrl) {
-    HomePage homePage = new HomePage();
-    homePage.getUrl(urlBuilder.getUrlForWiki(wikiName));
-    homePage.getGlobalNavigation().clickWikiaLogo();
-
-    PageObjectLogging.log("CHECK URL", "Expected: " + urlBuilder.getUrlForWiki(expectedCentralUrl),
-            new WebDriverWait(driver, 10).until(ExpectedConditions.urlContains(urlBuilder
-                    .getUrlForWiki(expectedCentralUrl))));
-  }
-
+  @Execute(onWikia = "muppet")
   @Test(groups = {"fandomLogoClickOnEnCommunityOpensFandomWikia"})
-  public void fandomLogoClickOnEnCommunityOpensFandomWikia() {
+  public void logoClickOnEnglishCommunityOpensFandom() {
     HomePage homePage = new HomePage();
-    homePage.getUrl(urlBuilder.getUrlForWiki(EN_COMMUNITY));
     GlobalNavigation globalNav = homePage.getGlobalNavigation();
 
     Assertion.assertTrue(globalNav.isFandomLogoVisible(), "Fandom logo not visible");
 
-    globalNav.clickWikiaLogo();
+    homePage = globalNav.clickWikiaLogo();
 
-    PageObjectLogging.log("CHECK URL", "Expected: " + FANDOM_URL,
-            new WebDriverWait(driver, 10).until(ExpectedConditions.urlContains(FANDOM_URL)));
+    Assertion.assertEquals(homePage.getCurrentUrl(), FANDOM_URL);
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Navigating.java
@@ -2,14 +2,9 @@ package com.wikia.webdriver.testcases.globalnavigationbar;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.globalnav.GlobalNavigation;
-
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = {"globalnavigationbar", "globalnavigationbarNavigating"})


### PR DESCRIPTION
* Remove test for unsupported functionality (Wikia logo is now always navigating to Fandom)
* Update selector

Reviewers:
@Wikia/west-wing 