### PR TITLE
NotificationsComponentObject: fix verifyNotification

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/global_navitagtion/NotificationsComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/global_navitagtion/NotificationsComponentObject.java
@@ -23,7 +23,7 @@ public class NotificationsComponentObject extends WikiBasePageObject {
   private List<WebElement> notificationsList;
   @FindBy(css = "#notificationsContainer")
   private WebElement notificationsDropdown;
-  @FindBy(css = ".wds-global-navigation__notifications-menu-counter")
+  @FindBy(css = ".wds-global-navigation__notifications-menu-counter.notifications-count")
   private WebElement bubblesCount;
   @FindBy(css = "#wall-notifications-markasread-sub")
   private WebElement markNotificationsAsRead;


### PR DESCRIPTION
Use more specific CSS selector to get bubblesCount for Wall, not for on site notifications

Porting @macbre fix to preview