### PR TITLE
SUS-789 Remove support for GameStar video provider

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/VideoUrlProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/VideoUrlProvider.java
@@ -33,9 +33,6 @@ public class VideoUrlProvider {
             "http://www.dailymotion.com/video/x101vdw_robert-pattison-y-kristen-stewart-se-dan-un-tiempo_people#.UZovsrWnqXw",
             "Robert Pattison y Kristen Stewart se dan un tiempo"
         }, {
-            "http://www.gamestar.de/videos/action,9/batman-arkham-origins,70131.html",
-            "Batman Arkham Origins - Erster Teaser-Trailer Batman vs. Deathstroke"
-        }, {
             "http://www.hulu.com/watch/489169",
             "The Unnatural (Bob's Burgers)"
         }, {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/InfoboxBuilderPage.java
@@ -358,8 +358,8 @@ public class InfoboxBuilderPage extends SpecialPageObject {
   public WebElement dragAndDropToTheTop(WebElement draggedElement) {
     this.wait.forElementClickable(draggedElement);
 
-    Point location = driver.findElement(By.cssSelector(".portable-infobox")).getLocation();
-    Integer targetY = draggedElement.getLocation().getY() - location.getY() + 10;
+    Point location = driver.findElement(By.cssSelector(".portable-infobox.pi-background")).getLocation();
+    Integer targetY = draggedElement.getLocation().getY() - location.getY() - 10;
 
     new Actions(driver)
         .clickAndHold(draggedElement)

--- a/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/VetProvidersTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mediatests/providers/VetProvidersTests.java
@@ -1,7 +1,6 @@
 package com.wikia.webdriver.testcases.mediatests.providers;
 
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.dataprovider.VideoUrlProvider;
@@ -11,7 +10,6 @@ import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetAddVideoCom
 import com.wikia.webdriver.pageobjectsfactory.componentobject.vet.VetOptionsComponentObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.article.editmode.VisualEditModePageObject;
-
 import org.testng.annotations.Test;
 
 @Test(groups = {"VetProvidersArticle", "ProviderTests", "Media"})
@@ -19,7 +17,6 @@ public class VetProvidersTests extends NewTestTemplate {
 
   @Execute(asUser = User.USER)
   @Test(dataProviderClass = VideoUrlProvider.class, dataProvider = "videoUrl")
-  @RelatedIssue(issueID= "SUS-789", comment= "P2 for gamestar")
   public void VetProvidersTests_001_article(String videoUrl, String videoName) {
     new ArticleContent().clear();
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SUS-789

There is a ticket to sunset GameStar video provider support (https://wikia-inc.atlassian.net/browse/SUS-979) and we're not going to fix it, so I removed the test which check GameStar video adding.