### PR TITLE
Fix call logging

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/api/ApiCall.java
+++ b/src/test/java/com/wikia/webdriver/common/core/api/ApiCall.java
@@ -24,8 +24,6 @@ public abstract class ApiCall {
 
   private static String ERROR_MESSAGE = "Problem with API call";
 
-  protected static String URL_STRING = null;
-
   protected ApiCall() {
   }
 
@@ -61,7 +59,7 @@ public abstract class ApiCall {
 
       httpClient.execute(httpPost);
 
-      PageObjectLogging.log("CONTENT PUSH", "Content posted to: " + URL_STRING, true);
+      PageObjectLogging.log("CONTENT PUSH", "Content posted to: " + getURL(), true);
     } catch (ClientProtocolException e) {
       PageObjectLogging.log("EXCEPTION", ExceptionUtils.getStackTrace(e), false);
       throw new WebDriverException(ERROR_MESSAGE);

--- a/src/test/java/com/wikia/webdriver/common/core/api/ApiCall.java
+++ b/src/test/java/com/wikia/webdriver/common/core/api/ApiCall.java
@@ -24,6 +24,8 @@ public abstract class ApiCall {
 
   private static String ERROR_MESSAGE = "Problem with API call";
 
+  protected static String URL_STRING = null;
+
   protected ApiCall() {
   }
 

--- a/src/test/java/com/wikia/webdriver/common/core/api/ArticleContent.java
+++ b/src/test/java/com/wikia/webdriver/common/core/api/ArticleContent.java
@@ -17,7 +17,6 @@ public class ArticleContent extends ApiCall {
 
   private static String secret;
   private static String baseURL;
-  private static String URL_STRING;
   private static ArrayList<BasicNameValuePair> PARAMS;
 
   public ArticleContent() {

--- a/src/test/java/com/wikia/webdriver/common/core/api/TemplateContent.java
+++ b/src/test/java/com/wikia/webdriver/common/core/api/TemplateContent.java
@@ -17,7 +17,6 @@ public class TemplateContent extends ApiCall {
 
   private static String secret;
   private static String baseURL;
-  private static String URL_STRING;
   private static ArrayList<BasicNameValuePair> PARAMS;
 
   public TemplateContent() {


### PR DESCRIPTION
Removing declarations of static variables that are already defined in parent class. This fixes recording of URL in the ApiCall.call() method