### PR TITLE
IRIS-4246 - fixes tests for forgot password flow

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 
 public final class ForgottenPasswordUserFactory {
 
+  private ForgottenPasswordUserFactory() {
+    // no-op
+  }
+
   @Builder
   public static class ForgottenPasswordUser {
     private User user;

--- a/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
@@ -1,0 +1,44 @@
+package com.wikia.webdriver.common.core.helpers;
+
+
+import com.wikia.webdriver.common.core.configuration.Configuration;
+import com.wikia.webdriver.common.properties.Credentials;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ForgottenPasswordUserFactory {
+
+  private static Credentials credentials = Configuration.getCredentials();
+
+  @Builder
+  @Getter
+  public class ForgottenPasswordUser {
+    private User user;
+    private String email;
+    private String emailPassword;
+    private String username = user.getUserName();
+    private String password = user.getPassword();
+  }
+
+  private static ForgottenPasswordUser user(User user, String email, String password) {
+    return ForgottenPasswordUser.builder()
+      .user(user)
+      .email(email)
+      .emailPassword(password)
+      .build();
+  }
+
+  public static ForgottenPasswordUser user1() {
+    return user(
+      User.FORGOTTEN_PASSWORD,
+      credentials.forgottenPasswordEmail1Address,
+      credentials.forgottenPasswordEmail1Password);
+  }
+
+  public static ForgottenPasswordUser user2() {
+    return user(
+      User.FORGOTTEN_PASSWORD_SPACES,
+      credentials.forgottenPasswordEmail2Address,
+      credentials.forgottenPasswordEmail2Password);
+  }
+}

--- a/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
+++ b/src/test/java/com/wikia/webdriver/common/core/helpers/ForgottenPasswordUserFactory.java
@@ -6,19 +6,28 @@ import com.wikia.webdriver.common.properties.Credentials;
 import lombok.Builder;
 import lombok.Getter;
 
-public class ForgottenPasswordUserFactory {
-
-  private static Credentials credentials = Configuration.getCredentials();
+public final class ForgottenPasswordUserFactory {
 
   @Builder
-  @Getter
-  public class ForgottenPasswordUser {
+  public static class ForgottenPasswordUser {
     private User user;
+
+    @Getter
     private String email;
+
+    @Getter
     private String emailPassword;
-    private String username = user.getUserName();
-    private String password = user.getPassword();
+
+    public String getUsername() {
+      return user.getUserName();
+    }
+
+    public String getPassword() {
+      return user.getPassword();
+    }
   }
+
+  private static Credentials credentials = Configuration.getCredentials();
 
   private static ForgottenPasswordUser user(User user, String email, String password) {
     return ForgottenPasswordUser.builder()

--- a/src/test/java/com/wikia/webdriver/common/properties/Credentials.java
+++ b/src/test/java/com/wikia/webdriver/common/properties/Credentials.java
@@ -62,6 +62,12 @@ public class Credentials {
   public final String emailPasswordQaart2;
   public final String emailQaart4;
   public final String emailPasswordQaart4;
+  public final String forgottenPasswordEmail1Address;
+  public final String forgottenPasswordEmail1Password;
+
+  public final String forgottenPasswordEmail2Address;
+  public final String forgottenPasswordEmail2Password;
+
   public final String userNameStaff;
   public final String userNameStaffId;
   public final String passwordStaff;
@@ -214,6 +220,13 @@ public class Credentials {
     emailPasswordQaart2 = XMLReader.getValue(file, "ci.email.qawikia2.password");
     emailQaart4 = XMLReader.getValue(file, "ci.email.qawikia4.username");
     emailPasswordQaart4 = XMLReader.getValue(file, "ci.email.qawikia4.password");
+
+    forgottenPasswordEmail1Address = XMLReader.getValue(file, "ci.email.forgotPass1.username");
+    forgottenPasswordEmail1Password = XMLReader.getValue(file, "ci.email.forgotPass1.password");
+
+    forgottenPasswordEmail2Address = XMLReader.getValue(file, "ci.email.forgotPass2.username");
+    forgottenPasswordEmail2Password = XMLReader.getValue(file, "ci.email.forgotPass2.password");
+
     userNameBlocked = XMLReader.getValue(file, "ci.user.tooManyLoginAttempts.username");
     passwordBlocked = XMLReader.getValue(file, "ci.user.tooManyLoginAttempts.password");
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -583,7 +583,7 @@ public class BasePageObject {
         .map(handleName -> Pair.of(handleName, driver.switchTo().window(handleName).getTitle()))
         .filter(condition).map(Pair::getKey).findFirst();
     return newTab.orElseThrow(
-        () -> new NotFoundException(String.format("Tab with title %s doesn't exist", title)));
+        () -> new NotFoundException("Tab that satisfies the condition doesn't exist"));
   }
 
   public WebDriver switchToWindowWithTitle(String title) {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -579,9 +579,13 @@ public class BasePageObject {
 
   private String getTabWithCondition(
       java.util.function.Predicate<? super Pair<String, String>> condition) {
-    Optional<String> newTab = driver.getWindowHandles().stream()
-        .map(handleName -> Pair.of(handleName, driver.switchTo().window(handleName).getTitle()))
-        .filter(condition).map(Pair::getKey).findFirst();
+    Optional<String> newTab = driver.getWindowHandles()
+      .stream()
+      .map(handleName -> Pair.of(handleName, driver.switchTo().window(handleName).getTitle()))
+      .peek(handleTitle -> PageObjectLogging.log("Found window", String.format("Window with title %s", handleTitle), true))
+      .filter(condition)
+      .map(Pair::getKey)
+      .findFirst();
     return newTab.orElseThrow(
         () -> new NotFoundException("Tab that satisfies the condition doesn't exist"));
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/WikiBasePageObject.java
@@ -472,7 +472,7 @@ public class WikiBasePageObject extends BasePageObject {
 
   public String getPasswordResetLink(String email, String password) {
     String passwordResetEmail = EmailUtils
-      .getFirstEmailContent(email, password, "Reset your Fandom password");
+      .getFirstEmailContent(email, password, "Reset your FANDOM password");
     String resetLink = EmailUtils.getPasswordResetLinkFromEmailContent(passwordResetEmail);
     PageObjectLogging.log("Password reset link", "Password reset link received: " + resetLink,
         true);

--- a/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
@@ -20,23 +20,30 @@ public class ForgottenPasswordTests extends NewTestTemplate {
 
   Credentials credentials = Configuration.getCredentials();
 
+  // Email credentials for User.FORGOTTEN_PASSWORD
+  String EMAIL1 = credentials.forgottenPasswordEmail1Address;
+  String PASSWORD1 = credentials.forgottenPasswordEmail1Password;
+
+  // Email credentials for User.FORGOTTEN_PASSWORD_SPACES
+  String EMAIL2 = credentials.forgottenPasswordEmail2Address;
+  String PASSWORD2 = credentials.forgottenPasswordEmail2Password;
+
   @Test
   public void anonCanRemindPasswordFromAuthModal() {
-    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD);
+    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD, EMAIL1, PASSWORD1);
   }
 
   @Test
   public void anonCanResetPasswordForUsernameWithSpaces() {
-    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD_SPACES);
+    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD_SPACES, EMAIL2, PASSWORD2);
   }
 
   @Test
   public void anonCanRemindPasswordOnUserLoginSpecialPage() {
-    EmailUtils.deleteAllEmails(credentials.email, credentials.emailPassword);
     WikiBasePageObject base = new WikiBasePageObject();
     AttachedSignInPage signIn = new AttachedSignInPage().open();
     signIn.clickForgotPasswordLink().requestLinkForUsername(User.FORGOTTEN_PASSWORD.getUserName());
-    String resetLink = base.getPasswordResetLink(credentials.email, credentials.emailPassword);
+    String resetLink = base.getPasswordResetLink(EMAIL1, PASSWORD1);
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
     resetPass.setNewPassword(User.FORGOTTEN_PASSWORD.getPassword());
 
@@ -47,19 +54,18 @@ public class ForgottenPasswordTests extends NewTestTemplate {
   public void anonCanRemindPasswordOnUserLoginSpecialPageUsingLowerCaseUserName() {
     String username = User.FORGOTTEN_PASSWORD.getUserName();
     String lowercaseUsername = Character.toLowerCase(username.charAt(0)) + username.substring(1);
-    EmailUtils.deleteAllEmails(credentials.email, credentials.emailPassword);
+
     WikiBasePageObject base = new WikiBasePageObject();
     AttachedSignInPage signIn = new AttachedSignInPage().open();
     signIn.clickForgotPasswordLink().requestLinkForUsername(lowercaseUsername);
-    String resetLink = base.getPasswordResetLink(credentials.email, credentials.emailPassword);
+    String resetLink = base.getPasswordResetLink(EMAIL1, PASSWORD1);
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
     resetPass.setNewPassword(User.FORGOTTEN_PASSWORD.getPassword());
 
     assertTrue(resetPass.newPasswordSetSuccessfully());
   }
 
-  private void executeResetPasswordFlow(User user) {
-    EmailUtils.deleteAllEmails(credentials.email, credentials.emailPassword);
+  private void executeResetPasswordFlow(User user, String email, String password) {
     WikiBasePageObject base = new WikiBasePageObject();
     base.openWikiPage(wikiURL);
     DetachedSignInPage loginModal = new DetachedSignInPage(new NavigationBar(driver).clickOnSignIn());
@@ -67,7 +73,7 @@ public class ForgottenPasswordTests extends NewTestTemplate {
       .clickForgotPasswordLink()
       .requestLinkForUsername(user.getUserName());
 
-    String resetLink = base.getPasswordResetLink(credentials.email, credentials.emailPassword);
+    String resetLink = base.getPasswordResetLink(email, password);
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
     resetPass.setNewPassword(user.getPassword());
 

--- a/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.testcases.auth;
 
+import com.wikia.webdriver.common.core.EmailUtils;
 import com.wikia.webdriver.common.core.helpers.ForgottenPasswordUserFactory;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.global_navitagtion.NavigationBar;
@@ -8,6 +9,9 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.auth.signin.AttachedSig
 import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
 import com.wikia.webdriver.pageobjectsfactory.pageobject.auth.signin.DetachedSignInPage;
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static com.wikia.webdriver.common.core.Assertion.assertTrue;
@@ -18,9 +22,15 @@ public class ForgottenPasswordTests extends NewTestTemplate {
   private ForgottenPasswordUserFactory.ForgottenPasswordUser user = ForgottenPasswordUserFactory.user1();
   private ForgottenPasswordUserFactory.ForgottenPasswordUser userWithSpaces = ForgottenPasswordUserFactory.user2();
 
+  @BeforeTest
+  @AfterTest
+  private void cleanUpEmails() {
+    EmailUtils.deleteAllEmails(user.getEmail(), user.getEmailPassword());
+    EmailUtils.deleteAllEmails(userWithSpaces.getEmail(), userWithSpaces.getEmailPassword());
+  }
+
   @Test
   public void anonCanRemindPasswordFromAuthModal() {
-
     executeResetPasswordFlow(user);
   }
 

--- a/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
@@ -49,7 +49,7 @@ public class ForgottenPasswordTests extends NewTestTemplate {
     WikiBasePageObject base = new WikiBasePageObject();
     AttachedSignInPage signIn = new AttachedSignInPage().open();
     signIn.clickForgotPasswordLink().requestLinkForUsername(lowercaseUsername);
-    String resetLink = base.getPasswordResetLink(user.getEmail(), user.getPassword());
+    String resetLink = base.getPasswordResetLink(user.getEmail(), user.getEmailPassword());
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
     resetPass.setNewPassword(user.getPassword());
 

--- a/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
@@ -10,9 +10,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.WikiBasePageObject;
 
 import com.wikia.webdriver.pageobjectsfactory.pageobject.auth.signin.DetachedSignInPage;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import static com.wikia.webdriver.common.core.Assertion.assertTrue;
 
@@ -22,8 +20,8 @@ public class ForgottenPasswordTests extends NewTestTemplate {
   private ForgottenPasswordUserFactory.ForgottenPasswordUser user = ForgottenPasswordUserFactory.user1();
   private ForgottenPasswordUserFactory.ForgottenPasswordUser userWithSpaces = ForgottenPasswordUserFactory.user2();
 
-  @BeforeTest
-  @AfterTest
+  @BeforeMethod
+  @AfterMethod
   private void cleanUpEmails() {
     EmailUtils.deleteAllEmails(user.getEmail(), user.getEmailPassword());
     EmailUtils.deleteAllEmails(userWithSpaces.getEmail(), userWithSpaces.getEmailPassword());

--- a/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/auth/ForgottenPasswordTests.java
@@ -1,9 +1,6 @@
 package com.wikia.webdriver.testcases.auth;
 
-import com.wikia.webdriver.common.core.EmailUtils;
-import com.wikia.webdriver.common.core.configuration.Configuration;
-import com.wikia.webdriver.common.core.helpers.User;
-import com.wikia.webdriver.common.properties.Credentials;
+import com.wikia.webdriver.common.core.helpers.ForgottenPasswordUserFactory;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.global_navitagtion.NavigationBar;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.auth.ResetPasswordPage;
@@ -18,62 +15,56 @@ import static com.wikia.webdriver.common.core.Assertion.assertTrue;
 @Test(groups = "auth-forgottenPassword")
 public class ForgottenPasswordTests extends NewTestTemplate {
 
-  Credentials credentials = Configuration.getCredentials();
-
-  // Email credentials for User.FORGOTTEN_PASSWORD
-  String EMAIL1 = credentials.forgottenPasswordEmail1Address;
-  String PASSWORD1 = credentials.forgottenPasswordEmail1Password;
-
-  // Email credentials for User.FORGOTTEN_PASSWORD_SPACES
-  String EMAIL2 = credentials.forgottenPasswordEmail2Address;
-  String PASSWORD2 = credentials.forgottenPasswordEmail2Password;
+  private ForgottenPasswordUserFactory.ForgottenPasswordUser user = ForgottenPasswordUserFactory.user1();
+  private ForgottenPasswordUserFactory.ForgottenPasswordUser userWithSpaces = ForgottenPasswordUserFactory.user2();
 
   @Test
   public void anonCanRemindPasswordFromAuthModal() {
-    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD, EMAIL1, PASSWORD1);
+
+    executeResetPasswordFlow(user);
   }
 
   @Test
   public void anonCanResetPasswordForUsernameWithSpaces() {
-    executeResetPasswordFlow(User.FORGOTTEN_PASSWORD_SPACES, EMAIL2, PASSWORD2);
+    executeResetPasswordFlow(userWithSpaces);
   }
 
   @Test
   public void anonCanRemindPasswordOnUserLoginSpecialPage() {
     WikiBasePageObject base = new WikiBasePageObject();
     AttachedSignInPage signIn = new AttachedSignInPage().open();
-    signIn.clickForgotPasswordLink().requestLinkForUsername(User.FORGOTTEN_PASSWORD.getUserName());
-    String resetLink = base.getPasswordResetLink(EMAIL1, PASSWORD1);
+    signIn.clickForgotPasswordLink().requestLinkForUsername(user.getUsername());
+    String resetLink = base.getPasswordResetLink(user.getEmail(), user.getEmailPassword());
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
-    resetPass.setNewPassword(User.FORGOTTEN_PASSWORD.getPassword());
+    resetPass.setNewPassword(user.getPassword());
 
     assertTrue(resetPass.newPasswordSetSuccessfully());
   }
 
   @Test
   public void anonCanRemindPasswordOnUserLoginSpecialPageUsingLowerCaseUserName() {
-    String username = User.FORGOTTEN_PASSWORD.getUserName();
-    String lowercaseUsername = Character.toLowerCase(username.charAt(0)) + username.substring(1);
+    String lowercaseUsername = Character.toLowerCase(user.getUsername().charAt(0))
+          + user.getUsername().substring(1);
 
     WikiBasePageObject base = new WikiBasePageObject();
     AttachedSignInPage signIn = new AttachedSignInPage().open();
     signIn.clickForgotPasswordLink().requestLinkForUsername(lowercaseUsername);
-    String resetLink = base.getPasswordResetLink(EMAIL1, PASSWORD1);
+    String resetLink = base.getPasswordResetLink(user.getEmail(), user.getPassword());
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
-    resetPass.setNewPassword(User.FORGOTTEN_PASSWORD.getPassword());
+    resetPass.setNewPassword(user.getPassword());
 
     assertTrue(resetPass.newPasswordSetSuccessfully());
   }
 
-  private void executeResetPasswordFlow(User user, String email, String password) {
+  private void executeResetPasswordFlow(ForgottenPasswordUserFactory.ForgottenPasswordUser user) {
     WikiBasePageObject base = new WikiBasePageObject();
     base.openWikiPage(wikiURL);
     DetachedSignInPage loginModal = new DetachedSignInPage(new NavigationBar(driver).clickOnSignIn());
     loginModal
       .clickForgotPasswordLink()
-      .requestLinkForUsername(user.getUserName());
+      .requestLinkForUsername(user.getUsername());
 
-    String resetLink = base.getPasswordResetLink(email, password);
+    String resetLink = base.getPasswordResetLink(user.getEmail(), user.getEmailPassword());
     ResetPasswordPage resetPass = new ResetPasswordPage(resetLink);
     resetPass.setNewPassword(user.getPassword());
 


### PR DESCRIPTION
Tests are passing: http://jenkins.wikia-prod:8080/view/Iris/view/preview/job/iris-auth-forgotten-password-preview/327/

Summary of changes:
- FANDOMize email suject
- delete all emails before and after each tests is executed
- users now have dedicated email accounts (https://github.com/Wikia/selenium-config/pull/53) so that it doesn't interrupt other tests
- slight refactoring