### PR TITLE
ADEN-4038 stabilize recovery test

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsRecoveryObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsRecoveryObject.java
@@ -14,6 +14,7 @@ public class AdsRecoveryObject extends AdsBaseObject {
   }
 
   public String getRecoveredAdUnitId(String adUnitId) {
+    jsActions.waitForJavaScriptTruthy("window._sp_");
     return jsActions.execute(String.format("window._sp_.getElementId('%s')", adUnitId)).toString();
   }
 }


### PR DESCRIPTION
Sometimes we get error:
`org.openqa.selenium.WebDriverException: unknown error: window._sp_.getElementId is not a function`
it might be because of SourcePoint lib is not loaded on time, this change should fix it

