### PR TITLE
IRIS-hotfix | moved upvoting tests back to dauto wikia because they don't really work anywhere else

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/discussions/UpvotingTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/UpvotingTests.java
@@ -14,7 +14,7 @@ import com.wikia.webdriver.elements.mercury.components.discussions.common.Reply;
 import com.wikia.webdriver.elements.mercury.pages.discussions.PostDetailsPage;
 import com.wikia.webdriver.elements.mercury.pages.discussions.PostsListPage;
 
-@Execute(onWikia = MercuryWikis.DISCUSSIONS_4)
+@Execute(onWikia = MercuryWikis.DISCUSSIONS_1)
 @Test(groups = {"discussions-upvoting"})
 public class UpvotingTests extends NewTestTemplate {
 


### PR DESCRIPTION
To be fixed properly in https://wikia-inc.atlassian.net/browse/IRIS-4139