### PR TITLE
Dat 4596 - mobile top leaderboard tests for pages w/o Infobox

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -49,7 +49,7 @@ public class MobileAdsDataProvider {
   public static Object[][] leaderboardSlotOnPageWithoutInfobox() {
     return new Object[][]{
         {
-            "project43", "SyntheticTests/Mercury/Slots/Leaderboard below page header",
+            "project43", "SyntheticTests/Mercury/Slots/Leaderboard_below_page_header",
             "wka.life/_project43//article"
         }
     };

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -36,6 +36,26 @@ public class MobileAdsDataProvider {
   }
 
   @DataProvider
+  public static Object[][] leaderboardSlotOnPageWithInfobox() {
+    return new Object[][]{
+        {
+            "project43", "SyntheticTests/Mercury/Slots/Leaderboard_below_infobox",
+            "wka.life/_project43//article"
+        }
+    };
+  }
+
+  @DataProvider
+  public static Object[][] leaderboardSlotOnPageWithoutInfobox() {
+    return new Object[][]{
+        {
+            "project43", "SyntheticTests/Mercury/Slots/Leaderboard below page header",
+            "wka.life/_project43//article"
+        }
+    };
+  }
+
+  @DataProvider
   public static Object[][] allSlots() {
     return new Object[][]{
         {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -533,4 +533,20 @@ public class BasePageObject {
     List<String> tabs = new ArrayList<String>(driver.getWindowHandles());
     driver.switchTo().window(tabs.get(tabs.size() - 1));
   }
+
+
+  public Point getElementLocationByCssSelector(String elementName) {
+    WebElement element = driver.findElement(By.cssSelector(elementName));
+    wait.forElementVisible(element);
+
+    return element.getLocation();
+  }
+
+  public Dimension getElementSizeByCssSelector(String elementName) {
+    WebElement element = driver.findElement(By.cssSelector(elementName));
+    wait.forElementVisible(element);
+
+    return element.getSize();
+  }
+
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -534,19 +534,16 @@ public class BasePageObject {
     driver.switchTo().window(tabs.get(tabs.size() - 1));
   }
 
-
-  public Point getElementLocationByCssSelector(String elementName) {
+  public int getElementBottomPositionByCssSelector(String elementName) {
     WebElement element = driver.findElement(By.cssSelector(elementName));
-    wait.forElementVisible(element);
 
-    return element.getLocation();
+    return element.getLocation().getY() + element.getSize().getHeight();
   }
 
-  public Dimension getElementSizeByCssSelector(String elementName) {
+  public int getElementTopPositionByCssSelector(String elementName) {
     WebElement element = driver.findElement(By.cssSelector(elementName));
-    wait.forElementVisible(element);
 
-    return element.getSize();
+    return element.getLocation().getY();
   }
 
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -59,7 +59,6 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.Point;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -59,6 +59,7 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -94,12 +94,10 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
-    int infoboxYPosition = infobox.getElementLocationByCssSelector(PORTABLE_INFOBOX).getY();
-    int infoboxHeight = infobox.getElementSizeByCssSelector(PORTABLE_INFOBOX).getHeight();
-    int leaderboardTopYPosition =
-        ads.getElementLocationByCssSelector(MOBILE_TOP_LEADERBOARD_ID).getY();
-
-    Assertion.assertTrue(leaderboardTopYPosition >= (infoboxHeight + infoboxYPosition));
+    Assertion.assertTrue(
+        ads.getElementTopPositionByCssSelector(MOBILE_TOP_LEADERBOARD_ID) >=
+        infobox.getElementBottomPositionByCssSelector(PORTABLE_INFOBOX)
+    );
   }
 
   @InBrowser(
@@ -120,12 +118,10 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
-    int headerYPosition = ads.getElementLocationByCssSelector(ARTICLE_HEADER).getY();
-    int headerHeight = ads.getElementSizeByCssSelector(ARTICLE_HEADER).getHeight();
-    int leaderboardTopYPosition =
-        ads.getElementLocationByCssSelector(MOBILE_TOP_LEADERBOARD_ID).getY();
-
-    Assertion.assertTrue(leaderboardTopYPosition >= (headerYPosition + headerHeight));
+    Assertion.assertTrue(
+        ads.getElementTopPositionByCssSelector(MOBILE_TOP_LEADERBOARD_ID) >=
+        ads.getElementBottomPositionByCssSelector(ARTICLE_HEADER)
+    );
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.testcases.adstests;
 
+import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.drivers.Browser;
@@ -18,7 +19,6 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
   private static final String SRC = "mobile";
   private static final String PORTABLE_INFOBOX = ".portable-infobox";
   private static final String ARTICLE_HEADER = ".wiki-page-header";
-  private static final String MOBILE_TOP_LEADERBOARD_ID = "#MOBILE_TOP_LEADERBOARD";
 
   @Test(
       groups = "AdsSlotsMercury",
@@ -95,8 +95,8 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
     Assertion.assertTrue(
-        ads.getElementTopPositionByCssSelector(MOBILE_TOP_LEADERBOARD_ID) >=
-        infobox.getElementBottomPositionByCssSelector(PORTABLE_INFOBOX)
+        ads.getElementTopPositionByCssSelector(AdsContent.getSlotSelector(AdsContent.MOBILETOP_LB))
+        >= infobox.getElementBottomPositionByCssSelector(PORTABLE_INFOBOX)
     );
   }
 
@@ -119,8 +119,8 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
     Assertion.assertTrue(
-        ads.getElementTopPositionByCssSelector(MOBILE_TOP_LEADERBOARD_ID) >=
-        ads.getElementBottomPositionByCssSelector(ARTICLE_HEADER)
+        ads.getElementTopPositionByCssSelector(AdsContent.getSlotSelector(AdsContent.MOBILETOP_LB))
+        >= ads.getElementBottomPositionByCssSelector(ARTICLE_HEADER)
     );
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -85,12 +85,11 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
-    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, CREATIVE_IMAGE_URL);
 
     Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
     Point infoboxLocation = driver.findElement(By.className("portable-infobox")).getLocation();
-    
-    Assertion.assertTrue(leaderboardLocation.getY() < infoboxLocation.getY());
+
+    Assertion.assertTrue(leaderboardLocation.getY() > infoboxLocation.getY());
   }
 
   @Test(
@@ -106,12 +105,11 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
-    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, CREATIVE_IMAGE_URL);
 
     Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
     Point pageHeader = driver.findElement(By.className("wiki-page-header")).getLocation();
 
-    Assertion.assertTrue(leaderboardLocation.getY() < pageHeader.getY());
+    Assertion.assertTrue(leaderboardLocation.getY() > pageHeader.getY());
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -1,9 +1,13 @@
 package com.wikia.webdriver.testcases.adstests;
 
+import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.dataprovider.mobile.MobileAdsDataProvider;
 import com.wikia.webdriver.common.templates.mobile.MobileTestTemplate;
+import com.wikia.webdriver.elements.mercury.old.PortableInfoboxObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.mobile.MobileAdsBaseObject;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.Point;
 import org.testng.annotations.Test;
 
 public class TestAdsSlotsMercury extends MobileTestTemplate {
@@ -66,6 +70,48 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, CREATIVE_IMAGE_URL);
     ads.verifyImgAdLoadedInSlot(MOBILE_IN_CONTENT, CREATIVE_IMAGE_URL);
     ads.verifyNoSlotPresent(MOBILE_PREFOOTER);
+  }
+
+  @Test(
+      groups = "AdsSlotsMercury",
+      dataProviderClass = MobileAdsDataProvider.class,
+      dataProvider = "leaderboardSlotOnPageWithInfobox"
+  )
+  public void adsLeaderboardOnPageWithInfobox(String wikiName,
+                                               String article,
+                                               String adUnit) {
+
+    String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+    MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+
+    ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
+    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, CREATIVE_IMAGE_URL);
+
+    Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
+    Point infoboxLocation = driver.findElement(By.className("portable-infobox")).getLocation();
+    
+    Assertion.assertTrue(leaderboardLocation.getY() < infoboxLocation.getY());
+  }
+
+  @Test(
+      groups = "AdsSlotsMercury",
+      dataProviderClass = MobileAdsDataProvider.class,
+      dataProvider = "leaderboardSlotOnPageWithoutInfobox"
+  )
+  public void adsLeaderboardOnPageWithoutInfobox(String wikiName,
+                                              String article,
+                                              String adUnit) {
+
+    String testedPage = urlBuilder.getUrlForPath(wikiName, article);
+    MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+
+    ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
+    ads.verifyImgAdLoadedInSlot(MOBILE_TOP_LEADERBOARD, CREATIVE_IMAGE_URL);
+
+    Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
+    Point pageHeader = driver.findElement(By.className("wiki-page-header")).getLocation();
+
+    Assertion.assertTrue(leaderboardLocation.getY() < pageHeader.getY());
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -1,11 +1,13 @@
 package com.wikia.webdriver.testcases.adstests;
 
 import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.dataprovider.mobile.MobileAdsDataProvider;
 import com.wikia.webdriver.common.templates.mobile.MobileTestTemplate;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.PortableInfobox;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.mobile.MobileAdsBaseObject;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Point;
 import org.testng.annotations.Test;
 
 public class TestAdsSlotsMercury extends MobileTestTemplate {
@@ -14,6 +16,9 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
   private static final String MOBILE_IN_CONTENT = "MOBILE_IN_CONTENT";
   private static final String MOBILE_PREFOOTER = "MOBILE_PREFOOTER";
   private static final String SRC = "mobile";
+  private static final String PORTABLE_INFOBOX = ".portable-infobox";
+  private static final String ARTICLE_HEADER = ".wiki-page-header";
+  private static final String MOBILE_TOP_LEADERBOARD_ID = "#MOBILE_TOP_LEADERBOARD";
 
   @Test(
       groups = "AdsSlotsMercury",
@@ -70,44 +75,57 @@ public class TestAdsSlotsMercury extends MobileTestTemplate {
     ads.verifyNoSlotPresent(MOBILE_PREFOOTER);
   }
 
+  @InBrowser(
+      browser = Browser.CHROME,
+      emulator = Emulator.GOOGLE_NEXUS_5
+  )
   @Test(
       groups = "AdsSlotsMercury",
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardSlotOnPageWithInfobox"
   )
   public void adsLeaderboardOnPageWithInfobox(String wikiName,
-                                               String article,
-                                               String adUnit) {
+                                              String article,
+                                              String adUnit) {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
+    PortableInfobox infobox = new PortableInfobox();
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
-    Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
-    Point infoboxLocation = driver.findElement(By.className("portable-infobox")).getLocation();
+    int infoboxYPosition = infobox.getElementLocationByCssSelector(PORTABLE_INFOBOX).getY();
+    int infoboxHeight = infobox.getElementSizeByCssSelector(PORTABLE_INFOBOX).getHeight();
+    int leaderboardTopYPosition =
+        ads.getElementLocationByCssSelector(MOBILE_TOP_LEADERBOARD_ID).getY();
 
-    Assertion.assertTrue(leaderboardLocation.getY() > infoboxLocation.getY());
+    Assertion.assertTrue(leaderboardTopYPosition >= (infoboxHeight + infoboxYPosition));
   }
 
+  @InBrowser(
+      browser = Browser.CHROME,
+      emulator = Emulator.GOOGLE_NEXUS_5
+  )
   @Test(
       groups = "AdsSlotsMercury",
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "leaderboardSlotOnPageWithoutInfobox"
   )
   public void adsLeaderboardOnPageWithoutInfobox(String wikiName,
-                                              String article,
-                                              String adUnit) {
+                                                 String article,
+                                                 String adUnit) {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     MobileAdsBaseObject ads = new MobileAdsBaseObject(driver, testedPage);
 
     ads.verifyGptIframe(adUnit, MOBILE_TOP_LEADERBOARD, SRC);
 
-    Point leaderboardLocation = driver.findElement(By.id(MOBILE_TOP_LEADERBOARD)).getLocation();
-    Point pageHeader = driver.findElement(By.className("wiki-page-header")).getLocation();
+    int headerYPosition = ads.getElementLocationByCssSelector(ARTICLE_HEADER).getY();
+    int headerHeight = ads.getElementSizeByCssSelector(ARTICLE_HEADER).getHeight();
+    int leaderboardTopYPosition =
+        ads.getElementLocationByCssSelector(MOBILE_TOP_LEADERBOARD_ID).getY();
 
-    Assertion.assertTrue(leaderboardLocation.getY() > pageHeader.getY());
+    Assertion.assertTrue(leaderboardTopYPosition >= (headerYPosition + headerHeight));
   }
 
   @Test(

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsMercury.java
@@ -3,9 +3,7 @@ package com.wikia.webdriver.testcases.adstests;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.dataprovider.mobile.MobileAdsDataProvider;
 import com.wikia.webdriver.common.templates.mobile.MobileTestTemplate;
-import com.wikia.webdriver.elements.mercury.old.PortableInfoboxObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.mobile.MobileAdsBaseObject;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.Point;
 import org.testng.annotations.Test;


### PR DESCRIPTION
Add two tests which corresponds to move of Mobile Top Leaderboard ad on:
- pages with Infoboxes below the Infobox
- pages without Infoboxes below page header. 

Reviewers:
@Wikia/west-wing @drets @PiotrGackowski 