### PR TITLE
ADEN-3683 Make ads-tracking-pixels-mercury stable

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
@@ -7,14 +7,14 @@ import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
-import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
+import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsKruxObject;
 
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class TestAdsKruxSegments extends TemplateNoFirstLoad {
+public class TestAdsKruxSegments extends NewTestTemplate {
 
   /**
    * Krux loads after onload event happens.

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
@@ -4,6 +4,7 @@ import static com.wikia.webdriver.common.core.Assertion.assertStringContains;
 import static com.wikia.webdriver.common.core.Assertion.assertStringNotContains;
 
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
@@ -26,6 +27,7 @@ public class TestAdsKruxSegments extends TemplateNoFirstLoad {
   private static final String NO_ADS_URL_PARAM =
       "InstantGlobals.wgSitewideDisableGpt=1&InstantGlobals.wgSitewideDisableLiftium=1";
 
+  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "kruxSegments",

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
@@ -4,17 +4,16 @@ import static com.wikia.webdriver.common.core.Assertion.assertStringContains;
 import static com.wikia.webdriver.common.core.Assertion.assertStringNotContains;
 
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
-import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
-import com.wikia.webdriver.common.templates.NewTestTemplate;
+import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsKruxObject;
 
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class TestAdsKruxSegments extends NewTestTemplate {
+public class TestAdsKruxSegments extends TemplateNoFirstLoad {
 
   /**
    * Krux loads after onload event happens.
@@ -27,7 +26,6 @@ public class TestAdsKruxSegments extends NewTestTemplate {
   private static final String NO_ADS_URL_PARAM =
       "InstantGlobals.wgSitewideDisableGpt=1&InstantGlobals.wgSitewideDisableLiftium=1";
 
-  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "kruxSegments",

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
@@ -2,6 +2,7 @@ package com.wikia.webdriver.testcases.adstests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.DontRun;
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.annotations.NetworkTrafficDump;
 import com.wikia.webdriver.common.core.drivers.Browser;
@@ -10,9 +11,6 @@ import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
 import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
-import com.wikia.webdriver.elements.mercury.components.Navigation;
-import com.wikia.webdriver.elements.mercury.components.TopBar;
-import com.wikia.webdriver.elements.mercury.old.JoinPageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsBaseObject;
 
 import org.testng.annotations.Test;
@@ -32,6 +30,7 @@ public class TestAdsTrackingPixels extends TemplateNoFirstLoad {
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "adsTrackingPixelsOnConsecutivePages"
   )
+  @Execute(mockAds = "true")
   public void adsTrackingPixelsOnConsecutivePages(Page page, String[] articles, String[] urls) {
     // Check tracking pixels on first page view
     networkTrafficInterceptor.startIntercepting();
@@ -53,6 +52,7 @@ public class TestAdsTrackingPixels extends TemplateNoFirstLoad {
 
   @UseUnstablePageLoadStrategy
   @NetworkTrafficDump
+  @Execute(mockAds = "true")
   @Test(
       groups = "AdsTrackingPixels",
       dataProviderClass = AdsDataProvider.class,
@@ -68,6 +68,7 @@ public class TestAdsTrackingPixels extends TemplateNoFirstLoad {
   }
 
   @NetworkTrafficDump
+  @Execute(mockAds = "true")
   @Test(
       groups = "AdsTrackingPixels",
       dataProviderClass = AdsDataProvider.class,
@@ -83,6 +84,7 @@ public class TestAdsTrackingPixels extends TemplateNoFirstLoad {
   }
 
   @NetworkTrafficDump
+  @Execute(mockAds = "true")
   @Test(
       groups = "AdsTrackingPixelsCuratedMainPage",
       dataProviderClass = AdsDataProvider.class,

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
@@ -10,12 +10,12 @@ import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
-import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
+import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsBaseObject;
 
 import org.testng.annotations.Test;
 
-public class TestAdsTrackingPixels extends TemplateNoFirstLoad {
+public class TestAdsTrackingPixels extends NewTestTemplate {
 
   public static final String COMSCORE_PIXEL_URL = "http://b.scorecardresearch.com/b";
   public static final String GA_PIXEL_URL = "http://www.google-analytics.com/collect";


### PR DESCRIPTION
The changes mock ads explicitly methods in `TestAdsTrackingPixels` class, so we test pixels with mocked ads served from DFP, not with indirect ads which sometimes can kill our QA VMs.