### PR TITLE
Staging article mercury

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
@@ -5,7 +5,6 @@ public class MercurySubpages {
   // Articles prepared for mercuryautomationtesting.wikia.com wiki
   public static final String MAIN_PAGE = "/wiki/Main_Page";
   public static final String GALLERY = "/wiki/Gallery";
-  public static final String LINKED_IMAGES = "/wiki/LinkedImages";
   public static final String TOC = "/wiki/TOC";
   public static final String TOC_WITHOUT_H2 = "/wiki/TOCWithoutH2";
   public static final String TOC_WITH_PORTABLE_INFOBOX = "/wiki/TOC_with_portable_infobox";

--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/MercurySubpages.java
@@ -3,7 +3,7 @@ package com.wikia.webdriver.common.contentpatterns;
 public class MercurySubpages {
 
   // Articles prepared for mercuryautomationtesting.wikia.com wiki
-  public static final String MAIN_PAGE = "/wiki/Mercury_automation_testing_Wikia";
+  public static final String MAIN_PAGE = "/wiki/Main_Page";
   public static final String GALLERY = "/wiki/Gallery";
   public static final String LINKED_IMAGES = "/wiki/LinkedImages";
   public static final String TOC = "/wiki/TOC";

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/ArticlePageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/ArticlePageObject.java
@@ -58,7 +58,7 @@ public class ArticlePageObject {
   }
 
   public void clickOnAnchorInContent(int index) {
-    wait.forElementVisible(anchorsInContent.get(index));
+    wait.forElementClickable(anchorsInContent.get(index));
     anchorsInContent.get(index).click();
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -36,6 +36,9 @@ public class ArticlePageTests extends NewTestTemplate {
   private static final String MAIN_PAGE_CONTENT =
           ContentLoader.loadWikiTextContent("Mercury_MainPage");
 
+  private static final String LINKED_IMAGES_CONTENT =
+          ContentLoader.loadWikiTextContent("Mercury_LinkedImages");
+
   private void init() {
     this.topBar = new TopBar();
     this.navigation = new Navigation(driver);
@@ -46,11 +49,11 @@ public class ArticlePageTests extends NewTestTemplate {
   @Test(groups = "mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible")
   public void mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible() {
     new ArticleContent().clear();
-    new ArticleContent().push(MAIN_PAGE_CONTENT, MercurySubpages.MAIN_PAGE);
+    new ArticleContent().push(MAIN_PAGE_CONTENT, "Main_Page");
 
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
-    navigate.toPage(MercurySubpages.MAIN_PAGE);
+    navigate.toPage("/wiki/Main_Page");
 
     Assertion.assertTrue(articlePage.isWikiaLogoVisible());
     Assertion.assertTrue(articlePage.isSearchButtonVisible());
@@ -63,11 +66,11 @@ public class ArticlePageTests extends NewTestTemplate {
   @Test(groups = "mercury_article_linksInTopContributorsSectionRedirectsToUserPage")
   public void mercury_article_linksInTopContributorsSectionRedirectsToUserPage() {
     new ArticleContent().clear();
-    new ArticleContent().push(MAIN_PAGE_CONTENT, MercurySubpages.MAIN_PAGE);
+    new ArticleContent().push(MAIN_PAGE_CONTENT, "Main_Page");
 
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
-    navigate.toPage(MercurySubpages.MAIN_PAGE);
+    navigate.toPage("/wiki/Main_Page");
 
     articlePage.clickTopContributor(0);
 
@@ -76,25 +79,27 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_linkedImagesRedirectToCorrespondingUrl")
   public void mercury_article_linkedImagesRedirectToCorrespondingUrl() {
+    new ArticleContent().clear();
+    new ArticleContent().push(LINKED_IMAGES_CONTENT, "LinkedImages");
+
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
-    navigate.toPage(MercurySubpages.LINKED_IMAGES);
+    navigate.toPage("/wiki/LinkedImages");
 
     String oldUrl = driver.getCurrentUrl();
     articlePage.clickOnImage(0);
     loading.handleAsyncPageReload();
+    System.out.println(oldUrl);
+    System.out.println(driver.getCurrentUrl());
 
-    boolean result = !driver.getCurrentUrl().equals(oldUrl);
-    PageObjectLogging.log(
-        "Redirection",
-        "works",
-        "does not work",
-        result
-    );
+    Assertion.assertFalse(driver.getCurrentUrl().equals(oldUrl));
   }
 
   @Test(groups = "mercury_article_navigateToArticlesWithColonAndQuestionMark")
   public void mercury_article_navigateToArticlesWithColonAndQuestionMark() {
+    new ArticleContent().push("Article about colon [[Question?mark?question]]", "Colon:colon:colon");
+    new ArticleContent().push("Article about question mark [[Colon:colon:colon]]", "Question?mark?question");
+
     init();
     ArticlePageObject article = new ArticlePageObject(driver);
 
@@ -108,40 +113,14 @@ public class ArticlePageTests extends NewTestTemplate {
 
     navigate.toPage(encodedColonUrl);
 
-    boolean result = driver.getCurrentUrl().contains(encodedColonUrl);
-    PageObjectLogging.log(
-        "URL for colon",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for colon",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedColonUrl));
+    Assertion.assertTrue(MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     navigate.toPage(encodedQuestionMarkUrl);
 
-    result = driver.getCurrentUrl().contains(encodedQuestionMarkUrl);
-    PageObjectLogging.log(
-        "URL for question mark",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.QUESTION_MARK.toLowerCase()
-        .contains(article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for question mark",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedQuestionMarkUrl));
+    System.out.println(article.getArticleTitle().toLowerCase());
+    Assertion.assertTrue(MercurySubpages.QUESTION_MARK.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     PageObjectLogging.logWarning(
         "Info",
@@ -151,41 +130,14 @@ public class ArticlePageTests extends NewTestTemplate {
     article.clickOnAnchorInContent(0);
     loading.handleAsyncPageReload();
 
-    result = !driver.getCurrentUrl().contains(encodedColonUrl);
-    PageObjectLogging.log(
-        "URL for colon",
-        "is not encoded",
-        "is encoded",
-        result
-    );
-
-    result = MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for colon",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertFalse(driver.getCurrentUrl().contains(encodedColonUrl));
+    Assertion.assertTrue(MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     article.clickOnAnchorInContent(0);
     loading.handleAsyncPageReload();
 
-    result = driver.getCurrentUrl().contains(encodedQuestionMarkUrl);
-    PageObjectLogging.log(
-        "URL for question mark",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.QUESTION_MARK.toLowerCase().contains(
-        article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for question mark",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedQuestionMarkUrl));
+    Assertion.assertTrue(MercurySubpages.QUESTION_MARK.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     PageObjectLogging.logWarning("Info", "Accessing article through link in navigation side");
 
@@ -193,80 +145,26 @@ public class ArticlePageTests extends NewTestTemplate {
     navigation.openSubMenu(3);
     navigation.openPageLink(5);
 
-    result = !driver.getCurrentUrl().contains(encodedColonUrl);
-    PageObjectLogging.log(
-        "URL for colon",
-        "is not encoded",
-        "is encoded",
-        result
-    );
-
-    result = MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for colon",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertFalse(driver.getCurrentUrl().contains(encodedColonUrl));
+    Assertion.assertTrue(MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     topBar.openNavigation();
     navigation.openSubMenu(3);
     navigation.openPageLink(4);
 
-    result = driver.getCurrentUrl().contains(encodedQuestionMarkUrl);
-    PageObjectLogging.log(
-        "URL for question mark",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.QUESTION_MARK.toLowerCase().contains(
-        article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for question mark",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedQuestionMarkUrl));
+    Assertion.assertTrue(MercurySubpages.QUESTION_MARK.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     PageObjectLogging.logWarning("Info", "Accessing article through link in search result");
 
     topBar.openSearch().navigateToPage(MercurySubpages.COLON.substring(6));
 
-    result = driver.getCurrentUrl().contains(encodedColonUrl);
-    PageObjectLogging.log(
-        "URL for colon",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for colon",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedColonUrl));
+    Assertion.assertTrue(MercurySubpages.COLON.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     topBar.openSearch().navigateToPage(MercurySubpages.QUESTION_MARK.substring(6));
 
-    result = driver.getCurrentUrl().contains(encodedQuestionMarkUrl);
-    PageObjectLogging.log(
-        "URL for question mark",
-        "is encoded",
-        "is not encoded",
-        result
-    );
-
-    result = MercurySubpages.QUESTION_MARK.toLowerCase().contains(
-        article.getArticleTitle().toLowerCase());
-    PageObjectLogging.log(
-        "Article title for question mark",
-        "is correct",
-        "is not correct",
-        result
-    );
+    Assertion.assertTrue(driver.getCurrentUrl().contains(encodedQuestionMarkUrl));
+    Assertion.assertTrue(MercurySubpages.QUESTION_MARK.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -2,9 +2,13 @@ package com.wikia.webdriver.testcases.mercurytests.old;
 
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
+import com.wikia.webdriver.common.contentpatterns.PageContent;
+import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.ContentLoader;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -29,6 +33,9 @@ public class ArticlePageTests extends NewTestTemplate {
   private Navigate navigate;
   private Loading loading;
 
+  private static final String MAIN_PAGE_CONTENT =
+          ContentLoader.loadWikiTextContent("Mercury_MainPage");
+
   private void init() {
     this.topBar = new TopBar();
     this.navigation = new Navigation(driver);
@@ -38,57 +45,19 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible")
   public void mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible() {
+    new ArticleContent().clear();
+    new ArticleContent().push(MAIN_PAGE_CONTENT, "/Main_Page");
+
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
-    navigate.toPage(MercurySubpages.MAIN_PAGE);
+    navigate.toPage("/Main_Page");
 
-    boolean result = articlePage.isWikiaLogoVisible();
-    PageObjectLogging.log(
-        "Wikia logo",
-        "is visible",
-        "is not visible",
-        result
-    );
-
-    result = articlePage.isSearchButtonVisible();
-    PageObjectLogging.log(
-        "Search button",
-        "is visible",
-        "is not visible",
-        result
-    );
-
-    result = articlePage.isTopContributorsSectionVisible();
-    PageObjectLogging.log(
-        "Top contributors section",
-        "is visible",
-        "is not visible",
-        result
-    );
-
-    result = articlePage.isTopContributorsThumbVisible(0);
-    PageObjectLogging.log(
-        "Top contributors thumb",
-        "is visible",
-        "is not visible",
-        result
-    );
-
-    result = articlePage.isFooterVisible();
-    PageObjectLogging.log(
-        "Global footer",
-        "is visible",
-        "is not visible",
-        result
-    );
-
-    result = articlePage.isFooterLogoVisible();
-    PageObjectLogging.log(
-        "Global footer logo",
-        "is visible",
-        "is not visible",
-        result
-    );
+    Assertion.assertTrue(articlePage.isWikiaLogoVisible());
+    Assertion.assertTrue(articlePage.isSearchButtonVisible());
+    Assertion.assertTrue(articlePage.isTopContributorsSectionVisible());
+    Assertion.assertTrue(articlePage.isTopContributorsThumbVisible(0));
+    Assertion.assertTrue(articlePage.isFooterVisible());
+    Assertion.assertTrue(articlePage.isFooterLogoVisible());
   }
 
   @Test(groups = "mercury_article_linksInTopContributorsSectionRedirectsToUserPage")

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -86,8 +86,6 @@ public class ArticlePageTests extends NewTestTemplate {
     String oldUrl = driver.getCurrentUrl();
     articlePage.clickOnImage(0);
     loading.handleAsyncPageReload();
-    System.out.println(oldUrl);
-    System.out.println(driver.getCurrentUrl());
 
     Assertion.assertFalse(driver.getCurrentUrl().equals(oldUrl));
   }
@@ -116,7 +114,6 @@ public class ArticlePageTests extends NewTestTemplate {
     navigate.toPage(encodedQuestionMarkUrl);
 
     Assertion.assertTrue(driver.getCurrentUrl().contains(encodedQuestionMarkUrl));
-    System.out.println(article.getArticleTitle().toLowerCase());
     Assertion.assertTrue(MercurySubpages.QUESTION_MARK.toLowerCase().contains(article.getArticleTitle().toLowerCase()));
 
     PageObjectLogging.logWarning(

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -46,11 +46,11 @@ public class ArticlePageTests extends NewTestTemplate {
   @Test(groups = "mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible")
   public void mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible() {
     new ArticleContent().clear();
-    new ArticleContent().push(MAIN_PAGE_CONTENT, "/Main_Page");
+    new ArticleContent().push(MAIN_PAGE_CONTENT, MercurySubpages.MAIN_PAGE);
 
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
-    navigate.toPage("/Main_Page");
+    navigate.toPage(MercurySubpages.MAIN_PAGE);
 
     Assertion.assertTrue(articlePage.isWikiaLogoVisible());
     Assertion.assertTrue(articlePage.isSearchButtonVisible());
@@ -62,19 +62,16 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_linksInTopContributorsSectionRedirectsToUserPage")
   public void mercury_article_linksInTopContributorsSectionRedirectsToUserPage() {
+    new ArticleContent().clear();
+    new ArticleContent().push(MAIN_PAGE_CONTENT, MercurySubpages.MAIN_PAGE);
+
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);
     navigate.toPage(MercurySubpages.MAIN_PAGE);
 
     articlePage.clickTopContributor(0);
 
-    boolean result = articlePage.isUrlContainingUserPage();
-    PageObjectLogging.log(
-        "Url",
-        "match pattern /wiki/User:",
-        "does not match pattern /wiki/User:",
-        result
-    );
+    Assertion.assertTrue(articlePage.isUrlContainingUserPage());
   }
 
   @Test(groups = "mercury_article_linkedImagesRedirectToCorrespondingUrl")

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -2,7 +2,6 @@ package com.wikia.webdriver.testcases.mercurytests.old;
 
 import com.wikia.webdriver.common.contentpatterns.MercurySubpages;
 import com.wikia.webdriver.common.contentpatterns.MercuryWikis;
-import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -34,9 +34,10 @@ public class ArticlePageTests extends NewTestTemplate {
 
   private static final String MAIN_PAGE_CONTENT =
           ContentLoader.loadWikiTextContent("Mercury_MainPage");
-
   private static final String LINKED_IMAGES_CONTENT =
           ContentLoader.loadWikiTextContent("Mercury_LinkedImages");
+  private static final String GALLERY_CONTENT =
+          ContentLoader.loadWikiTextContent("Mercury_Gallery");
 
   private void init() {
     this.topBar = new TopBar();
@@ -77,6 +78,7 @@ public class ArticlePageTests extends NewTestTemplate {
   @Test(groups = "mercury_article_linkedImagesRedirectToCorrespondingUrl")
   public void mercury_article_linkedImagesRedirectToCorrespondingUrl() {
     new ArticleContent().push(LINKED_IMAGES_CONTENT, "LinkedImages");
+    new ArticleContent().push(GALLERY_CONTENT, "Gallery");
 
     init();
     ArticlePageObject articlePage = new ArticlePageObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mercurytests/old/ArticlePageTests.java
@@ -48,7 +48,6 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible")
   public void mercury_article_wikiaLogoTopContributorsSectionAndFooterElementsAreVisible() {
-    new ArticleContent().clear();
     new ArticleContent().push(MAIN_PAGE_CONTENT, "Main_Page");
 
     init();
@@ -65,7 +64,6 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_linksInTopContributorsSectionRedirectsToUserPage")
   public void mercury_article_linksInTopContributorsSectionRedirectsToUserPage() {
-    new ArticleContent().clear();
     new ArticleContent().push(MAIN_PAGE_CONTENT, "Main_Page");
 
     init();
@@ -79,7 +77,6 @@ public class ArticlePageTests extends NewTestTemplate {
 
   @Test(groups = "mercury_article_linkedImagesRedirectToCorrespondingUrl")
   public void mercury_article_linkedImagesRedirectToCorrespondingUrl() {
-    new ArticleContent().clear();
     new ArticleContent().push(LINKED_IMAGES_CONTENT, "LinkedImages");
 
     init();

--- a/src/test/resources/TextFiles/Mercury_Gallery
+++ b/src/test/resources/TextFiles/Mercury_Gallery
@@ -1,0 +1,106 @@
+===Gallery===
+Position tests
+left
+<gallery position="left">
+Image010.jpg|GalleryCaption001
+Image009.jpg|caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+center
+<gallery position="center">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+right
+<gallery position="right">
+File:Naruto_Manga_Sequel_Coming_In_2015_-_IGN_News
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+
+Caption tests
+<gallery>
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+Image007.jpg|[http://google.com Google]
+File:Naruto_Manga_Sequel_Coming_In_2015_-_IGN_News
+</gallery>
+
+===Gallery slider===
+Caption tests
+<gallery type="slider">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+Image007.jpg|[http://google.com Google]
+</gallery>
+
+Position tests
+left
+<gallery type="slider" position="left">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+center
+<gallery type="slider" position="center">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+right
+<gallery type="slider" position="right">
+Image010.jpg|GalleryCaption001
+Image009.jpg|caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+
+
+===Gallery slideshow===
+Caption tests
+<gallery type="slideshow">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+Image007.jpg|[http://google.com Google]
+</gallery>
+
+Position tests
+left
+<gallery type="slideshow" position="left">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+center
+<gallery type="slideshow" position="center">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+right
+<gallery type="slideshow" position="right">
+Image010.jpg|GalleryCaption001
+Image009.jpg|Caption + link http://google.com/
+Image008.jpg|http://google.com
+</gallery>
+
+===Images as File===
+
+[[File:Midnight Tango (2011) - Theatrical Trailer for Midnight Tango|thumb|335 px|center|caption 1]]
+[[File:Burton-jane-ginger-domestic-kitten-felis-catus-rolling-on-back-playing.jpg|thumb|sweet kitty]]
+[[File:Image010.jpg|center|link=w:c:www:Wikia|caption 2]]
+
+[[File:Image010.jpg|center|link=http://iam8bit.com/|caption 3]]
+[[File:Image010.jpg|center|link=http://www.logitech.com/|caption 4]]
+[[File:Image010.jpg|center|link=http://www.porternovelli.com/|caption 5]]
+[[File:Image008.jpg|left|link=w:c:www:Wikia|caption 6]]
+[[File:Image008.jpg|left|link=w:c:www:Wikia|caption 7]]
+[[File:Image008.jpg|right|link=w:c:www:Wikia|caption 8]]
+[[File:Image008.jpg|right|link=MercuryGallery|caption 9]]
+[[File:Red.jpg|center|caption 10]]
+[[File:The_Hobbit-Official_Trailer|center|caption 11]]
+[[Category:Galleries]]

--- a/src/test/resources/TextFiles/Mercury_LinkedImages
+++ b/src/test/resources/TextFiles/Mercury_LinkedImages
@@ -1,0 +1,46 @@
+[[File:Red.jpg|left|thumb|220x220px|link=Gallery]]
+
+Linked single images testing #1
+
+[[File:Image009.jpg|thumb|left|link=Gallery|Link to article]]
+
+Linked single images testing #2
+
+[[File:Image010.jpg|thumb|left|link=https://www.facebook.com|Link to external site]]
+
+Linked single images testing #3
+
+[[File:Image009.jpg|thumb|left|link=w:c:Glee:QAWebdriverCaption1|Link to article]]
+
+Linked slideshow images
+
+<gallery type="slideshow" navigation="true">
+Image010.jpg|Linked image long caption|link=https://www.facebook.com/|linktext=This should be clickable and redirecting user to facebook
+Image006.jpg|Long caption no link THIS IS TESTING A LONG CAPTION WITHOUT ANY LINK IN A SLIDESHOW|linktext=THIS IS TESTING A LONG CAPTION WITHOUT ANY LINK IN A SLIDESHOW
+Image005.jpg
+Image002.jpg|bla bla
+Image001.jpg
+</gallery>
+
+<gallery type="slideshow" navigation="true">
+Image010.jpg|Linked image long caption|link=https://www.facebook.com/|linktext=This should be clickable and redirecting user to facebook
+Image006.jpg|Long caption no link THIS IS TESTING A LONG CAPTION WITHOUT ANY LINK IN A SLIDESHOW|linktext=THIS IS TESTING A LONG CAPTION WITHOUT ANY LINK IN A SLIDESHOW
+Image005.jpg
+Image002.jpg
+Image001.jpg
+</gallery>
+
+<gallery type="slider">
+Image006.jpg|LONG CAPTION LINKED LONG CAPTION LINKED LONG CAPTI|link=https://www.facebook.com/|linktext=WHERE IS THIS APPEARING?
+Image005.jpg|LONG CAPTION LINKED|link=Non existent article|linktext=WHERE DOES THIS APPEAR AGAIN?
+Image004.jpg
+</gallery>
+
+No  Linked Images
+
+<gallery>
+Image010.jpg
+Image009.jpg
+Image006.jpg
+Image005.jpg
+</gallery>

--- a/src/test/resources/TextFiles/Mercury_MainPage
+++ b/src/test/resources/TextFiles/Mercury_MainPage
@@ -1,0 +1,18 @@
+<mainpage-leftcolumn-start />
+==Welcome to the Wiki==
+
+Welcome to the Mercury Automation Testing Wiki!
+
+
+==Latest activity==
+
+<activityfeed/>
+
+<mainpage-endcolumn />
+
+<mainpage-rightcolumn-start />
+
+Photos and videos are a great way to add visuals to your wiki. Find videos about your topic by exploring Wikia's [[w:c:video|Video Library]].
+
+[[File:Placeholder|298px]]
+<mainpage-endcolumn />


### PR DESCRIPTION
* Prepare Mercury Article tests to staging env - tests should prepare data set on it's own, before test's execution.
* Remove PageObjectLogging info, user Assertions on top level
* Tests verified working on production
* There's a bug with URL encoding in Mercury on staging although test code should stay as it is

@ludwikkazmierczak @sczerwinski-wikia 