### PR TITLE
WW-162 | disabling tests for NCF dialog

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/communitypagetests/CommunityPageSalesPitchDialogTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/communitypagetests/CommunityPageSalesPitchDialogTests.java
@@ -3,13 +3,15 @@ package com.wikia.webdriver.testcases.communitypagetests;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.communitypage.SalesPitchDialog;
 import org.testng.annotations.Test;
 
-@Test(groups = "CommunityPageTests")
+// disabling as feature is also disabled
+@Test(groups = "CommunityPageTests", enabled = false)
 @Execute(onWikia = "mediawiki119")
 public class CommunityPageSalesPitchDialogTests extends NewTestTemplate {
 

--- a/src/test/java/com/wikia/webdriver/testcases/communitypagetests/CommunityPageSalesPitchDialogTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/communitypagetests/CommunityPageSalesPitchDialogTests.java
@@ -3,11 +3,11 @@ package com.wikia.webdriver.testcases.communitypagetests;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.communitypage.SalesPitchDialog;
+
 import org.testng.annotations.Test;
 
 // disabling as feature is also disabled


### PR DESCRIPTION
Tickets: 
* https://wikia-inc.atlassian.net/browse/WW-162
* https://wikia-inc.atlassian.net/browse/WW-124

NCF dialog is disabled so we are disabling its tests.

@Wikia/west-wing @nikodamn 