### PR TITLE
Changing toolbar label from Watch to Follow

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/toolbars/CustomizedToolbarComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/toolbars/CustomizedToolbarComponentObject.java
@@ -151,6 +151,28 @@ public class CustomizedToolbarComponentObject extends WikiBasePageObject {
   }
 
   /**
+   * Verify that page is followed The method should be used only after clicking on "follow" button.
+   * Before that, "follow" button does not have 'title' attribute which is necessary in the method
+   */
+  public void verifyFollowedToolbar() {
+    waitForValueToBePresentInElementsAttributeByCss(String.format(toolbarToolCss, PageContent.FOLLOW),
+            "title", "Unfollow");
+    PageObjectLogging.log("verifyFollowedToolbar", "follow button verified", true);
+  }
+
+  /**
+   * Verify that page is unfollowed The method should be used only after clicking on "Unfollow"
+   * button. Before that, "follow" button does not have 'title' attribute which is necessary in the
+   * method
+   */
+  public void verifyUnfollowed() {
+    wait.forElementClickable(pageWatchlistStatusMessage);
+    waitForValueToBePresentInElementsAttributeByCss(String.format(toolbarToolCss, PageContent.FOLLOW),
+            "title", "Follow");
+    PageObjectLogging.log("verifyUnfollowed", "unfollow button verified", true);
+  }
+
+  /**
    * Look up if Tool appears on Toolbar List
    *
    * @param toolName {Follow, Edit, History, (...)}

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -581,7 +581,7 @@ public class WikiBasePageObject extends BasePageObject {
   public void follow() {
     wait.forElementVisible(followButton);
     jsActions.click(followButton);
-    wait.forTextInElement(followButton, "Watching");
+    wait.forTextInElement(followButton, "Following");
     PageObjectLogging.log("followArticle", "page is followed", true, driver);
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/toolbartests/CustomizeToolbarTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/toolbartests/CustomizeToolbarTests.java
@@ -25,10 +25,10 @@ public class CustomizeToolbarTests extends NewTestTemplate {
   // tools
   String toolPreferences = "Preferences";
   String toolDoubleRedirects = "Double redirects";
-  String toolUploadFile = "Upload file";
+  String toolUploadPhoto = "Upload photo";
   String toolMore = "more…";
-  String toolWatch = "Watch";
-  String toolUnwatch = "Unwatch";
+  String toolFollow = "Follow";
+  String toolFollowing = "Following";
 
   String editSuffix = "123";
 
@@ -91,10 +91,10 @@ public class CustomizeToolbarTests extends NewTestTemplate {
     toolbar.clickCustomize();
     toolbar.clickResetDefaults();
     toolbar.searchTool(searchQueryUploadPhoto);
-    toolbar.clickSearchSuggestion(toolUploadFile);
-    toolbar.verifyToolOnList(toolUploadFile);
+    toolbar.clickSearchSuggestion(toolUploadPhoto);
+    toolbar.verifyToolOnList(toolUploadPhoto);
     toolbar.clickSave();
-    toolbar.verifyToolOnToolbar(toolUploadFile);
+    toolbar.verifyToolOnToolbar(toolUploadPhoto);
   }
 
   @Test(groups = {"CustomizeToolbar005"})
@@ -122,13 +122,15 @@ public class CustomizeToolbarTests extends NewTestTemplate {
   // https://internal.wikia-inc.com/wiki/QA/Core_Features_and_Testing/Manual_Regression_Tests/Customize_Toolbar_Buttons_actions
   public void CustomizeToolbar006_ButtonsActions() {
     toolbar.unfollowIfFollowed();
-    toolbar.verifyToolOnToolbar(toolWatch);
+    toolbar.verifyToolOnToolbar(toolFollow);
     toolbar.clickOnTool("follow");
     toolbar.verifyFollowMessage();
-    toolbar.verifyToolOnToolbar(toolUnwatch);
+    toolbar.verifyFollowedToolbar();
+    toolbar.verifyToolOnToolbar(toolFollowing);
     toolbar.clickOnTool("follow");
     toolbar.verifyFollowMessage();
-    toolbar.verifyToolOnToolbar(toolWatch);
+    toolbar.verifyUnfollowed();
+    toolbar.verifyToolOnToolbar(toolFollow);
     toolbar.clickCustomize();
     toolbar.clickResetDefaults();
     toolbar.clickSave();


### PR DESCRIPTION
Reverting changes from:
https://github.com/Wikia/selenium-tests/pull/1430
https://github.com/Wikia/selenium-tests/pull/1432

On customize toolbar there were temporary changed label from "Follow" to "Watch".
Now it's changed back from "Watch" to "Follow", so I reverted changes in tests.