### PR TITLE
Fix tests for promoting

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
@@ -25,6 +25,7 @@ public enum Emulator {
           .put("mobile", true)
           .build(),
       "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"),
+  NEXUS_5X("Nexus 5X"),
   DESKTOP_BREAKPOINT_BIG(
       new ImmutableMap.Builder<String, Object>()
           .put("width", 1296)

--- a/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/Emulator.java
@@ -25,7 +25,16 @@ public enum Emulator {
           .put("mobile", true)
           .build(),
       "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"),
-  NEXUS_5X("Nexus 5X"),
+  NEXUS_5X(
+    new ImmutableMap.Builder<String, Object>()
+      .put("width", 412)
+      .put("height", 732)
+      .put("pixelRatio", 3.0)
+      .put("touch", true)
+      .put("mobile", true)
+      .build(),
+    "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Mobile Safari/537.36"
+  ),
   DESKTOP_BREAKPOINT_BIG(
       new ImmutableMap.Builder<String, Object>()
           .put("width", 1296)

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
@@ -61,7 +61,7 @@ public class PromotingTests extends NewTestTemplate {
     assertStringContains(promoting.getPromotionAppMobileText(), MOBILE_PROMOTION_TEXT);
   }
 
-  @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+  @InBrowser(browser = Browser.CHROME, emulator = Emulator.NEXUS_5X)
   public void anonUserOnMobileCanClickGooglePlayLink() {
     findPromoting().clickInstallOnMobileBanner();
     assertAppPageOpened(ANDROID_APP_TITLE);

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
@@ -24,7 +24,7 @@ public class PromotingTests extends NewTestTemplate {
   private static final String DESKTOP_PROMOTION_TEXT =
     "Take your fandom with you, download the app today!";
   private static final String IOS_APP_TITLE = "Fandom Community for: Fallout";
-  private static final String ANDROID_APP_TITLE = "Fandom: Fallout 4";
+  private static final String ANDROID_APP_TITLE = "FANDOM: Fallout 4";
 
   /**
    * ANON ON DESKTOP SECTION

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/PromotingTests.java
@@ -61,6 +61,7 @@ public class PromotingTests extends NewTestTemplate {
     assertStringContains(promoting.getPromotionAppMobileText(), MOBILE_PROMOTION_TEXT);
   }
 
+  // this test has to use a browser that is supported by Google Play website
   @InBrowser(browser = Browser.CHROME, emulator = Emulator.NEXUS_5X)
   public void anonUserOnMobileCanClickGooglePlayLink() {
     findPromoting().clickInstallOnMobileBanner();


### PR DESCRIPTION
- Andoid app name was FANDOMized, needed to update the test
- Google Play stopped supporting Nexus 5 with Android 4.2, switched to Nexus 5X with Android 6