### PR TITLE
Change REDIRECT_LINK to a page that always exists

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
@@ -80,7 +80,7 @@ public class PageContent {
   //links
   public static final String EXTERNAL_LINK = "http://www.wikia.com/";
   public static final String INTERNAL_LINK = "Home";
-  public static final String REDIRECT_LINK = "Formatting";
+  public static final String REDIRECT_LINK = "Main_Page";
   public static final String TEXT_LINK = "qaLink";
   public static final String REDLINK = "QAasdfasjsad123213lj";
   public static final String DISCUSSIONS_LINK = "/d/";


### PR DESCRIPTION
Do not assume that "Formatting" article always exists. Main_Page is present on all wikis and can be safely used when testing link suggest.

http://jenkins.wikia-prod:8080/view/Staging-test/view/staging/job/staging-forum-staging/lastSuccessfulBuild/artifact/logs/log.html

@ludwikkazmierczak / @nikodamn 