### PR TITLE
optionally not check for GPT

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -373,11 +373,17 @@ public class AdsBaseObject extends WikiBasePageObject {
 
   public AdsBaseObject waitForPageLoaded() {
     jsActions.waitForJavaScriptTruthy("document.readyState === 'complete'");
+    return this;
+  }
 
-    String waitForGPTJS = "typeof window.googletag === 'object'";
-    jsActions.waitForJavaScriptTruthy(waitForGPTJS);
+  public AdsBaseObject waitForPageLoaded(boolean withGPT) {
+    waitForPageLoaded();
+    if (withGPT) {
+      String waitForGPTJS = "typeof window.googletag === 'object'";
+      jsActions.waitForJavaScriptTruthy(waitForGPTJS);
 
-    PageObjectLogging.log("GPT Loaded", String.valueOf(jsActions.execute(waitForGPTJS)), true);
+      PageObjectLogging.log("GPT Loaded", String.valueOf(jsActions.execute(waitForGPTJS)), true);
+    }
     return this;
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsBaseObject.java
@@ -376,14 +376,13 @@ public class AdsBaseObject extends WikiBasePageObject {
     return this;
   }
 
-  public AdsBaseObject waitForPageLoaded(boolean withGPT) {
+  public AdsBaseObject waitForPageLoadedWithGpt() {
     waitForPageLoaded();
-    if (withGPT) {
-      String waitForGPTJS = "typeof window.googletag === 'object'";
-      jsActions.waitForJavaScriptTruthy(waitForGPTJS);
 
-      PageObjectLogging.log("GPT Loaded", String.valueOf(jsActions.execute(waitForGPTJS)), true);
-    }
+    String waitForGPTJS = "typeof window.googletag === 'object'";
+    jsActions.waitForJavaScriptTruthy(waitForGPTJS);
+    PageObjectLogging.log("GPT Loaded", String.valueOf(jsActions.execute(waitForGPTJS)), true);
+
     return this;
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
@@ -32,7 +32,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC), AdsContent.MEDREC);
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB), AdsContent.TOP_LB);
@@ -72,7 +72,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC));
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB));
@@ -106,7 +106,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, TABLET_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB), AdsContent.TOP_LB);
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT),
@@ -160,7 +160,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, MOBILE_SIZE);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MOBILE_TOP_LB),
                          AdsContent.MOBILE_TOP_LB);
@@ -193,7 +193,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, MOBILE_SIZE);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MOBILE_TOP_LB),
                          AdsContent.MOBILE_TOP_LB);

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsBtfBlocking.java
@@ -32,7 +32,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC), AdsContent.MEDREC);
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB), AdsContent.TOP_LB);
@@ -72,7 +72,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, DESKTOP_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MEDREC));
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB));
@@ -106,7 +106,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, TABLET_PAGE_SIZE);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.TOP_LB), AdsContent.TOP_LB);
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.PREFOOTER_LEFT),
@@ -160,7 +160,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, MOBILE_SIZE);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MOBILE_TOP_LB),
                          AdsContent.MOBILE_TOP_LB);
