### PR TITLE
IRIS-dirty-dirty-hotfix | fixes tests for opening navigation in mobile wiki and mobile view in mercury

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
@@ -23,7 +23,7 @@ public class TopBar extends BasePageObject {
   @FindBy(css = ".logo-fandom")
   private WebElement logoFandom;
 
-  @FindBy(css = ".site-head-icon-nav")
+  @FindBy(css = ".site-head__nav-icon-wrapper")
   private WebElement hamburgerIcon;
 
   @FindBy(css = ".site-head-icon-search")

--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/TopBar.java
@@ -23,7 +23,7 @@ public class TopBar extends BasePageObject {
   @FindBy(css = ".logo-fandom")
   private WebElement logoFandom;
 
-  @FindBy(css = ".site-head__nav-icon-wrapper")
+  @FindBy(css = ".site-head-icon-nav")
   private WebElement hamburgerIcon;
 
   @FindBy(css = ".site-head-icon-search")

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
@@ -54,7 +54,7 @@ public class NavigationMercuryTests extends NavigationTests {
   }
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
-  @Execute(asUser = User.USER)
+  @Execute(asUser = User.USER_3)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new GuidelinesPage().open()

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
@@ -55,7 +55,6 @@ public class NavigationMercuryTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
   @Execute(asUser = User.USER)
-  @InBrowser(browser = Browser.FIREFOX)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new GuidelinesPage().open()

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMercuryTests.java
@@ -55,6 +55,7 @@ public class NavigationMercuryTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
   @Execute(asUser = User.USER)
+  @InBrowser(browser = Browser.FIREFOX)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new GuidelinesPage().open()

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
@@ -55,7 +55,6 @@ public class NavigationMobileWikiTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
   @Execute(asUser = User.USER)
-  @InBrowser(browser = Browser.FIREFOX)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new ArticlePage().open(MercurySubpages.MAIN_PAGE)

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
@@ -55,6 +55,7 @@ public class NavigationMobileWikiTests extends NavigationTests {
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
   @Execute(asUser = User.USER)
+  @InBrowser(browser = Browser.FIREFOX)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new ArticlePage().open(MercurySubpages.MAIN_PAGE)

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/NavigationMobileWikiTests.java
@@ -54,7 +54,7 @@ public class NavigationMobileWikiTests extends NavigationTests {
   }
 
   @Test(groups = "mercury_navigation_navigationElementsUserLoggedIn")
-  @Execute(asUser = User.USER)
+  @Execute(asUser = User.USER_3)
   public void mercury_navigation_navigationElementsUserLoggedIn() {
     super.mercury_navigation_navigationElementsUserLoggedIn(
         new ArticlePage().open(MercurySubpages.MAIN_PAGE)


### PR DESCRIPTION
Dirty dirty hotfix. Rationale: 
- X-Wing's tests failed because navigation wouldn't open when notifications unread count covers up hamburger menu (opened https://wikia-inc.atlassian.net/browse/IRIS-4302 to address that)
- quick research shows that it is supposedly possible to click such a covered element in Firefox and IE drivers, however I can't switch to run these tests on anything else than Chrome driver, because it's the only one to work with mobile view
- Ticket to switch back to user with notifications when the whole thing is clickable: https://wikia-inc.atlassian.net/browse/IRIS-4303