### PR TITLE
Aden 3941 Yugioh categories change

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/mobile/MobileAdsDataProvider.java
@@ -126,7 +126,7 @@ public class MobileAdsDataProvider {
             Arrays.asList(
                 "\"s0\":\"gaming\"",
                 "\"s0v\":\"games\"",
-                "\"s0c\":[\"gaming\",\"videogames\",\"anime\"]",
+                "\"s0c\":[\"anime\"]",
                 "\"s1\":\"_yugioh\"",
                 "\"s2\":\"article\"",
                 "\"dmn\":\"wikiacom\"",

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsDfpParamsPresentMercury.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsDfpParamsPresentMercury.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-public class TestDfpParamsPresentMobile extends MobileTestTemplate {
+public class TestAdsDfpParamsPresentMercury extends MobileTestTemplate {
 
   private static final String LINE_ITEM_ID = "282067812";
   private static final String CREATIVE_ID = "50006703732";
@@ -27,7 +27,7 @@ public class TestDfpParamsPresentMobile extends MobileTestTemplate {
   @Test(
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "dfpParamsSynthetic",
-      groups = {"MobileAds", "DfpParamsPresentSyntheticMercury"}
+      groups = {"MobileAds", "AdsDfpParamsPresentSyntheticMercury"}
   )
   public void dfpParamsPresentSyntheticMercury(String wikiName,
                                                String article,
@@ -54,7 +54,7 @@ public class TestDfpParamsPresentMobile extends MobileTestTemplate {
   @Test(
       dataProviderClass = MobileAdsDataProvider.class,
       dataProvider = "dfpParams",
-      groups = {"MobileAds", "DfpParamsPresentMercury"}
+      groups = {"MobileAds", "AdsDfpParamsPresentMercury"}
   )
   public void dfpParamsPresentMercury(String wikiName,
                                       String article,

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -9,7 +9,7 @@
             <class name="com.wikia.webdriver.testcases.activityfeedstests.WikiActivityTests"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsScreenshotComparisonMobile"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdTypeMobile"/>
-            <class name="com.wikia.webdriver.testcases.adstests.TestDfpParamsPresentMobile"/>
+            <class name="com.wikia.webdriver.testcases.adstests.TestAdsDfpParamsPresentMercury"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsSlotsMercury"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsAdDriverForcedStatusOasis"/>
             <class name="com.wikia.webdriver.testcases.adstests.TestAdsAdvertisementTextOasis"/>


### PR DESCRIPTION
Categories for yugioh.wikia.com has changed. Code changes below address that and also they adjust class and method names to [our convention](https://wikia-inc.atlassian.net/wiki/display/ADEN/Ad+Engineering+Automated+Test+Naming+Convention).

Connected JJB PR: https://github.com/Wikia/jenkins-jobs/pull/121