@@ -193,7 +193,7 @@ public class TestAdsBtfBlocking extends NewTestTemplate {
 
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage, MOBILE_SIZE);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
 
     Assertion.assertTrue(adsBaseObject.checkSlotOnPageLoaded(AdsContent.MOBILE_TOP_LB),
                          AdsContent.MOBILE_TOP_LB);

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
@@ -49,7 +49,7 @@ public class TestAdsInterstitial extends TemplateNoFirstLoad {
     String url = urlBuilder.getUrlForPath(wikiName, article);
     String testedPage = urlBuilder.appendQueryStringToURL(url, "highimpactslot=1");
     AdsInterstitialObject adsInterstitial = new AdsInterstitialObject(driver, testedPage, pageSize);
-    adsInterstitial.waitForPageLoaded(true);
+    adsInterstitial.waitForPageLoadedWithGpt();
     adsInterstitial.waitForInterstitialShowUp();
     adsInterstitial.verifySize(adSize);
     if (shouldAdBeScaled) {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsInterstitial.java
@@ -49,7 +49,7 @@ public class TestAdsInterstitial extends TemplateNoFirstLoad {
     String url = urlBuilder.getUrlForPath(wikiName, article);
     String testedPage = urlBuilder.appendQueryStringToURL(url, "highimpactslot=1");
     AdsInterstitialObject adsInterstitial = new AdsInterstitialObject(driver, testedPage, pageSize);
-    adsInterstitial.waitForPageLoaded();
+    adsInterstitial.waitForPageLoaded(true);
     adsInterstitial.waitForInterstitialShowUp();
     adsInterstitial.verifySize(adSize);
     if (shouldAdBeScaled) {

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
@@ -48,12 +48,12 @@ public class TestAdsKruxSegments extends NewTestTemplate {
 
     // Visit page1:
     adsKruxObject.getUrl(page1, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded();
+    adsKruxObject.waitForPageLoaded(true);
     adsKruxObject.waitForKrux();
 
     // Most of the time we get the correct segment here, but let's check it on the next page view:
     adsKruxObject.getUrl(page1, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded();
+    adsKruxObject.waitForPageLoaded(true);
     adsKruxObject.waitForKrux();
 
     // Check the segments:
@@ -65,12 +65,12 @@ public class TestAdsKruxSegments extends NewTestTemplate {
 
     // Visit page2:
     adsKruxObject.getUrl(page2, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded();
+    adsKruxObject.waitForPageLoaded(true);
     adsKruxObject.waitForKrux();
 
     // Most of the time we get the correct segment here, but let's check it on the next page view:
     adsKruxObject.getUrl(page2, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded();
+    adsKruxObject.waitForPageLoaded(true);
     adsKruxObject.waitForKrux();
 
     // Check the segments:

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsKruxSegments.java
@@ -48,12 +48,12 @@ public class TestAdsKruxSegments extends NewTestTemplate {
 
     // Visit page1:
     adsKruxObject.getUrl(page1, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded(true);
+    adsKruxObject.waitForPageLoadedWithGpt();
     adsKruxObject.waitForKrux();
 
     // Most of the time we get the correct segment here, but let's check it on the next page view:
     adsKruxObject.getUrl(page1, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded(true);
+    adsKruxObject.waitForPageLoadedWithGpt();
     adsKruxObject.waitForKrux();
 
     // Check the segments:
@@ -65,12 +65,12 @@ public class TestAdsKruxSegments extends NewTestTemplate {
 
     // Visit page2:
     adsKruxObject.getUrl(page2, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded(true);
+    adsKruxObject.waitForPageLoadedWithGpt();
     adsKruxObject.waitForKrux();
 
     // Most of the time we get the correct segment here, but let's check it on the next page view:
     adsKruxObject.getUrl(page2, NO_ADS_URL_PARAM);
-    adsKruxObject.waitForPageLoaded(true);
+    adsKruxObject.waitForPageLoadedWithGpt();
     adsKruxObject.waitForKrux();
 
     // Check the segments:

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
@@ -18,7 +18,7 @@ public class TestAdsSlotsOasis extends TemplateNoFirstLoad {
   public void adsSmokeTestSlotsOasis() {
     String testedPage = urlBuilder.getUrlForPath("project43", "SyntheticTests/OasisSlots");
     ads = new AdsBaseObject(driver, testedPage);
-    ads.waitForPageLoaded();
+    ads.waitForPageLoaded(true);
 
     for (String slotName : AdsDataProvider.OASIS_SLOTS_TO_SMOKE_TEST) {
       smokeTestSlot(slotName);

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsSlotsOasis.java
@@ -18,7 +18,7 @@ public class TestAdsSlotsOasis extends TemplateNoFirstLoad {
   public void adsSmokeTestSlotsOasis() {
     String testedPage = urlBuilder.getUrlForPath("project43", "SyntheticTests/OasisSlots");
     ads = new AdsBaseObject(driver, testedPage);
-    ads.waitForPageLoaded(true);
+    ads.waitForPageLoadedWithGpt();
 
     for (String slotName : AdsDataProvider.OASIS_SLOTS_TO_SMOKE_TEST) {
       smokeTestSlot(slotName);

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
@@ -40,7 +40,7 @@ public class TestIVWAnalyticsProvider extends TemplateNoFirstLoad {
       );
     }
   }
-  @RelatedIssue(issueID = "ADEN-3495")
+
   @NetworkTrafficDump
   @GeoEdgeBrowserMobProxy(country = CountryCode.GERMANY)
   @Test(
@@ -68,7 +68,7 @@ public class TestIVWAnalyticsProvider extends TemplateNoFirstLoad {
     networkTrafficInterceptor.startIntercepting();
     String testedPage = urlBuilder.getUrlForPath(wikiName, path);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage);
-    adsBaseObject.waitForPageLoaded();
+    adsBaseObject.waitForPageLoaded(true);
     Assertion.assertNull(networkTrafficInterceptor.getEntryByUrlPart(URL_BASE_SCRIPT),
                           "Tracking should not be loaded outside DE/AT/CH country!");
   }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
@@ -2,7 +2,6 @@ package com.wikia.webdriver.testcases.adstests;
 
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.NetworkTrafficDump;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.elemnt.JavascriptActions;
 import com.wikia.webdriver.common.core.geoedge.CountryCode;
 import com.wikia.webdriver.common.core.geoedge.GeoEdgeBrowserMobProxy;

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestIVWAnalyticsProvider.java
@@ -67,7 +67,7 @@ public class TestIVWAnalyticsProvider extends TemplateNoFirstLoad {
     networkTrafficInterceptor.startIntercepting();
     String testedPage = urlBuilder.getUrlForPath(wikiName, path);
     AdsBaseObject adsBaseObject = new AdsBaseObject(driver, testedPage);
-    adsBaseObject.waitForPageLoaded(true);
+    adsBaseObject.waitForPageLoadedWithGpt();
     Assertion.assertNull(networkTrafficInterceptor.getEntryByUrlPart(URL_BASE_SCRIPT),
                           "Tracking should not be loaded outside DE/AT/CH country!");
   }


### PR DESCRIPTION
The PR splits waitForPageLoaded method into 2 version:
* with GPT checking
* without GPT checking

Most of the time GPT checking is useful, but this method is used to check if iframe is loaded as well. Then we shouldn't check for GPT. 