### PR TITLE
SUS-700 Remove checking date picker dialog in wam page

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -199,25 +199,6 @@ public class WamPageObject extends BasePageObject {
     Assertion.assertEquals(currentDate, latestDate, "Current date and the latest possible date are not the same");
   }
 
-  public String changeDateToLastMonth() {
-    scrollAndClick(datePickerInput);
-    wait.forElementVisible(calendarElement);
-    previousMonthArrow.click();
-    DateTime date = DateTime.now().minusMonths(1);
-    String previousMonth = DateTimeFormat.forPattern("MMMM").withLocale(Locale.ENGLISH).print(date);
-    wait.forTextInElement(monthInCalendar, previousMonth);
-
-    // first day of the current month
-    WebElement firstDay = (WebElement) jsActions.execute(
-            "return $(arguments[0]).find('.ui-state-default:not(.ui-priority-secondary):nth(0)')[0]",
-            calendarElement);
-    firstDay.click();
-
-    String year = DateTimeFormat.forPattern("YYYY").print(date);
-
-    return previousMonth + " 1, " + year;
-  }
-
   public void verifyDateInDatePicker(String date) {
     isLoaded();
     String currentDate = datePickerInput.getAttribute("value");

--- a/src/test/java/com/wikia/webdriver/testcases/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/wampagetests/WamPageTests.java
@@ -63,8 +63,6 @@ public class WamPageTests extends NewTestTemplate {
   @RelatedIssue(issueID = "MAIN-7392", comment = "test manually. Unable to reproduce defect")
   public void wam_005_testDatePicker() {
     wam.verifyLatestDateInDatePicker();
-    String lastMonthDate = wam.changeDateToLastMonth();
-    wam.verifyDateInDatePicker(lastMonthDate);
     String date = "July 12, 2014";
     wam.typeDateInDatePicker(date);
     wam.verifyDateInDatePicker(date);


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-700

Date picker dialog is not available on WAM page anymore. Currently date can be changed only by replacing date with new one in date input. Also WAM page is deprecated.
PR contains:
* removing test part that changes date by date picker dialog