### PR TITLE
XW-2817 | Update tests after releasing Mobile Wiki

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
@@ -46,7 +46,7 @@ public class MercurySubpages {
   public static final String NTAVCC_MAIN_PAGE = "/wiki/Mercuryntavcc_Wikia";
 
   // Articles prepared for mercuryemptycc.wikia.com wiki (without FC, CC, TA and TV)
-  public static final String ECC_MAIN_PAGE = "/wiki/Mercury_empty_CC_Wikia";
+  public static final String ECC_MAIN_PAGE = "/wiki/Mercury_Empty_CC_Editor_Wikia";
 
   // Articles on mlp.wikia.com
   public static final String MLP_MAIN_PAGE = "/wiki/My_Little_Pony_Friendship_is_Magic_Wiki";

--- a/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
+++ b/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
@@ -82,20 +82,13 @@ public abstract class BrowserAbstract {
    */
   protected void setProxy() {
 
-    if (true) {
+    if (Configuration.useProxy()) {
       server = new NetworkTrafficInterceptor();
       server.setTrustAllServers(true);
       server.setMitmDisabled(!Boolean.parseBoolean(Configuration.useMITM()));
       server.setRequestTimeout(90, TimeUnit.SECONDS);
       server.enableHarCaptureTypes(CaptureType.REQUEST_HEADERS, CaptureType.REQUEST_COOKIES,
           CaptureType.RESPONSE_HEADERS, CaptureType.RESPONSE_COOKIES);
-
-      server.addRequestFilter((request, contents, messageInfo) -> {
-        if (request.getUri().contains(".wikia.com/wiki/")){
-          request.headers().add("X-XW-2699", "1");
-        }
-        return null;
-      });
 
       caps.setCapability(CapabilityType.PROXY, server.startSeleniumProxyServer());
     }

--- a/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
+++ b/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
@@ -82,13 +82,20 @@ public abstract class BrowserAbstract {
    */
   protected void setProxy() {
 
-    if (Configuration.useProxy()) {
+    if (true) {
       server = new NetworkTrafficInterceptor();
       server.setTrustAllServers(true);
       server.setMitmDisabled(!Boolean.parseBoolean(Configuration.useMITM()));
       server.setRequestTimeout(90, TimeUnit.SECONDS);
       server.enableHarCaptureTypes(CaptureType.REQUEST_HEADERS, CaptureType.REQUEST_COOKIES,
           CaptureType.RESPONSE_HEADERS, CaptureType.RESPONSE_COOKIES);
+
+      server.addRequestFilter((request, contents, messageInfo) -> {
+        if (request.getUri().contains(".wikia")){
+          request.headers().add("HEADER-IGORA", "VALUE");
+        }
+        return null;
+      });
 
       caps.setCapability(CapabilityType.PROXY, server.startSeleniumProxyServer());
     }

--- a/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
+++ b/src/test/java/com/wikia/webdriver/common/core/drivers/BrowserAbstract.java
@@ -91,8 +91,8 @@ public abstract class BrowserAbstract {
           CaptureType.RESPONSE_HEADERS, CaptureType.RESPONSE_COOKIES);
 
       server.addRequestFilter((request, contents, messageInfo) -> {
-        if (request.getUri().contains(".wikia")){
-          request.headers().add("HEADER-IGORA", "VALUE");
+        if (request.getUri().contains(".wikia.com/wiki/")){
+          request.headers().add("X-XW-2699", "1");
         }
         return null;
       });

--- a/src/test/java/com/wikia/webdriver/common/skin/Skin.java
+++ b/src/test/java/com/wikia/webdriver/common/skin/Skin.java
@@ -1,5 +1,5 @@
 package com.wikia.webdriver.common.skin;
 
 public enum Skin {
-  OASIS, MERCURY, WIKIAMOBILE
+  OASIS, MERCURY, MOBILE_WIKI, WIKIAMOBILE
 }

--- a/src/test/java/com/wikia/webdriver/common/skin/Skin.java
+++ b/src/test/java/com/wikia/webdriver/common/skin/Skin.java
@@ -1,5 +1,5 @@
 package com.wikia.webdriver.common.skin;
 
 public enum Skin {
-  OASIS, MERCURY, MOBILE_WIKI, WIKIAMOBILE
+  OASIS, MERCURY, MOBILE_WIKI
 }

--- a/src/test/java/com/wikia/webdriver/common/skin/SkinHelper.java
+++ b/src/test/java/com/wikia/webdriver/common/skin/SkinHelper.java
@@ -14,6 +14,9 @@ public class SkinHelper extends WikiBasePageObject {
   @FindBy(css = "body.ember-application")
   private WebElement mercuryClassInBody;
 
+  @FindBy(css = "body.ember-application.mobile-wiki")
+  private WebElement mobileWikiClassInBody;
+
   @FindBy(css = "body.wkMobile")
   private WebElement wikiaMobileClassInBody;
 
@@ -27,6 +30,8 @@ public class SkinHelper extends WikiBasePageObject {
         return wait.forElementInViewPort(oasisClassInBody);
       case MERCURY:
         return wait.forElementInViewPort(mercuryClassInBody);
+      case MOBILE_WIKI:
+        return wait.forElementInViewPort(mobileWikiClassInBody);
       case WIKIAMOBILE:
         return wait.forElementInViewPort(wikiaMobileClassInBody);
       default:

--- a/src/test/java/com/wikia/webdriver/common/skin/SkinHelper.java
+++ b/src/test/java/com/wikia/webdriver/common/skin/SkinHelper.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.common.skin;
 
+import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
 import org.openqa.selenium.WebDriver;
@@ -17,26 +18,34 @@ public class SkinHelper extends WikiBasePageObject {
   @FindBy(css = "body.ember-application.mobile-wiki")
   private WebElement mobileWikiClassInBody;
 
-  @FindBy(css = "body.wkMobile")
-  private WebElement wikiaMobileClassInBody;
-
   public SkinHelper(WebDriver driver) {
     super();
   }
 
   public boolean isSkin(Skin skin) {
+    boolean isExpectedSkin;
+
     switch (skin) {
       case OASIS:
-        return wait.forElementInViewPort(oasisClassInBody);
+        isExpectedSkin = wait.forElementInViewPort(oasisClassInBody);
+        break;
       case MERCURY:
-        return wait.forElementInViewPort(mercuryClassInBody);
+        isExpectedSkin = wait.forElementInViewPort(mercuryClassInBody);
+        break;
       case MOBILE_WIKI:
-        return wait.forElementInViewPort(mobileWikiClassInBody);
-      case WIKIAMOBILE:
-        return wait.forElementInViewPort(wikiaMobileClassInBody);
+        isExpectedSkin = wait.forElementInViewPort(mobileWikiClassInBody);
+        break;
       default:
-        return false;
+        isExpectedSkin = false;
     }
+
+    if (isExpectedSkin) {
+      PageObjectLogging.logInfo("Expected skin is loaded: " + skin.toString());
+    } else {
+      PageObjectLogging.logWarning("isSkin", "Expected skin is not loaded: " + skin.toString());
+    }
+
+    return isExpectedSkin;
   }
 }
 

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/Navigation.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/Navigation.java
@@ -3,6 +3,8 @@ package com.wikia.webdriver.elements.mercury.components;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.elemnt.Wait;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.elements.mercury.pages.login.RegisterPage;
 
 import org.openqa.selenium.By;
@@ -81,12 +83,18 @@ public class Navigation {
     return this;
   }
 
-  public Navigation clickExploreWikiHeader() {
+  public Navigation clickExploreWikiHeader(Skin fromSkin) {
     PageObjectLogging.logInfo("Click 'Explore Wiki' header");
     wait.forElementClickable(exploreWikiHeader);
 
     exploreWikiHeader.click();
-    loading.handleAsyncPageReload();
+
+    // Mobile wiki opens the main page using AJAX, Mercury reloads the page and opens Mobile Wiki
+    if (fromSkin == Skin.MOBILE_WIKI) {
+      loading.handleAsyncPageReload();
+    } else {
+      new SkinHelper(driver).isSkin(Skin.MERCURY);
+    }
 
     return this;
   }
@@ -146,10 +154,6 @@ public class Navigation {
 
   public boolean isLogoutLinkVisible() {
     return isElementVisible(logoutLink);
-  }
-
-  public boolean isExploreWikiHeaderVisible() {
-    return isElementVisible(exploreWikiHeader);
   }
 
   public boolean areHubLinksVisible() {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/Search.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/Search.java
@@ -1,6 +1,9 @@
 package com.wikia.webdriver.elements.mercury.components;
 
+import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.elements.mercury.pages.SearchResultsPage;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.BasePageObject;
 
@@ -29,8 +32,7 @@ public class Search extends BasePageObject {
   private static final String searchSuggestionClass = ".wikia-search__suggestions li.mw-content";
   private static final String focusedSearchInput = ".wikia-search--focused input";
 
-  public String clickSearchSuggestion(int index) {
-    Loading loading = new Loading(driver);
+  public String clickSearchSuggestion(int index, Skin fromSkin) {
     String clickedSuggestion;
 
     PageObjectLogging.logInfo("Select search suggestion no.: " + index);
@@ -40,7 +42,14 @@ public class Search extends BasePageObject {
     clickedSuggestion = searchResult.getText();
 
     searchResult.click();
-    loading.handleAsyncPageReload();
+
+    // Mobile wiki opens the suggested page using AJAX, Mercury reloads the page and opens Mobile Wiki
+    if (fromSkin == Skin.MOBILE_WIKI) {
+      Loading loading = new Loading(driver);
+      loading.handleAsyncPageReload();
+    } else {
+      Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+    }
 
     return clickedSuggestion;
   }
@@ -64,7 +73,7 @@ public class Search extends BasePageObject {
     PageObjectLogging.logInfo("Type in search input field: " + pageName);
     typeInSearch(pageName);
     PageObjectLogging.logInfo("Select first search suggestion");
-    clickSearchSuggestion(0);
+    clickSearchSuggestion(0, Skin.MOBILE_WIKI);
 
     return this;
   }
@@ -77,8 +86,16 @@ public class Search extends BasePageObject {
     return this;
   }
 
-  public SearchResultsPage clickEnterAndNavigateToSearchResults() {
+  public SearchResultsPage clickEnterAndNavigateToSearchResults(Skin fromSkin) {
     new Actions(driver).sendKeys(Keys.ENTER).perform();
+
+    // Mobile wiki opens the SRP using AJAX, Mercury reloads the page and opens Mobile Wiki
+    if (fromSkin == Skin.MOBILE_WIKI) {
+      Loading loading = new Loading(driver);
+      loading.handleAsyncPageReload();
+    } else {
+      Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+    }
 
     return new SearchResultsPage();
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/Search.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/Search.java
@@ -23,7 +23,7 @@ public class Search extends BasePageObject {
   @FindBy(css = ".wikia-search__clear")
   private WebElement clearSearchButton;
 
-  @FindBy(css = ".wikia-search__search-icon > svg > use[*|href*='#search']")
+  @FindBy(css = ".wikia-search__search-icon > svg")
   private WebElement inputFieldSearchIcon;
 
   public static final int FOCUS_TIMEOUT_IN_SECONDS = 1;

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
@@ -32,7 +32,7 @@ public class TopBar extends BasePageObject {
   @FindBy(css = ".site-head-icon-search > a.icon-button")
   private WebElement searchIconClickableLink;
 
-  @FindBy(css = ".site-head-icon-nav > .icon-button-icon")
+  @FindBy(css = ".icon-button-icon > use[*|href*='close']")
   private WebElement closeButton;
 
   @FindBy(css = ".nav-menu")

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
@@ -32,7 +32,7 @@ public class TopBar extends BasePageObject {
   @FindBy(css = ".site-head-icon-search > a.icon-button")
   private WebElement searchIconClickableLink;
 
-  @FindBy(css = ".icon-button-icon > use[*|href*='close']")
+  @FindBy(css = ".site-head-icon-nav > .icon-button-icon")
   private WebElement closeButton;
 
   @FindBy(css = ".nav-menu")

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
@@ -33,7 +33,7 @@ public class TopBar extends BasePageObject {
   private WebElement searchIconClickableLink;
 
   @FindBy(css = ".icon-button-icon > use[*|href*='close']")
-  private WebElement closeButton;
+  private WebElement closeButtonInnerElement;
 
   @FindBy(css = ".nav-menu")
   private WebElement navMenu;
@@ -45,6 +45,7 @@ public class TopBar extends BasePageObject {
   private List<WebElement> searchSuggestions;
 
   private By navigationComponent = By.cssSelector(".side-nav-drawer");
+  private By parentBy = By.xpath("./..");
 
   public TopBar(WebDriver driver) {
     PageFactory.initElements(driver, this);
@@ -86,6 +87,9 @@ public class TopBar extends BasePageObject {
   }
 
   public Navigation clickCloseButton() {
+    // Clicking on the inner element doesn't always work so we click the parent (<svg>) instead
+    WebElement closeButton = closeButtonInnerElement.findElement(parentBy);
+
     PageObjectLogging.logInfo("Click close button");
     wait.forElementClickable(closeButton);
     closeButton.click();
@@ -153,7 +157,7 @@ public class TopBar extends BasePageObject {
 
   public boolean isCloseIconVisible() {
     try {
-      return closeButton.isDisplayed();
+      return closeButtonInnerElement.isDisplayed();
     } catch (NoSuchElementException e) {
       PageObjectLogging.logInfo(e.getMessage());
       return false;

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/curatedcontent/CuratedMainPagePageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/curatedcontent/CuratedMainPagePageObject.java
@@ -58,8 +58,9 @@ public class CuratedMainPagePageObject {
 
   public int getElementOffsetTop(String element) {
     JavascriptExecutor js = (JavascriptExecutor) driver;
-    return Integer
-        .parseInt(js.executeScript("return $(arguments[0]).offset().top", element).toString());
+    return Integer.parseInt(
+        js.executeScript("return $(arguments[0]).offset() && $(arguments[0]).offset().top", element).toString()
+    );
   }
 
   public boolean isMobileTopLeaderboardVisible() {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/curatedcontent/CuratedMainPagePageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/curatedcontent/CuratedMainPagePageObject.java
@@ -1,6 +1,5 @@
 package com.wikia.webdriver.elements.mercury.old.curatedcontent;
 
-import com.wikia.webdriver.common.core.elemnt.JavascriptActions;
 import com.wikia.webdriver.common.core.elemnt.Wait;
 
 import org.openqa.selenium.By;
@@ -49,12 +48,10 @@ public class CuratedMainPagePageObject {
 
   private WebDriver driver;
   private Wait wait;
-  private JavascriptActions jsActions;
 
   public CuratedMainPagePageObject(WebDriver driver) {
     this.driver = driver;
     this.wait = new Wait(driver);
-    this.jsActions = new JavascriptActions(driver);
 
     PageFactory.initElements(driver, this);
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
@@ -63,8 +63,4 @@ public class ArticlePage extends WikiBasePageObject {
   public String getArticleContent() {
     return driver.findElement(articleContent).getText();
   }
-
-  public ArticlePage openDiscussions() {
-    return this.open("/d/");
-  }
 }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
@@ -55,7 +55,7 @@ public class ArticlePage extends WikiBasePageObject {
     getUrl(urlBuilder.getUrlForWiki(Configuration.getWikiName()) + URLsContent.WIKI_DIR
            + TestContext.getCurrentMethodName());
 
-    new SkinHelper(driver).isSkin(Skin.MERCURY);
+    new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI);
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/ArticlePage.java
@@ -48,6 +48,8 @@ public class ArticlePage extends WikiBasePageObject {
   public ArticlePage open(String pageName) {
     getNavigate().toPage(pageName);
 
+    new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI);
+
     return this;
   }
 

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/CategoryPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/CategoryPage.java
@@ -34,7 +34,7 @@ public class CategoryPage extends WikiBasePageObject {
 
   public CategoryPage open(String categoryName) {
     this.navigate.toPage(String.format("%s%s", URLsContent.WIKI_DIR, categoryName));
-    new SkinHelper(driver).isSkin(Skin.MERCURY);
+    new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI);
 
     PageObjectLogging.logInfo(String.format("%s category page opened", categoryName));
 
@@ -43,7 +43,7 @@ public class CategoryPage extends WikiBasePageObject {
 
 
   public ArticlePage navigateToCategoryMemberPage() {
-    new SkinHelper(driver).isSkin(Skin.MERCURY);
+    new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI);
 
     WebElement member = driver.findElement(categoryMembers);
     String memberName = member.getText();
@@ -54,7 +54,7 @@ public class CategoryPage extends WikiBasePageObject {
     new Loading(driver).handleAsyncPageReload();
     PageObjectLogging.logInfo(String.format("You were redirected to page: \"%s\".", memberName));
 
-    new SkinHelper(driver).isSkin(Skin.MERCURY);
+    new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI);
 
     return new ArticlePage();
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/SearchResultsPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/SearchResultsPage.java
@@ -25,7 +25,7 @@ public class SearchResultsPage extends WikiBasePageObject {
   @FindBy(css = ".search-error-not-found__action")
   private WebElement tryAnotherSearchLink;
 
-  @FindBy(css = ".search-results__load-more-wrapper .wikia-button")
+  @FindBy(css = ".search-results__load-more-wrapper .wds-button")
   private WebElement loadMoreButton;
 
   @FindBy(css = ".search-results__list .wikia-card")
@@ -38,8 +38,10 @@ public class SearchResultsPage extends WikiBasePageObject {
   private static final String SPINNER_SELECTOR = ".spinner";
 
   public SearchResultsPage openForQuery(String query) {
-    getUrl(String.format("%s%s", urlBuilder.getUrlForWiki(),
-                         URLsContent.MOBILE_SEARCH_RESULTS_PAGE.replace("%query%", query)));
+    getUrl(
+        String.format("%s%s", urlBuilder.getUrlForWiki(),
+        URLsContent.MOBILE_SEARCH_RESULTS_PAGE.replace("%query%", query))
+    );
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
@@ -1,6 +1,8 @@
 package com.wikia.webdriver.elements.mercury.pages.discussions;
 
 import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.elements.mercury.components.discussions.common.ErrorMessages;
 import com.wikia.webdriver.elements.mercury.components.discussions.common.TextGenerator;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
@@ -46,6 +48,9 @@ public class GuidelinesPage extends WikiBasePageObject {
 
   public GuidelinesPage open() {
     driver.get(urlBuilder.getUrlForWiki() + String.format(PATH));
+
+    new SkinHelper(driver).isSkin(Skin.MERCURY);
+
     return this;
   }
 
@@ -109,7 +114,7 @@ public class GuidelinesPage extends WikiBasePageObject {
     contentText.isDisplayed();
   }
 
-  public void deleteTextFromGuidelines(String text) {
+  private void deleteTextFromGuidelines(String text) {
     clickEditGuidelines();
     addText(DEFAULT_GUIDELINES_TEXT);
     wait.forTextNotInElement(contentText, text);

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTest.java
@@ -1,11 +1,14 @@
 package com.wikia.webdriver.testcases.mercurytests;
 
+import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.common.skin.Skin;
 import com.wikia.webdriver.elements.mercury.pages.discussions.GuidelinesPage;
 import org.testng.annotations.Test;
 
@@ -68,8 +71,12 @@ public class NavigationMercuryTest extends NavigationTest {
 
   @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
   public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
-    super.mercury_navigation_exploreWikiNavigatesToWikiMainPage(
-        new GuidelinesPage().open()
-    );
+    new GuidelinesPage()
+        .open()
+        .getTopBar()
+        .openNavigation()
+        .clickExploreWikiHeader(Skin.MERCURY);
+
+    Assertion.assertTrue(driver.getCurrentUrl().contains(MercurySubpages.MAIN_PAGE));
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTest.java
@@ -1,0 +1,75 @@
+package com.wikia.webdriver.testcases.mercurytests;
+
+import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
+import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.elements.mercury.pages.discussions.GuidelinesPage;
+import org.testng.annotations.Test;
+
+@Test(groups = "Mercury_Navigation")
+@InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+@Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+public class NavigationMercuryTest extends NavigationTest {
+
+  @Test(groups = "mercury_navigation_openAndCloseNavigationAndItsSubMenu")
+  public void mercury_navigation_openAndCloseNavigationAndItsSubMenu() {
+    super.mercury_navigation_openAndCloseNavigationAndItsSubMenu(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_resetNavigationState")
+  public void mercury_navigation_resetNavigationState() {
+    super.mercury_navigation_resetNavigationState(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_backButton")
+  public void mercury_navigation_backButton() {
+    super.mercury_navigation_backButton(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationOnEnglishWiki")
+  public void mercury_navigation_navigationOnEnglishWiki() {
+    super.mercury_navigation_navigationOnEnglishWiki(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.DE_WIKI)
+  @Test(groups = "mercury_navigation_navigationOnNonEnglishWiki")
+  public void mercury_navigation_navigationOnNonEnglishWiki() {
+    super.mercury_navigation_navigationOnNonEnglishWiki(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
+  @Execute(asUser = User.USER)
+  public void mercury_navigation_navigationElementsUserLoggedIn() {
+    super.mercury_navigation_navigationElementsUserLoggedIn(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationElementsAnonymousUser")
+  @Execute(asUser = User.ANONYMOUS)
+  public void mercury_navigation_navigationElementsAnonymousUser() {
+    super.mercury_navigation_navigationElementsAnonymousUser(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
+  public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
+    super.mercury_navigation_exploreWikiNavigatesToWikiMainPage(
+        new GuidelinesPage().open()
+    );
+  }
+}

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
@@ -9,39 +9,39 @@ import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.skin.Skin;
-import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
+import com.wikia.webdriver.elements.mercury.pages.discussions.GuidelinesPage;
 import org.testng.annotations.Test;
 
 @Test(groups = "Mercury_Navigation")
 @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
 @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-public class NavigationMobileWikiTest extends NavigationTest {
+public class NavigationMercuryTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_openAndCloseNavigationAndItsSubMenu")
   public void mercury_navigation_openAndCloseNavigationAndItsSubMenu() {
     super.mercury_navigation_openAndCloseNavigationAndItsSubMenu(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
   @Test(groups = "mercury_navigation_resetNavigationState")
   public void mercury_navigation_resetNavigationState() {
     super.mercury_navigation_resetNavigationState(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
   @Test(groups = "mercury_navigation_backButton")
   public void mercury_navigation_backButton() {
     super.mercury_navigation_backButton(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
   @Test(groups = "mercury_navigation_navigationOnEnglishWiki")
   public void mercury_navigation_navigationOnEnglishWiki() {
     super.mercury_navigation_navigationOnEnglishWiki(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
@@ -49,7 +49,7 @@ public class NavigationMobileWikiTest extends NavigationTest {
   @Test(groups = "mercury_navigation_navigationOnNonEnglishWiki")
   public void mercury_navigation_navigationOnNonEnglishWiki() {
     super.mercury_navigation_navigationOnNonEnglishWiki(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
@@ -57,7 +57,7 @@ public class NavigationMobileWikiTest extends NavigationTest {
   @Execute(asUser = User.USER)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
@@ -65,17 +65,17 @@ public class NavigationMobileWikiTest extends NavigationTest {
   @Execute(asUser = User.ANONYMOUS)
   public void mercury_navigation_navigationElementsAnonymousUser() {
     super.mercury_navigation_navigationElementsAnonymousUser(
-        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+        new GuidelinesPage().open()
     );
   }
 
   @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
   public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
-    new ArticlePage()
-        .open(MercurySubpages.INFOBOX_1)
+    new GuidelinesPage()
+        .open()
         .getTopBar()
         .openNavigation()
-        .clickExploreWikiHeader(Skin.MOBILE_WIKI);
+        .clickExploreWikiHeader(Skin.MERCURY);
 
     Assertion.assertTrue(driver.getCurrentUrl().contains(MercurySubpages.MAIN_PAGE));
   }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTest.java
@@ -1,0 +1,76 @@
+package com.wikia.webdriver.testcases.mercurytests;
+
+import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
+import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
+import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
+import org.testng.annotations.Test;
+
+@Test(groups = "Mercury_Navigation")
+@InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+@Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+public class NavigationMobileWikiTest extends NavigationTest {
+
+  @Test(groups = "mercury_navigation_openAndCloseNavigationAndItsSubMenu")
+  public void mercury_navigation_openAndCloseNavigationAndItsSubMenu() {
+    super.mercury_navigation_openAndCloseNavigationAndItsSubMenu(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_resetNavigationState")
+  public void mercury_navigation_resetNavigationState() {
+    super.mercury_navigation_resetNavigationState(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_backButton")
+  public void mercury_navigation_backButton() {
+    super.mercury_navigation_backButton(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationOnEnglishWiki")
+  public void mercury_navigation_navigationOnEnglishWiki() {
+    super.mercury_navigation_navigationOnEnglishWiki(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.DE_WIKI)
+  @Test(groups = "mercury_navigation_navigationOnNonEnglishWiki")
+  public void mercury_navigation_navigationOnNonEnglishWiki() {
+    super.mercury_navigation_navigationOnNonEnglishWiki(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
+  @Execute(asUser = User.USER)
+  public void mercury_navigation_navigationElementsUserLoggedIn() {
+    super.mercury_navigation_navigationElementsUserLoggedIn(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_navigationElementsAnonymousUser")
+  @Execute(asUser = User.ANONYMOUS)
+  public void mercury_navigation_navigationElementsAnonymousUser() {
+    super.mercury_navigation_navigationElementsAnonymousUser(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
+  public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
+    super.mercury_navigation_exploreWikiNavigatesToWikiMainPage(
+        new ArticlePage().open(MercurySubpages.INFOBOX_1)
+    );
+  }
+}

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTest.java
@@ -2,11 +2,13 @@ package com.wikia.webdriver.testcases.mercurytests;
 
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.common.skin.Skin;
 import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
 import org.testng.annotations.Test;
 
@@ -69,8 +71,12 @@ public class NavigationMobileWikiTest extends NavigationTest {
 
   @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
   public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
-    super.mercury_navigation_exploreWikiNavigatesToWikiMainPage(
-        new ArticlePage().open(MercurySubpages.INFOBOX_1)
-    );
+    new ArticlePage()
+        .open(MercurySubpages.INFOBOX_1)
+        .getTopBar()
+        .openNavigation()
+        .clickExploreWikiHeader(Skin.MOBILE_WIKI);
+
+    Assertion.assertTrue(driver.getCurrentUrl().contains(MercurySubpages.MAIN_PAGE));
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
@@ -9,39 +9,39 @@ import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.skin.Skin;
-import com.wikia.webdriver.elements.mercury.pages.discussions.GuidelinesPage;
+import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
 import org.testng.annotations.Test;
 
 @Test(groups = "Mercury_Navigation")
 @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
 @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-public class NavigationMercuryTest extends NavigationTest {
+public class NavigationMobileWikiTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_openAndCloseNavigationAndItsSubMenu")
   public void mercury_navigation_openAndCloseNavigationAndItsSubMenu() {
     super.mercury_navigation_openAndCloseNavigationAndItsSubMenu(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
   @Test(groups = "mercury_navigation_resetNavigationState")
   public void mercury_navigation_resetNavigationState() {
     super.mercury_navigation_resetNavigationState(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
   @Test(groups = "mercury_navigation_backButton")
   public void mercury_navigation_backButton() {
     super.mercury_navigation_backButton(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
   @Test(groups = "mercury_navigation_navigationOnEnglishWiki")
   public void mercury_navigation_navigationOnEnglishWiki() {
     super.mercury_navigation_navigationOnEnglishWiki(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
@@ -49,7 +49,7 @@ public class NavigationMercuryTest extends NavigationTest {
   @Test(groups = "mercury_navigation_navigationOnNonEnglishWiki")
   public void mercury_navigation_navigationOnNonEnglishWiki() {
     super.mercury_navigation_navigationOnNonEnglishWiki(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
@@ -57,7 +57,7 @@ public class NavigationMercuryTest extends NavigationTest {
   @Execute(asUser = User.USER)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
@@ -65,17 +65,17 @@ public class NavigationMercuryTest extends NavigationTest {
   @Execute(asUser = User.ANONYMOUS)
   public void mercury_navigation_navigationElementsAnonymousUser() {
     super.mercury_navigation_navigationElementsAnonymousUser(
-        new GuidelinesPage().open()
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
     );
   }
 
   @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
   public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
-    new GuidelinesPage()
-        .open()
+    new ArticlePage()
+        .open(MercurySubpages.INFOBOX_1)
         .getTopBar()
         .openNavigation()
-        .clickExploreWikiHeader(Skin.MERCURY);
+        .clickExploreWikiHeader(Skin.MOBILE_WIKI);
 
     Assertion.assertTrue(driver.getCurrentUrl().contains(MercurySubpages.MAIN_PAGE));
   }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTest.java
@@ -1,6 +1,5 @@
 package com.wikia.webdriver.testcases.mercurytests;
 
-import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.mercury.components.Navigation;
@@ -76,13 +75,5 @@ public abstract class NavigationTest extends NewTestTemplate {
     Assertion.assertFalse(navigation.isUserProfileLinkVisible());
     Assertion.assertFalse(navigation.isLogoutLinkVisible());
     Assertion.assertEquals(navigation.getNavigationHeaderText(), "Sign In | Register");
-  }
-
-  void mercury_navigation_exploreWikiNavigatesToWikiMainPage(WikiBasePageObject page) {
-    page.getTopBar()
-        .openNavigation()
-        .clickExploreWikiHeader();
-
-    Assertion.assertTrue(driver.getCurrentUrl().contains(MercurySubpages.MAIN_PAGE));
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTest.java
@@ -1,29 +1,16 @@
 package com.wikia.webdriver.testcases.mercurytests;
 
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
-import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.InBrowser;
-import com.wikia.webdriver.common.core.drivers.Browser;
-import com.wikia.webdriver.common.core.helpers.Emulator;
-import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.mercury.components.Navigation;
 import com.wikia.webdriver.elements.mercury.components.TopBar;
-import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
-import org.testng.annotations.Test;
-@Test(groups = "Mercury_Navigation")
-@Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-@InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
-public class NavigationTest extends NewTestTemplate {
+import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
-  @Test(groups = "mercury_navigation_openAndCloseNavigationAndItsSubMenu")
-  public void mercury_navigation_openAndCloseNavigationAndItsSubMenu() {
-    TopBar topBar =
-        new ArticlePage()
-          .open(MercurySubpages.MAIN_PAGE)
-          .getTopBar();
+public abstract class NavigationTest extends NewTestTemplate {
+
+  void mercury_navigation_openAndCloseNavigationAndItsSubMenu(WikiBasePageObject page) {
+    TopBar topBar = page.getTopBar();
 
     topBar
         .openNavigation()
@@ -35,12 +22,8 @@ public class NavigationTest extends NewTestTemplate {
     Assertion.assertTrue(topBar.isHamburgerIconVisible());
   }
 
-  @Test(groups = "mercury_navigation_resetNavigationState")
-  public void mercury_navigation_resetNavigationState() {
-    TopBar topBar =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar();
+  void mercury_navigation_resetNavigationState(WikiBasePageObject page) {
+    TopBar topBar = page.getTopBar();
 
     Navigation navigation = topBar.openNavigation();
 
@@ -54,13 +37,8 @@ public class NavigationTest extends NewTestTemplate {
     Assertion.assertTrue(navigation.isMainHeaderVisible());
   }
 
-  @Test(groups = "mercury_navigation_backButton")
-  public void mercury_navigation_backButton() {
-    Navigation navigation =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openNavigation();
+  void mercury_navigation_backButton(WikiBasePageObject page) {
+    Navigation navigation = page.getTopBar().openNavigation();
 
     Assertion.assertTrue(navigation.isMainHeaderVisible());
     navigation.openSubMenu(1);
@@ -71,51 +49,28 @@ public class NavigationTest extends NewTestTemplate {
     Assertion.assertTrue(navigation.isMainHeaderVisible());
   }
 
-  @Test(groups = "mercury_navigation_navigationOnEnglishWiki")
-  public void mercury_navigation_navigationOnEnglishWiki() {
-    Navigation navigation =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openNavigation();
+  void mercury_navigation_navigationOnEnglishWiki(WikiBasePageObject page) {
+    Navigation navigation = page.getTopBar().openNavigation();
 
     Assertion.assertTrue(navigation.areHubLinksVisible());
   }
 
-  @Execute(onWikia = MercuryWikis.DE_WIKI)
-  @Test(groups = "mercury_navigation_navigationOnNonEnglishWiki")
-  public void mercury_navigation_navigationOnNonEnglishWiki() {
-    Navigation navigation =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openNavigation();
+  void mercury_navigation_navigationOnNonEnglishWiki(WikiBasePageObject page) {
+    Navigation navigation = page.getTopBar().openNavigation();
 
     Assertion.assertFalse(navigation.areHubLinksVisible());
   }
 
-  @Execute(asUser = User.USER)
-  @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
-  public void mercury_navigation_navigationElementsUserLoggedIn() {
-    Navigation navigation =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openNavigation();
+  void mercury_navigation_navigationElementsUserLoggedIn(WikiBasePageObject page) {
+    Navigation navigation = page.getTopBar().openNavigation();
 
     Assertion.assertTrue(navigation.isUserAvatarVisible());
     Assertion.assertTrue(navigation.isUserProfileLinkVisible());
     Assertion.assertTrue(navigation.isLogoutLinkVisible());
   }
 
-  @Execute(asUser = User.ANONYMOUS)
-  @Test(groups = "mercury_navigation_navigationElementsAnonymousUser")
-  public void mercury_navigation_navigationElementsAnonymousUser() {
-    Navigation navigation =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openNavigation();
+  void mercury_navigation_navigationElementsAnonymousUser(WikiBasePageObject page) {
+    Navigation navigation = page.getTopBar().openNavigation();
 
     Assertion.assertTrue(navigation.isUserAvatarVisible());
     Assertion.assertFalse(navigation.isUserProfileLinkVisible());
@@ -123,11 +78,8 @@ public class NavigationTest extends NewTestTemplate {
     Assertion.assertEquals(navigation.getNavigationHeaderText(), "Sign In | Register");
   }
 
-  @Test(groups = "mercury_navigation_exploreWikiNavigatesToWikiMainPage")
-  public void mercury_navigation_exploreWikiNavigatesToWikiMainPage() {
-    new ArticlePage()
-        .open(MercurySubpages.INFOBOX_1)
-        .getTopBar()
+  void mercury_navigation_exploreWikiNavigatesToWikiMainPage(WikiBasePageObject page) {
+    page.getTopBar()
         .openNavigation()
         .clickExploreWikiHeader();
 

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationTests.java
@@ -6,7 +6,7 @@ import com.wikia.webdriver.elements.mercury.components.Navigation;
 import com.wikia.webdriver.elements.mercury.components.TopBar;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
-public abstract class NavigationTest extends NewTestTemplate {
+public abstract class NavigationTests extends NewTestTemplate {
 
   void mercury_navigation_openAndCloseNavigationAndItsSubMenu(WikiBasePageObject page) {
     TopBar topBar = page.getTopBar();

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMercuryTests.java
@@ -1,0 +1,90 @@
+package com.wikia.webdriver.testcases.mercurytests;
+
+import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
+import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
+import com.wikia.webdriver.elements.mercury.pages.SearchResultsPage;
+import com.wikia.webdriver.elements.mercury.pages.discussions.GuidelinesPage;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
+import org.testng.annotations.Test;
+
+@InBrowser(browser = Browser.CHROME)
+public class SearchMercuryTests extends SearchTests {
+
+  private static final String SEARCH_PHRASE = "Infobox";
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnMobile",
+                  "Mercury_Search_001"})
+  public void mercury_search_navigateUsingSearchSuggestionsOnMobile() {
+    String clickedSuggestion = new GuidelinesPage()
+        .open()
+        .getTopBar()
+        .openSearch()
+        .typeInSearch(SEARCH_PHRASE)
+        .clickSearchSuggestion(0, Skin.MERCURY);
+
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+    Assertion.assertEquals(
+        clickedSuggestion.toLowerCase(),
+        new ArticlePage().getHeader().getPageTitle().toLowerCase()
+    );
+  }
+
+  @Execute(onWikia = "dauto")
+  @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnDesktop",
+                  "Mercury_Search_001"})
+  @InBrowser(browser = Browser.CHROME, browserSize = "1920x1080")
+  public void mercury_search_navigateUsingSearchSuggestionsOnDesktop() {
+    String clickedSuggestion = new GuidelinesPage()
+        .open()
+        .getTopBar()
+        .typeInDesktopSearchAndSelectSuggestion(SEARCH_PHRASE, 0);
+
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.OASIS));
+    Assertion.assertEquals(
+        clickedSuggestion.toLowerCase(),
+        new ArticlePageObject().getArticleName().toLowerCase()
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_cancelSearchPhrase", "Mercury_Search_001"})
+  public void mercury_search_clearSearchPhrase() {
+    super.mercury_search_clearSearchPhrase(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_verifySearchLayout", "Mercury_Search_001"})
+  public void mercury_search_verifySearchLayout() {
+    super.mercury_search_verifySearchLayout(
+        new GuidelinesPage().open()
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_userIsRedirectedToSearchResultsPage", "Mercury_Search_001"})
+  public void mercury_search_userIsRedirectedToSearchResultsPage() {
+    SearchResultsPage searchResults =
+        new GuidelinesPage()
+            .open()
+            .getTopBar()
+            .openSearch()
+            .typeInSearch(SEARCH_PHRASE)
+            .clickEnterAndNavigateToSearchResults(Skin.MERCURY);
+
+    Assertion.assertTrue(searchResults.isSearchResultsPageOpen());
+  }
+}

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMercuryTests.java
@@ -41,7 +41,7 @@ public class SearchMercuryTests extends SearchTests {
   @Execute(onWikia = "dauto")
   @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnDesktop",
                   "Mercury_Search_001"})
-  @InBrowser(browser = Browser.CHROME, browserSize = "1920x1080")
+  @InBrowser(browser = Browser.FIREFOX, browserSize = "1920x1080")
   public void mercury_search_navigateUsingSearchSuggestionsOnDesktop() {
     String clickedSuggestion = new GuidelinesPage()
         .open()

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchMobileWikiTests.java
@@ -1,0 +1,226 @@
+package com.wikia.webdriver.testcases.mercurytests;
+
+import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
+import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
+import com.wikia.webdriver.elements.mercury.pages.SearchResultsPage;
+import org.testng.annotations.Test;
+
+@InBrowser(browser = Browser.CHROME)
+public class SearchMobileWikiTests extends SearchTests {
+
+  private static final String SEARCH_PHRASE = "Infobox";
+  private static final String SEARCH_PHRASE_NO_RESULTS = "AComplexQueryWithNoResults";
+  private static final String MULTIPLE_RESULTS_SEARCH_PHRASE = "Test";
+  private static final String SINGLE_RESULT_SEARCH_PHRASE = "SRPWithOnlyOneSearchResult";
+  private static final String EMPTY_SEARCH_PHRASE = "";
+  // Mobile Wiki tries to get 25 results, but a bug in the Search API returns 24 for the first batch
+  // See SUS-1151 for details
+  private static final int SEARCH_RESULTS_NUMBER_FIRST_BATCH = 24;
+  private static final int SEARCH_RESULTS_NUMBER_NEXT_BATCH = 25;
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnMobile",
+                  "Mercury_Search_001"})
+  public void mercury_search_navigateUsingSearchSuggestionsOnMobile() {
+    ArticlePage article = new ArticlePage().open(MercurySubpages.MAIN_PAGE);
+    String clickedSuggestion = article.getTopBar()
+        .openSearch()
+        .typeInSearch(SEARCH_PHRASE)
+        .clickSearchSuggestion(0, Skin.MOBILE_WIKI);
+
+    Assertion.assertEquals(
+        clickedSuggestion.toLowerCase(),
+        article.getHeader().getPageTitle().toLowerCase()
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_navigateToPageUsingSearchResults", "Mercury_Search_001"})
+  public void mercury_search_navigateToPageUsingSearchResults() {
+    String resultLink =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE)
+            .clickSearchResult(0);
+
+    Assertion.assertEquals(driver.getCurrentUrl(), resultLink);
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_cancelSearchPhrase", "Mercury_Search_001"})
+  public void mercury_search_clearSearchPhrase() {
+    super.mercury_search_clearSearchPhrase(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_verifySearchLayout", "Mercury_Search_001"})
+  public void mercury_search_verifySearchLayout() {
+    super.mercury_search_verifySearchLayout(
+        new ArticlePage().open(MercurySubpages.MAIN_PAGE)
+    );
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_userIsRedirectedToSearchResultsPage", "Mercury_Search_001"})
+  public void mercury_search_userIsRedirectedToSearchResultsPage() {
+    SearchResultsPage searchResults =
+        new ArticlePage()
+            .open(MercurySubpages.MAIN_PAGE)
+            .getTopBar()
+            .openSearch()
+            .typeInSearch(SEARCH_PHRASE)
+            .clickEnterAndNavigateToSearchResults(Skin.MOBILE_WIKI);
+
+    Assertion.assertTrue(searchResults.isSearchResultsPageOpen());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_searchResultsPageHasNoSearchIconInTopBar", "Mercury_Search_001"})
+  public void mercury_search_searchResultsPageHasNoSearchIconInTopBar() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE);
+
+    Assertion.assertFalse(resultsPage.getTopBar().isSearchIconClickable());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_searchInputDoesNotCoverNavigation", "Mercury_Search_001"})
+  public void mercury_search_searchInputDoesNotCoverNavigation() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE);
+
+    resultsPage
+        .getTopBar()
+        .openNavigation();
+
+    Assertion.assertFalse(resultsPage.getSearch().isSearchInputFieldEditable());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_searchNoResultsPageDisplayed", "Mercury_Search_002"})
+  public void mercury_search_searchNoResultsPageDisplayed() {
+    SearchResultsPage searchResults =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE_NO_RESULTS);
+
+    Assertion.assertTrue(searchResults.isNoResultsPagePresent());
+    Assertion.assertFalse(searchResults.isLoadMoreButtonVisible());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_noSuggestionsOnSearchResultsPage", "Mercury_Search_002"})
+  public void mercury_search_noSuggestionsOnSearchResultsPage() {
+    SearchResultsPage searchResults =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE_NO_RESULTS);
+
+    Assertion.assertFalse(searchResults.getSearch().areSearchSuggestionsDisplayed());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_focusOnTryAnotherSearchWhenNoResults", "Mercury_Search_002"})
+  public void mercury_search_focusOnTryAnotherSearchWhenNoResults() {
+    SearchResultsPage searchResults =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE_NO_RESULTS)
+            .clickTryAnotherSearch();
+
+    Assertion.assertTrue(searchResults.getSearch().isInputFieldFocused());
+    Assertion.assertTrue(searchResults.getSearch().getSearchPhrase().isEmpty());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_redirectToNewResultsPageFromNoResults",
+                  "Mercury_Search_002"})
+  public void mercury_search_redirectToNewResultsPageFromNoResults() {
+    SearchResultsPage searchResults =
+        new SearchResultsPage()
+            .openForQuery(SEARCH_PHRASE_NO_RESULTS)
+            .clickTryAnotherSearch()
+            .getSearch()
+            .typeInSearch(SEARCH_PHRASE)
+            .clickEnterAndNavigateToSearchResults(Skin.MOBILE_WIKI);
+
+    Assertion.assertTrue(searchResults.isSearchResultsPageOpen());
+    Assertion.assertFalse(searchResults.isNoResultsPagePresent());
+    Assertion.assertTrue(searchResults.areResultsPresent());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_defaultResultsNumberOnSearchResultsPage"})
+  public void mercury_search_defaultResultsNumberOnSearchResultsPage() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(MULTIPLE_RESULTS_SEARCH_PHRASE);
+
+    Assertion.assertEquals(resultsPage.getResultCardsNumber(), SEARCH_RESULTS_NUMBER_FIRST_BATCH);
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_loadingMoreResultsOnSearchResultsPage"})
+  public void mercury_search_loadingMoreResultsOnSearchResultsPage() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(MULTIPLE_RESULTS_SEARCH_PHRASE);
+
+    int defaultCardNumber = resultsPage.getResultCardsNumber();
+
+    Assertion.assertTrue(resultsPage.isLoadMoreButtonVisible());
+    Assertion.assertEquals(defaultCardNumber, SEARCH_RESULTS_NUMBER_FIRST_BATCH);
+
+    resultsPage.clickLoadMoreButton();
+    int moreResultsLoaded = resultsPage.getResultCardsNumber() - defaultCardNumber;
+
+    Assertion.assertEquals(moreResultsLoaded, SEARCH_RESULTS_NUMBER_NEXT_BATCH);
+    Assertion.assertTrue(resultsPage.isLoadMoreButtonVisible());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_loadMoreResultsOnSearchResultsPageNotVisible",
+                  "Mercury_Search_002"})
+  public void mercury_search_loadMoreResultsOnSearchResultsPageNotVisible() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(SINGLE_RESULT_SEARCH_PHRASE);
+
+    Assertion.assertTrue(resultsPage.getResultCardsNumber() < SEARCH_RESULTS_NUMBER_FIRST_BATCH);
+    Assertion.assertFalse(resultsPage.isLoadMoreButtonVisible());
+  }
+
+  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
+  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
+  @Test(groups = {"mercury_search_loadMoreResultsOnSearchResultsPageNotVisible",
+                  "Mercury_Search_002"})
+  public void mercury_search_emptySearchPhrase() {
+    SearchResultsPage resultsPage =
+        new SearchResultsPage()
+            .openForQuery(EMPTY_SEARCH_PHRASE);
+
+    Assertion.assertEquals(resultsPage.getResultCardsNumber(), 0);
+    Assertion.assertFalse(resultsPage.isLoadMoreButtonVisible());
+  }
+}

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchTests.java
@@ -41,7 +41,7 @@ public class SearchTests extends NewTestTemplate {
         .typeInSearch(SEARCH_PHRASE)
         .clickSearchSuggestion(0);
 
-    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MERCURY));
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
     Assertion.assertEquals(clickedSuggestion.toLowerCase(),
                            article.getHeader().getPageTitle().toLowerCase());
   }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/SearchTests.java
@@ -1,82 +1,16 @@
 package com.wikia.webdriver.testcases.mercurytests;
 
-import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
-import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
-import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.InBrowser;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
-import com.wikia.webdriver.common.core.drivers.Browser;
-import com.wikia.webdriver.common.core.helpers.Emulator;
-import com.wikia.webdriver.common.skin.Skin;
-import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.mercury.components.Search;
-import com.wikia.webdriver.elements.mercury.pages.ArticlePage;
-import com.wikia.webdriver.elements.mercury.pages.SearchResultsPage;
-import com.wikia.webdriver.elements.mercury.pages.discussions.DiscussionsPage;
-import com.wikia.webdriver.pageobjectsfactory.pageobject.article.ArticlePageObject;
+import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
-import org.testng.annotations.Test;
-
-@InBrowser(browser = Browser.CHROME)
 public class SearchTests extends NewTestTemplate {
 
   private static final String SEARCH_PHRASE = "Infobox";
-  private static final String SEARCH_PHRASE_NO_RESULTS = "AComplexQueryWithNoResults";
-  private static final String MULTIPLE_RESULTS_SEARCH_PHRASE = "Test";
-  private static final String SINGLE_RESULT_SEARCH_PHRASE = "SRPWithOnlyOneSearchResult";
-  private static final String EMPTY_SEARCH_PHRASE = "";
-  private static final int SEARCH_RESULTS_DEFAULT_NUMBER = 25;
 
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnMobile",
-                  "Mercury_Search_001"})
-  public void mercury_search_navigateUsingSearchSuggestionsOnMobile() {
-    ArticlePage article = new ArticlePage().open(MercurySubpages.MAIN_PAGE);
-    String clickedSuggestion = article.getTopBar()
-        .openSearch()
-        .typeInSearch(SEARCH_PHRASE)
-        .clickSearchSuggestion(0);
-
-    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
-    Assertion.assertEquals(clickedSuggestion.toLowerCase(),
-                           article.getHeader().getPageTitle().toLowerCase());
-  }
-
-  @Execute(onWikia = "dauto")
-  @Test(groups = {"mercury_search_navigateUsingSearchSuggestionsOnDesktop",
-                  "Mercury_Search_001"})
-  @InBrowser(browser = Browser.FIREFOX, browserSize = "1920x1080")
-  public void mercury_search_navigateUsingSearchSuggestionsOnDesktop() {
-    String clickedSuggestion = new DiscussionsPage().getTopBar()
-            .typeInDesktopSearchAndSelectSuggestion(SEARCH_PHRASE, 0);
-
-    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.OASIS));
-    Assertion.assertEquals(clickedSuggestion.toLowerCase(),
-                           new ArticlePageObject().getArticleName().toLowerCase());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_navigateToPageUsingSearchResults", "Mercury_Search_001"})
-  public void mercury_search_navigateToPageUsingSearchResults() {
-    String resultLink =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE)
-            .clickSearchResult(0);
-
-    Assertion.assertEquals(driver.getCurrentUrl(), resultLink);
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_cancelSearchPhrase", "Mercury_Search_001"})
-  public void mercury_search_clearSearchPhrase() {
-    String currentPhrase = new ArticlePage()
-        .open(MercurySubpages.MAIN_PAGE)
+  void mercury_search_clearSearchPhrase(WikiBasePageObject page) {
+    String currentPhrase = page
         .getTopBar()
         .openSearch()
         .typeInSearch(SEARCH_PHRASE)
@@ -86,174 +20,13 @@ public class SearchTests extends NewTestTemplate {
     Assertion.assertTrue(currentPhrase.isEmpty());
   }
 
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_verifySearchLayout", "Mercury_Search_001"})
-  public void mercury_search_verifySearchLayout() {
-    Search search =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openSearch();
+  void mercury_search_verifySearchLayout(WikiBasePageObject page) {
+    Search search = page
+        .getTopBar()
+        .openSearch();
 
     Assertion.assertTrue(search.isSearchInputFieldVisible());
     Assertion.assertTrue(search.isClearSearchButtonVisible());
     Assertion.assertTrue(search.isInputFieldSearchIconVisible());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_userIsRedirectedToSearchResultsPage", "Mercury_Search_001"})
-  public void mercury_search_userIsRedirectedToSearchResultsPage() {
-    SearchResultsPage searchResults =
-        new ArticlePage()
-            .open(MercurySubpages.MAIN_PAGE)
-            .getTopBar()
-            .openSearch()
-            .typeInSearch(SEARCH_PHRASE)
-            .clickEnterAndNavigateToSearchResults();
-
-    Assertion.assertTrue(searchResults.isSearchResultsPageOpen());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_searchResultsPageHasNoSearchIconInTopBar", "Mercury_Search_001"})
-  public void mercury_search_searchResultsPageHasNoSearchIconInTopBar() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE);
-
-    Assertion.assertFalse(resultsPage.getTopBar().isSearchIconClickable());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_searchInputDoesNotCoverNavigation", "Mercury_Search_001"})
-  public void mercury_search_searchInputDoesNotCoverNavigation() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE);
-
-    resultsPage
-        .getTopBar()
-        .openNavigation();
-
-    Assertion.assertFalse(resultsPage.getSearch().isSearchInputFieldEditable());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_searchNoResultsPageDisplayed", "Mercury_Search_002"})
-  public void mercury_search_searchNoResultsPageDisplayed() {
-    SearchResultsPage searchResults =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE_NO_RESULTS);
-
-    Assertion.assertTrue(searchResults.isNoResultsPagePresent());
-    Assertion.assertFalse(searchResults.isLoadMoreButtonVisible());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_noSuggestionsOnSearchResultsPage", "Mercury_Search_002"})
-  public void mercury_search_noSuggestionsOnSearchResultsPage() {
-    SearchResultsPage searchResults =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE_NO_RESULTS);
-
-    Assertion.assertFalse(searchResults.getSearch().areSearchSuggestionsDisplayed());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_focusOnTryAnotherSearchWhenNoResults", "Mercury_Search_002"})
-  public void mercury_search_focusOnTryAnotherSearchWhenNoResults() {
-    SearchResultsPage searchResults =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE_NO_RESULTS)
-            .clickTryAnotherSearch();
-
-    Assertion.assertTrue(searchResults.getSearch().isInputFieldFocused());
-    Assertion.assertTrue(searchResults.getSearch().getSearchPhrase().isEmpty());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_redirectToNewResultsPageFromNoResults",
-                  "Mercury_Search_002"})
-  public void mercury_search_redirectToNewResultsPageFromNoResults() {
-    SearchResultsPage searchResults =
-        new SearchResultsPage()
-            .openForQuery(SEARCH_PHRASE_NO_RESULTS)
-            .clickTryAnotherSearch()
-            .getSearch()
-            .typeInSearch(SEARCH_PHRASE)
-            .clickEnterAndNavigateToSearchResults();
-
-    Assertion.assertTrue(searchResults.isSearchResultsPageOpen());
-    Assertion.assertFalse(searchResults.isNoResultsPagePresent());
-    Assertion.assertTrue(searchResults.areResultsPresent());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_defaultResultsNumberOnSearchResultsPage"})
-  @DontRun(env = {"preview", "prod"})
-  @RelatedIssue(issueID = "SUS-1151")
-  public void mercury_search_defaultResultsNumberOnSearchResultsPage() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(MULTIPLE_RESULTS_SEARCH_PHRASE);
-
-    Assertion.assertEquals(resultsPage.getResultCardsNumber(), SEARCH_RESULTS_DEFAULT_NUMBER);
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_loadingMoreResultsOnSearchResultsPage"})
-  @DontRun(env = {"preview", "prod"})
-  @RelatedIssue(issueID = "SUS-1151")
-  public void mercury_search_loadingMoreResultsOnSearchResultsPage() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(MULTIPLE_RESULTS_SEARCH_PHRASE);
-
-    int defaultCardNumber = resultsPage.getResultCardsNumber();
-
-    Assertion.assertTrue(resultsPage.isLoadMoreButtonVisible());
-    Assertion.assertEquals(defaultCardNumber, SEARCH_RESULTS_DEFAULT_NUMBER);
-
-    resultsPage.clickLoadMoreButton();
-    int moreResultsLoaded = resultsPage.getResultCardsNumber() - defaultCardNumber;
-
-    Assertion.assertEquals(moreResultsLoaded, SEARCH_RESULTS_DEFAULT_NUMBER);
-    Assertion.assertTrue(resultsPage.isLoadMoreButtonVisible());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_loadMoreResultsOnSearchResultsPageNotVisible",
-                  "Mercury_Search_002"})
-  public void mercury_search_loadMoreResultsOnSearchResultsPageNotVisible() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(SINGLE_RESULT_SEARCH_PHRASE);
-
-    Assertion.assertTrue(resultsPage.getResultCardsNumber() < SEARCH_RESULTS_DEFAULT_NUMBER);
-    Assertion.assertFalse(resultsPage.isLoadMoreButtonVisible());
-  }
-
-  @Execute(onWikia = MercuryWikis.MERCURY_AUTOMATION_TESTING)
-  @InBrowser(emulator = Emulator.GOOGLE_NEXUS_5)
-  @Test(groups = {"mercury_search_loadMoreResultsOnSearchResultsPageNotVisible",
-                  "Mercury_Search_002"})
-  public void mercury_search_emptySearchPhrase() {
-    SearchResultsPage resultsPage =
-        new SearchResultsPage()
-            .openForQuery(EMPTY_SEARCH_PHRASE);
-
-    Assertion.assertEquals(resultsPage.getResultCardsNumber(), 0);
-    Assertion.assertFalse(resultsPage.isLoadMoreButtonVisible());
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/curatedcontenttests/EditorTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/curatedcontenttests/EditorTests.java
@@ -12,9 +12,10 @@ import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.common.Navigate;
-import com.wikia.webdriver.elements.mercury.components.Loading;
 import com.wikia.webdriver.elements.mercury.old.curatedcontent.CuratedContentPageObject;
 import com.wikia.webdriver.elements.mercury.old.curatedcontent.CuratedMainPagePageObject;
 import com.wikia.webdriver.elements.mercury.old.curatedcontent.EditorHomePageObject;
@@ -56,7 +57,6 @@ public class EditorTests extends NewTestTemplate {
   private SearchForImagePageObject search;
   private CroppingToolPageObject croppingTool;
   private Navigate navigate;
-  private Loading loading;
 
   private void init() {
     this.curatedMainPage = new CuratedMainPagePageObject(driver);
@@ -70,7 +70,6 @@ public class EditorTests extends NewTestTemplate {
     this.search = new SearchForImagePageObject(driver);
     this.croppingTool = new CroppingToolPageObject(driver);
     this.navigate = new Navigate();
-    this.loading = new Loading(driver);
   }
 
   @BeforeMethod(alwaysRun = true)
@@ -88,11 +87,15 @@ public class EditorTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.ECC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+
     Boolean result = curatedMainPage.isFeaturedContentVisible();
 
     Assertion.assertFalse(result, MercuryMessages.VISIBLE_MSG);
 
     navigate.toPage(MercuryPaths.ROOT_MAIN_EDIT);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MERCURY));
+
     editor.clickAddFeaturedContent();
     itemForm.typeDisplayName(ITEM_DISPLAY_NAME);
     itemForm.typePageName(ITEM_PAGE_NAME);
@@ -108,6 +111,7 @@ public class EditorTests extends NewTestTemplate {
     editor.waitForAddCategoryButtonToBeVisible();
     editor.publish();
 
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
     result = curatedMainPage.isFeaturedContentVisible();
 
     PageObjectLogging.log(
@@ -123,11 +127,15 @@ public class EditorTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.ECC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+
     Boolean result = curatedMainPage.isCuratedContentVisible();
 
     Assertion.assertFalse(result, MercuryMessages.VISIBLE_MSG);
 
     navigate.toPage(MercuryPaths.ROOT_MAIN_EDIT);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MERCURY));
+
     editor.clickAddSection();
     section.typeDisplayName(SECTION_DISPLAY_NAME);
     section.clickOnImage();
@@ -154,6 +162,7 @@ public class EditorTests extends NewTestTemplate {
     editor.waitForAddCategoryButtonToBeVisible();
     editor.publish();
 
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
     result = curatedMainPage.isCuratedContentVisible();
 
     PageObjectLogging.log(
@@ -177,11 +186,15 @@ public class EditorTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.ECC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
+
     Boolean result = curatedMainPage.isCuratedContentVisible();
 
     Assertion.assertFalse(result, MercuryMessages.VISIBLE_MSG);
 
     navigate.toPage(MercuryPaths.ROOT_MAIN_EDIT);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MERCURY));
+
     editor.clickAddCategory();
     itemForm.typeDisplayName(ITEM_DISPLAY_NAME);
     itemForm.typePageName(ITEM_PAGE_NAME);
@@ -197,6 +210,7 @@ public class EditorTests extends NewTestTemplate {
     editor.waitForAddCategoryButtonToBeVisible();
     editor.publish();
 
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
     result = curatedMainPage.isCuratedContentVisible();
 
     PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/curatedcontenttests/MainPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/curatedcontenttests/MainPageTests.java
@@ -10,6 +10,8 @@ import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
+import com.wikia.webdriver.common.skin.Skin;
+import com.wikia.webdriver.common.skin.SkinHelper;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.common.Navigate;
 import com.wikia.webdriver.elements.mercury.components.Loading;
@@ -69,6 +71,7 @@ public class MainPageTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.CC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
     new ArticlePageObject(driver).isFooterVisible();
 
     boolean result = driver.getCurrentUrl().contains(ROOT_PATH);
@@ -178,6 +181,7 @@ public class MainPageTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.ECC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
 
     boolean result = cc.isRevisedArticleTitleVisible();
     PageObjectLogging.log(
@@ -234,6 +238,7 @@ public class MainPageTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.NTACC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
 
     boolean result = !cc.isTrendingArticlesVisible();
     PageObjectLogging.log(
@@ -314,6 +319,7 @@ public class MainPageTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.NTVCC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
 
     boolean result = cc.isMobileTopLeaderboardVisible();
     PageObjectLogging.log(
@@ -378,6 +384,7 @@ public class MainPageTests extends NewTestTemplate {
     init();
 
     navigate.toPage(MercurySubpages.NTAVCC_MAIN_PAGE);
+    Assertion.assertTrue(new SkinHelper(driver).isSkin(Skin.MOBILE_WIKI));
 
     boolean result = cc.isMobileTopLeaderboardVisible();
     PageObjectLogging.log(

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -179,8 +179,8 @@
             <class name="com.wikia.webdriver.testcases.mercurytests.HTMLTitleTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.ImageReviewTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.LoginTests"/>
-            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMercuryTest"/>
-            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMobileWikiTest"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMercuryTests"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMobileWikiTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SearchTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SmartBannerTest"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.TopBarTests"/>

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -181,7 +181,8 @@
             <class name="com.wikia.webdriver.testcases.mercurytests.LoginTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMercuryTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMobileWikiTests"/>
-            <class name="com.wikia.webdriver.testcases.mercurytests.SearchTests"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.SearchMercuryTests"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.SearchMobileWikiTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SmartBannerTest"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.TopBarTests"/>
             <class name="com.wikia.webdriver.testcases.messagewall.MessageWallFeaturesTests"/>

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -179,7 +179,8 @@
             <class name="com.wikia.webdriver.testcases.mercurytests.HTMLTitleTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.ImageReviewTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.LoginTests"/>
-            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationTest"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMercuryTest"/>
+            <class name="com.wikia.webdriver.testcases.mercurytests.NavigationMobileWikiTest"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SearchTests"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.SmartBannerTest"/>
             <class name="com.wikia.webdriver.testcases.mercurytests.TopBarTests"/>


### PR DESCRIPTION
Mercury handles:
- Discussions
- Image Review
- Curated Content Editor
- Infobox Builder

Mobile Wiki handles:
- Wiki Pages
- Curated Main Pages
- Article Preview
- Mobile Search Results Page (`/search`)

They both use Navigation and Search Suggestions, which share most of the code between apps but differ in the way they handle different routes. E.g. when you're on Discussions (handled by Mercury), open Navigation and click a link to article, you'll have full page reload and Mobile Wiki will be loaded. If you do the same thing while on a different article, you'll stay in the SPA without page reload.

This PR updates tests to check shared features in both apps and make sure that navigation between them works as expected.

@ludwikkazmierczak @kvas-damian @idradm @qaga 