### PR TITLE
SUS-700 update wam_005_testDatePicker for new contract

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -196,7 +196,7 @@ public class WamPageObject extends BasePageObject {
     String latestDate =
             DateTimeFormat.forPattern("MMMM d, yyyy").withLocale(Locale.ENGLISH)
                     .print(DateTime.now().minus(Period.days(2)).withZone(DateTimeZone.UTC));
-    Assertion.assertEquals(latestDate, currentDate, "Current date and the latest possible date are not the same");
+    Assertion.assertEquals(currentDate, latestDate, "Current date and the latest possible date are not the same");
   }
 
   public String changeDateToLastMonth() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -8,6 +8,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.BasePageObject;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
+import org.joda.time.Period;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -190,12 +190,12 @@ public class WamPageObject extends BasePageObject {
     return selectedHeaderName.getText();
   }
 
-  public void verifyTodayDateInDatePicker() {
+  public void verifyLatestDateInDatePicker() {
     String currentDate = datePickerInput.getAttribute("value");
-    String todayDate =
+    String latestDate =
             DateTimeFormat.forPattern("MMMM d, yyyy").withLocale(Locale.ENGLISH)
-                    .print(DateTime.now().withZone(DateTimeZone.UTC));
-    Assertion.assertEquals(todayDate, currentDate, "Current date and today date are not the same");
+                    .print(DateTime.now().minus(Period.days(2)).withZone(DateTimeZone.UTC));
+    Assertion.assertEquals(latestDate, currentDate, "Current date and the latest possible date are not the same");
   }
 
   public String changeDateToLastMonth() {

--- a/src/test/java/com/wikia/webdriver/testcases/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wampagetests/WamPageTests.java
@@ -61,7 +61,7 @@ public class WamPageTests extends NewTestTemplate {
   @Test(groups = {"wamPage_005", "WamPageTests"})
   @RelatedIssue(issueID = "MAIN-7392", comment = "test manually. Unable to reproduce defect")
   public void wam_005_testDatePicker() {
-    wam.verifyTodayDateInDatePicker();
+    wam.verifyLatestDateInDatePicker();
     String lastMonthDate = wam.changeDateToLastMonth();
     wam.verifyDateInDatePicker(lastMonthDate);
     String date = "July 12, 2014";


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-700

The contract changed. The latest day show on the WAM page was _now_, is _2 days ago_. This change updates the tests.

The tests fail for the `master` branch: http://jenkins.wikia-prod:8080/view/Sustaining/view/Sustaining%20Production%20Status/job/sustaining-wam-page-prod/98/

The tests pass for the `SUS-700` branch: http://jenkins.wikia-prod:8080/view/Sustaining/view/Sustaining%20Production%20Status/job/sustaining-wam-page-prod/97/

@ludwikkazmierczak 