### PR TITLE
Scroll to delete wiki button before click

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -601,7 +601,7 @@ public class WikiBasePageObject extends BasePageObject {
   public DeletePageObject deleteUsingDropdown() {
     articleEditDropdown.click();
     wait.forElementVisible(deleteDropdown);
-    deleteDropdown.click();
+    scrollAndClick(deleteDropdown);
     return new DeletePageObject(driver);
   }
 


### PR DESCRIPTION
Fix for `CreateNewWiki_001_createDeleteWiki` test as it failed when trying to click delete a wiki button from dropdown.