### PR TITLE
Rewritten old mobile emulation devices to an explicit definition

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/drivers/browsers/ChromeBrowser.java
+++ b/src/test/java/com/wikia/webdriver/common/core/drivers/browsers/ChromeBrowser.java
@@ -63,6 +63,9 @@ public class ChromeBrowser extends BrowserAbstract {
 
     if (!emulator.equals(Emulator.DEFAULT)) {
       Map<String, Object> mobileEmulation = new HashMap<>();
+      if(StringUtils.isNotBlank(emulator.getUserAgent())){
+        mobileEmulation.put("userAgent", emulator.getUserAgent());
+      }
       if (StringUtils.isNotBlank(emulator.getDeviceName())) {
         mobileEmulation.put("deviceName", emulator.getDeviceName());
       } else {

--- a/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
@@ -7,8 +7,24 @@ import lombok.Getter;
 import com.google.common.collect.ImmutableMap;
 
 public enum Emulator {
-  GOOGLE_NEXUS_5("Google Nexus 5"),
-  APPLE_IPHONE_6("Apple iPhone 6"),
+  GOOGLE_NEXUS_5(
+      new ImmutableMap.Builder<String, Object>()
+          .put("width", 360)
+          .put("height", 640)
+          .put("pixelRatio", 3.0)
+          .put("touch", true)
+          .put("mobile", true)
+          .build(),
+      "Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"),
+  APPLE_IPHONE_6(
+      new ImmutableMap.Builder<String, Object>()
+          .put("width", 375)
+          .put("height", 667)
+          .put("pixelRatio", 2.0)
+          .put("touch", true)
+          .put("mobile", true)
+          .build(),
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"),
   DESKTOP_BREAKPOINT_BIG(
       new ImmutableMap.Builder<String, Object>()
           .put("width", 1296)
@@ -39,12 +55,21 @@ public enum Emulator {
   private String deviceName;
   @Getter
   private Map<String, Object> deviceMetrics;
+  @Getter
+  private String userAgent;
 
   Emulator(String deviceName) {
     this.deviceName = deviceName;
+    this.userAgent = "";
   }
 
   Emulator(Map<String, Object> deviceMetrics) {
     this.deviceMetrics = deviceMetrics;
+    this.userAgent = "";
+  }
+
+  Emulator(Map<String, Object> deviceMetrics, String userAgent) {
+    this.deviceMetrics = deviceMetrics;
+    this.userAgent = userAgent;
   }
 }


### PR DESCRIPTION
Cause Google changed their device name map, and now - "GOOGLE NEXUS 5" is just "NEXUS_5" in new chrome 😿 