### PR TITLE
Fix next button on the second step of Create New Wiki process

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep2.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep2.java
@@ -18,7 +18,7 @@ public class CreateNewWikiPageObjectStep2 extends BasePageObject {
   private WebElement wikiCategoryDropdown;
   @FindBy(css = "#DescWiki .wds-dropdown .wds-list")
   private WebElement wikiCategoryList;
-  @FindBy(css = "form[name='desc-form'] input[class='next']")
+  @FindBy(css = "form[name='desc-form'] input.next")
   private WebElement submitButton;
   @FindBy(css = "label[for='allAges']")
   private WebElement allAgesCheckBox;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep3.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/createnewwiki/CreateNewWikiPageObjectStep3.java
@@ -20,7 +20,7 @@ public class CreateNewWikiPageObjectStep3 extends BasePageObject {
   private By loadingIndicatorBy = By.cssSelector(".wikiaThrobber");
   private String themeLocator = "li[data-theme='%name%']";
 
-  @FindBy(css = "li[id='ThemeWiki'] input[class='next enabled']")
+  @FindBy(css = "li[id='ThemeWiki'] input.next.enabled")
   private WebElement submitButton;
 
   public CreateNewWikiPageObjectStep3(WebDriver driver) {


### PR DESCRIPTION
We style buttons to be design system compliant so this button has additional classes, not only `next`

@Wikia/west-wing @mixth-sense @ludwikkazmierczak @nikodamn 