### PR TITLE
ADEN | fix: allow https tracking on auth pages

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsTrackingPixels.java
@@ -100,7 +100,7 @@ public class TestAdsTrackingPixels extends NewTestTemplate {
     assertTrackingPixelsSent(adsBaseObject, pixelUrls);
   }
 
-  @NetworkTrafficDump
+  @NetworkTrafficDump(useMITM = true)
   @Test(
           groups = "AdsTrackingPixelsAuthPage",
           dataProviderClass = AdsDataProvider.class,


### PR DESCRIPTION
allow https tracking on auth pages