### PR TITLE
ADEN-3941 Move Ooyala pre-roll test to project43

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/ads/AdsDataProvider.java
@@ -41,7 +41,7 @@ public class AdsDataProvider {
   public static Object[][] ooyalaAds() {
     return new Object[][]{
         {
-            "adtest",
+            "project43",
             "SyntheticTests/OoyalaVideo/" +
             "Simple?file=Synthetic_video_ad_test_(all_green_video)_320x240_(ooyala-stored_video)",
         }

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsOoyalaOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsOoyalaOasis.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 
 import java.awt.*;
 
-public class TestOoyalaAds extends TemplateNoFirstLoad {
+public class TestAdsOoyalaOasis extends TemplateNoFirstLoad {
 
   private static final Color GREEN = new Color(4, 253, 6);
   private static final Color BLUE = new Color(4, 0, 254);
@@ -17,10 +17,10 @@ public class TestOoyalaAds extends TemplateNoFirstLoad {
 
   @Test(
       dataProviderClass = AdsDataProvider.class,
-      groups = {"TestOoyalaAds_GeoEdgeFree"},
+      groups = {"AdsOoyalaPrerollOasis"},
       dataProvider = "ooyalaAds"
   )
-  public void TestOoyalaAds_GeoEdgeFree(String wikiName, String article) {
+  public void adsOoyalaPrerollOasis(String wikiName, String article) {
     String testedPage = urlBuilder.getUrlForPath(wikiName, article);
     AdsOoyalaObject wikiPage = new AdsOoyalaObject(driver, testedPage);
     wikiPage.verifyLightboxAd(BLUE, AD_DURATION_SEC);

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -55,7 +55,7 @@
             <class name="com.wikia.webdriver.testcases.adstests.TestIVWAnalyticsProvider"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestNoAdsForUsers"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestNoAdsOnAdFreeWikis"/>
-            <class name="com.wikia.webdriver.testcases.adstests.TestOoyalaAds"/>
+            <class name="com.wikia.webdriver.testcases.adstests.TestAdsOoyalaOasis"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestPad"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsRoadblocksAfterMultiplePageViewsOasis"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestTopWamWikis"/>


### PR DESCRIPTION
Moved the test from adtest.wikia.com to project43.wikia.com and renamed it to follow [our convention](https://wikia-inc.atlassian.net/wiki/display/ADEN/Ad+Engineering+Automated+Test+Naming+Convention).