### PR TITLE
Aden 3761 wait for page load

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -754,16 +754,28 @@ public class AdsDataProvider {
   @DataProvider
   public static Object[][] delayBtf() {
     return new Object[][]{
-        {"project43", "SyntheticTests/ATF_DELAY_BTF", 20, true},
-        {"adtest-pluto", "SyntheticTests/ATF_DELAY_BTF", 20, false},
+        {"project43", "SyntheticTests/ATF_DELAY_BTF", 20, true}
     };
   }
 
   @DataProvider
   public static Object[][] disableBtf() {
     return new Object[][]{
-        {"project43", "SyntheticTests/ATF_DISABLE_BTF", true},
-        {"adtest-pluto", "SyntheticTests/ATF_DISABLE_BTF", false},
+        {"project43", "SyntheticTests/ATF_DISABLE_BTF", true}
+    };
+  }
+
+  @DataProvider
+  public static Object[][] delayBtfPluto() {
+      return new Object[][]{
+            {"adtest-pluto", "SyntheticTests/ATF_DELAY_BTF", 20, false}
+      };
+    }
+
+  @DataProvider
+  public static Object[][] disableBtfPluto() {
+    return new Object[][]{
+            {"adtest-pluto", "SyntheticTests/ATF_DISABLE_BTF", false}
     };
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -373,6 +373,11 @@ public class AdsBaseObject extends WikiBasePageObject {
 
   public AdsBaseObject waitForPageLoaded() {
     jsActions.waitForJavaScriptTruthy("document.readyState === 'complete'");
+
+    String waitForGPTJS = "typeof window.googletag === 'object'";
+    jsActions.waitForJavaScriptTruthy(waitForGPTJS);
+
+    PageObjectLogging.log("GPT Loaded", String.valueOf(jsActions.execute(waitForGPTJS)), true);
     return this;
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
@@ -3,6 +3,9 @@ package com.wikia.webdriver.testcases.adstests;
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -113,6 +116,10 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
   }
 
   @Execute(mockAds = "true")
+  @InBrowser(
+      emulator = Emulator.GOOGLE_NEXUS_5,
+      browser = Browser.CHROME
+  )
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "delayBtfPluto",
@@ -124,6 +131,10 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
   }
 
   @Execute(mockAds = "true")
+  @InBrowser(
+      emulator = Emulator.GOOGLE_NEXUS_5,
+      browser = Browser.CHROME
+  )
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtfPluto",
@@ -134,6 +145,10 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
     adsAtfDisableBtfMercury(wikiName, article, isWgVarOn);
   }
 
+  @InBrowser(
+      emulator = Emulator.GOOGLE_NEXUS_5,
+      browser = Browser.CHROME
+  )
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "delayBtf",
@@ -164,6 +179,10 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
                          AdsContent.MOBILE_PREFOOTER);
   }
 
+  @InBrowser(
+      emulator = Emulator.GOOGLE_NEXUS_5,
+      browser = Browser.CHROME
+  )
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtf",

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
@@ -2,21 +2,23 @@ package com.wikia.webdriver.testcases.adstests;
 
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
-import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
+import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsBaseObject;
 
 import org.openqa.selenium.Dimension;
 import org.testng.annotations.Test;
 
-public class TestAdsBtfBlocking extends TemplateNoFirstLoad {
+public class TestAdsBtfBlocking extends NewTestTemplate {
 
   private static final Dimension DESKTOP_PAGE_SIZE = new Dimension(1366, 768);
   private static final Dimension TABLET_PAGE_SIZE = new Dimension(850, 600);
   private static final Dimension MOBILE_SIZE = new Dimension(414, 736);
 
+  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "delayBtf",
@@ -57,6 +59,7 @@ public class TestAdsBtfBlocking extends TemplateNoFirstLoad {
                          AdsContent.FLOATING_MEDREC);
   }
 
+  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtf",
@@ -91,6 +94,7 @@ public class TestAdsBtfBlocking extends TemplateNoFirstLoad {
    * https://wikia-inc.atlassian.net/browse/ADEN-2156 Test whether ads on small screens are
    * displayed when wgAdDriverDelayBelowTheFold is enabled
    */
+  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtf",
@@ -111,6 +115,7 @@ public class TestAdsBtfBlocking extends TemplateNoFirstLoad {
   }
 
   @RelatedIssue(issueID = "ADEN-3761")
+  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "delayBtf",
@@ -141,6 +146,7 @@ public class TestAdsBtfBlocking extends TemplateNoFirstLoad {
                          AdsContent.MOBILE_PREFOOTER);
   }
 
+  @Execute(mockAds = "true")
   @RelatedIssue(issueID = "ADEN-3761")
   @Test(
       dataProviderClass = AdsDataProvider.class,

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
@@ -3,7 +3,6 @@ package com.wikia.webdriver.testcases.adstests;
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -94,7 +93,6 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
    * https://wikia-inc.atlassian.net/browse/ADEN-2156 Test whether ads on small screens are
    * displayed when wgAdDriverDelayBelowTheFold is enabled
    */
-  @Execute(mockAds = "true")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtf",
@@ -114,8 +112,28 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
                          AdsContent.PREFOOTER_RIGHT);
   }
 
-  @RelatedIssue(issueID = "ADEN-3761")
   @Execute(mockAds = "true")
+  @Test(
+      dataProviderClass = AdsDataProvider.class,
+      dataProvider = "delayBtfPluto",
+      groups = "AdsBtfBlockingMercury"
+  )
+  public void adsAtfDelayBtfMercuryPluto(String wikiName, String article, int delaySec, boolean isWgVarOn)
+      throws InterruptedException {
+    adsAtfDelayBtfMercury(wikiName, article, delaySec, isWgVarOn);
+  }
+
+  @Execute(mockAds = "true")
+  @Test(
+      dataProviderClass = AdsDataProvider.class,
+      dataProvider = "disableBtfPluto",
+      groups = "AdsBtfBlockingMercury"
+  )
+  public void adsAtfDisableBtfMercuryPluto(String wikiName, String article, boolean isWgVarOn)
+      throws InterruptedException {
+    adsAtfDisableBtfMercury(wikiName, article, isWgVarOn);
+  }
+
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "delayBtf",
@@ -146,8 +164,6 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
                          AdsContent.MOBILE_PREFOOTER);
   }
 
-  @Execute(mockAds = "true")
-  @RelatedIssue(issueID = "ADEN-3761")
   @Test(
       dataProviderClass = AdsDataProvider.class,
       dataProvider = "disableBtf",


### PR DESCRIPTION
- extend method AdsBaseObject.waitForPageLoaded to wait for gpt is loaded

- split tests for project43 and adtest-pluto in order to use mockAds=true on adtest-pluto