### PR TITLE
WW-246: Add space before preformatted text

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/WikiTextContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/WikiTextContent.java
@@ -13,6 +13,9 @@ public class WikiTextContent {
   public static final String SUBHEADING4_OPENING = "====== ";
   public static final String SUBHEADING4_CLOSING = " ======";
 
+  /**
+   * @see <a href="https://www.mediawiki.org/wiki/Help:Formatting">Wikitext formatting</a>
+   */
   public static final String PREFORMATTED = " ";
   public static final String BOLD = "'''";
   public static final String ITALIC = "''";

--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/WikiTextContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/WikiTextContent.java
@@ -13,7 +13,7 @@ public class WikiTextContent {
   public static final String SUBHEADING4_OPENING = "====== ";
   public static final String SUBHEADING4_CLOSING = " ======";
 
-  public static final String PREFORMATTED = "";
+  public static final String PREFORMATTED = " ";
   public static final String BOLD = "'''";
   public static final String ITALIC = "''";
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorReviewChangesDialog.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/visualeditordialogs/VisualEditorReviewChangesDialog.java
@@ -102,7 +102,7 @@ public class VisualEditorReviewChangesDialog extends VisualEditorDialog {
 
   private boolean isDiffFound(List<String> targets, String source) {
     for (String target : targets) {
-      if (source.contains(target)) {
+      if (source.equals(target)) {
         return true;
       }
     }


### PR DESCRIPTION
Fix for VisualEditorEditing_003_insertToExistingArticle test

Based on https://www.mediawiki.org/wiki/Help:Formatting preformatted text can be added by starting each new line with a space 

@Wikia/west-wing 