### PR TITLE
ADEN-3644 Fix for monitoring and infobox change

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/imageutilities/ImageEditor.java
+++ b/src/test/java/com/wikia/webdriver/common/core/imageutilities/ImageEditor.java
@@ -44,6 +44,14 @@ public class ImageEditor {
     if (height < 1) {
       height = 1;
     }
+    // workaround for whenever WebElement.getLocation() return negatives
+    // https://github.com/Wikia/selenium-tests/blob/9d00f02ba24391534a80520908c2973d9e6bed86/src/test/java/com/wikia/webdriver/common/core/imageutilities/Shooter.java#L46
+    if (start.getX() < 0) {
+      start.move(0, start.getY());
+    }
+    if (start.getY() < 0) {
+      start.move(start.getX(), 0);
+    }
     BufferedImage dest = image.getSubimage(
         start.getX(), start.getY(), width, height
     );

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -19,6 +19,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
                                                      "[style*='left: 0'][style*='bottom: auto'][style*='right: auto']";
   private static final String MERCURY_ARTICLE_CONTAINER_SELECTOR = "#ember-container";
   private static final String INTERSTITIAL_AD_OPENED_SELECTOR = ".ember-view.lightbox-wrapper.open";
+  private static final String MOBILE_TOP_LEADERBOARD_ID = "MOBILE_TOP_LEADERBOARD";
 
   private AdsComparison adsComparison;
 
@@ -44,8 +45,7 @@ public class MobileAdsBaseObject extends AdsBaseObject {
       return;
     }
     waitForSlotExpanded(presentLeaderboard);
-
-    scrollToSlotOnMobile(presentLeaderboardSelector);
+    scrollToSlotOnMobile(MOBILE_TOP_LEADERBOARD_ID);
 
     if (!adsComparison.isAdVisible(presentLeaderboard, presentLeaderboardSelector, driver)) {
       extractGptInfo(presentLeaderboardSelector);
@@ -139,8 +139,10 @@ public class MobileAdsBaseObject extends AdsBaseObject {
   private void scrollToSlotOnMobile(String slotName) {
     JavascriptExecutor js = (JavascriptExecutor) driver;
     js.executeScript(
-        "var elementY = document.getElementById(arguments[0]).offsetTop;" +
-        "window.scrollTo(0, elementY);",
+        "var element = document.getElementById(arguments[0]);" +
+        "var elementY = element.offsetTop;" +
+        "var elementH = element.offsetHeight;" +
+        "window.scrollTo(0, elementY - elementH);",
         slotName
     );
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/mobile/MobileAdsBaseObject.java
@@ -45,6 +45,8 @@ public class MobileAdsBaseObject extends AdsBaseObject {
     }
     waitForSlotExpanded(presentLeaderboard);
 
+    scrollToSlotOnMobile(presentLeaderboardSelector);
+
     if (!adsComparison.isAdVisible(presentLeaderboard, presentLeaderboardSelector, driver)) {
       extractGptInfo(presentLeaderboardSelector);
 


### PR DESCRIPTION
After the change which moved `MOBILE_TOP_LEADERBOARD` below Portable Infobox (PI) our monitoring tests started to fail on some wikis (those with PI enabled).