### PR TITLE
PageContent.ARTICLESOURCEMODEFILE - use a file that exists on staging

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
@@ -60,7 +60,7 @@ public class PageContent {
 
   //image storage
   public static final String FILERENAME = "Image003.jpg";
-  public static final String ARTICLESOURCEMODEFILE = "VE_ContributeDropDown.png";
+  public static final String ARTICLESOURCEMODEFILE = "Image010.jpg";
 
   public static final String[] LIST_OF_FILES = {
       "Image001.jpg", "Image002.jpg", "Image003.jpg", "Image004.jpg", "Image005.jpg",

--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/PageContent.java
@@ -60,7 +60,6 @@ public class PageContent {
 
   //image storage
   public static final String FILERENAME = "Image003.jpg";
-  public static final String ARTICLESOURCEMODEFILE = "Image010.jpg";
 
   public static final String[] LIST_OF_FILES = {
       "Image001.jpg", "Image002.jpg", "Image003.jpg", "Image004.jpg", "Image005.jpg",

--- a/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/articlecrudtests/ArticleSourceModeTests.java
@@ -165,7 +165,7 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     SourceEditModePageObject source = article.openCurrectArticleSourceMode();
     PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
     PhotoOptionsComponentObject photoOptions =
-        photoAddPhoto.addPhotoFromWiki(PageContent.ARTICLESOURCEMODEFILE);
+        photoAddPhoto.addPhotoFromWiki(PageContent.FILE);
     photoOptions.setCaption(PageContent.CAPTION);
     photoOptions.clickAddPhoto();
     String photoName = photoAddPhoto.getPhotoName();


### PR DESCRIPTION
Use [a nice picture of mouse](http://mediawiki119.wikia.com/wiki/File:Image010.jpg) when adding an image in editor's source mode. Image010.jpg exists on both production and staging environment.

This fixes [ArticleSourceModeTests](http://jenkins.wikia-prod:8080/view/Staging-test/view/staging/job/staging-rte-2-staging/lastSuccessfulBuild/artifact/logs/log.html#toc3) on staging.

@ludwikkazmierczak / @nikodamn 