### PR TITLE
Dat 4593 - global navigation layout tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/dropdowncomponentobject/DropDownComponentObject.java
@@ -5,6 +5,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -54,24 +55,13 @@ public class DropDownComponentObject extends WikiBasePageObject {
   }
 
   public DropDownComponentObject openDropDownWithEntryPoint(final WebElement entryPoint) {
-    driver.manage().timeouts().implicitlyWait(500, TimeUnit.MILLISECONDS);
     try {
-      new WebDriverWait(driver, 20, 2000).until(new ExpectedCondition<Boolean>() {
-        @Override
-        public Boolean apply(WebDriver webDriver) {
-          if (!entryPoint.getAttribute("class").contains("active")) {
-            ((JavascriptExecutor) driver)
-                    .executeScript("$(arguments[0]).trigger('click')", entryPoint);
-            return false;
-          }
-          return true;
-        }
-      });
-    } finally {
-      restoreDeaultImplicitWait();
+      wait.forElementClickable(entryPoint);
+      PageObjectLogging.log("DropdownClickable", "Dropdown is clickable", true, driver);
+      entryPoint.click();
+    } catch (NoSuchElementException e) {
+      PageObjectLogging.log("DropdownClickable", "Dropdown is not clickable", false, driver);
     }
-
-    PageObjectLogging.log("DropdownVisible", "Dropdown is visible", true, driver);
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/globalnav/GlobalNavigation.java
@@ -32,7 +32,7 @@ public class GlobalNavigation extends BasePageObject {
   @FindBy(id = "exploreWikiaDropdown")
   private WebElement exploreWikiaDropdown;
 
-  @FindBy(css = ".global-navigation-2016 .hubs-links a")
+  @FindBy(css = ".global-navigation .hubs-links a")
   private List<WebElement> hubsLinks;
 
   @FindBy(css = ".wikia-logo__subtitle")

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Layout.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Layout.java
@@ -14,10 +14,14 @@ import java.util.Arrays;
 import java.util.List;
 
 @Test(groups = {"globalnavigationbar", "globalnavigationbarLayout"})
-public class Layout extends NewTestTemplate{
+public class Layout extends NewTestTemplate {
 
+  /**
+   * Additional 10 px are added to width dimension because of the scrollbar appearance.
+   * Dimension is used to resize the window, while test is related to viewport size.
+   */
+  private static final Dimension HUBS_OUTSIDE_DROPDOWN_RESOLUTION = new Dimension(1034, 1024);
   private static final Dimension HUBS_IN_DROPDOWN_RESOLUTION = new Dimension(768, 1024);
-  private static final Dimension HUBS_OUTSIDE_DROPDOWN_RESOLUTION = new Dimension(1024, 1024);
   private static final List<String> EXPECTED_LINKS_BIG_RESOLUTION =
       Arrays.asList("Top Communities", "Community CenFl", "START A WIKIA");
   private static final List<String> EXPECTED_LINKS_SMALL_RESOLUTION =
@@ -69,6 +73,13 @@ public class Layout extends NewTestTemplate{
 
     driver.manage().window().setSize(HUBS_OUTSIDE_DROPDOWN_RESOLUTION);
     Assertion.assertTrue(globalNav.areHubsLinksVisible());
+  }
+
+  @Test(groups = {"linksArePresentOn768x1024Resolution"})
+  public void linksAreNotPresentOn768x1024Resolution() {
+    HomePage homePage = new HomePage();
+    GlobalNavigation globalNav = new GlobalNavigation();
+    homePage.openWikiPage(this.wikiURL);
 
     driver.manage().window().setSize(HUBS_IN_DROPDOWN_RESOLUTION);
     Assertion.assertFalse(globalNav.areHubsLinksVisible());

--- a/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Layout.java
+++ b/src/test/java/com/wikia/webdriver/testcases/globalnavigationbar/Layout.java
@@ -18,14 +18,14 @@ public class Layout extends NewTestTemplate {
 
   /**
    * Additional 10 px are added to width dimension because of the scrollbar appearance.
-   * Dimension is used to resize the window, while test is related to viewport size.
+   * Dimension is used to resize the window, while test is verifying viewport size.
    */
   private static final Dimension HUBS_OUTSIDE_DROPDOWN_RESOLUTION = new Dimension(1034, 1024);
   private static final Dimension HUBS_IN_DROPDOWN_RESOLUTION = new Dimension(768, 1024);
   private static final List<String> EXPECTED_LINKS_BIG_RESOLUTION =
-      Arrays.asList("Top Communities", "Community CenFl", "START A WIKIA");
+      Arrays.asList("Trending Wikias", "Community Central");
   private static final List<String> EXPECTED_LINKS_SMALL_RESOLUTION =
-      Arrays.asList("Games", "Movies", "TV", "Top Communities", "Community Central", "START A WIKIA");
+      Arrays.asList("Games", "Movies", "TV", "Trending Wikias", "Community Central");
 
   private final static String deWikiName = "de.gta";
   private static final Dimension HIDE_LOGO_RESOLUTION = new Dimension(1200, 720);
@@ -38,8 +38,8 @@ public class Layout extends NewTestTemplate {
     wikiActivity.verifyGlobalNavigation();
   }
 
-  @Test(groups = {"dropdownContainsExpectedLinksOnResolutionChange"})
-  public void dropdownContainsExpectedLinksOnResolutionChange() {
+  @Test(groups = {"verifyDropdownLinksOn1024x1024Resolution"})
+  public void verifyDropdownLinksOn1024x1024Resolution() {
     HomePage homePage = new HomePage();
     GlobalNavigation globalNav = new GlobalNavigation();
     homePage.openWikiPage(this.wikiURL);
@@ -49,14 +49,21 @@ public class Layout extends NewTestTemplate {
     globalNav.openExploreWikiaDropdown();
     Assertion.assertEquals(globalNav.getDropdownLinks(), EXPECTED_LINKS_BIG_RESOLUTION);
     globalNav.closeDropdown();
+  }
+
+  @Test(groups = {"verifyDropdownLinksOn768x1024Resolution"})
+  public void verifyDropdownLinksOn768x1024Resolution() {
+    HomePage homePage = new HomePage();
+    GlobalNavigation globalNav = new GlobalNavigation();
+    homePage.openWikiPage(this.wikiURL);
 
     driver.manage().window().setSize(HUBS_IN_DROPDOWN_RESOLUTION);
     globalNav.openExploreWikiaDropdown();
     Assertion.assertEquals(globalNav.getDropdownLinks(), EXPECTED_LINKS_SMALL_RESOLUTION);
   }
 
-  @Test(groups = {"gameStarLogoIsNotPresentOn768x1024WidthResolution"})
-  public void gameStarLogoIsNotPresentOn768x1024WidthResolution() {
+  @Test(groups = {"gameStarLogoIsNotPresentOn768x1024Resolution"})
+  public void gameStarLogoIsNotPresentOn768x1024Resolution() {
     HomePage homePage = new HomePage();
     homePage.openWikiPage(urlBuilder.getUrlForWiki(deWikiName));
     homePage.resizeWindow(HIDE_LOGO_RESOLUTION);


### PR DESCRIPTION
- Add scrollbar width to desired dimension. Window is resized to that dimension although test is based on viewport size. That's why I decided to add scrollbar width there and put comment.
- Simplify method for opening dropdown component. It caused to wait everytime for 20 s.

Reviewers:
@Wikia/west-wing 