### PR TITLE
Fix for hanging browser

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/templates/core/CoreTestTemplate.java
+++ b/src/test/java/com/wikia/webdriver/common/templates/core/CoreTestTemplate.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 
 import org.openqa.selenium.Dimension;
 import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -153,6 +154,7 @@ public abstract class CoreTestTemplate {
   }
 
   @AfterMethod(alwaysRun = true)
+  @AfterClass(alwaysRun = true)
   public void stop() {
     DriverProvider.close();
   }


### PR DESCRIPTION
I noticed that when tests are skipped there is a chromedriver process hanging, together with a browser window. here is the fix for closing all the windows after each class. 