### PR TITLE
Iris-hotfix | fix flaky signup test

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -4,6 +4,7 @@ import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.elemnt.Wait;
 import com.wikia.webdriver.common.core.url.UrlBuilder;
+import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.elements.mercury.components.Navigation;
 import com.wikia.webdriver.elements.mercury.components.TopBar;
 
@@ -85,14 +86,17 @@ public class SignupPageObject {
     wait.forElementVisible(signupBirthMonth);
     signupBirthMonth.click();
     signupBirthMonth.sendKeys(month);
+    PageObjectLogging.logInfo(String.format("Set month value to %s", month));
 
     wait.forElementVisible(signupBirthDay);
     signupBirthDay.click();
     signupBirthDay.sendKeys(day);
+    PageObjectLogging.logInfo(String.format("Set day value to %s", month));
 
     wait.forElementVisible(signupBirthYear);
     signupBirthYear.click();
     signupBirthYear.sendKeys(year);
+    PageObjectLogging.logInfo(String.format("Set year value to %s", month));
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -87,17 +87,17 @@ public class SignupPageObject {
     wait.forElementVisible(signupBirthMonth);
     signupBirthMonth.click();
     signupBirthMonth.sendKeys(month);
-    PageObjectLogging.logInfo("Set month value", String.format("value set to %s", month));
+    PageObjectLogging.log("Set month value", String.format("value set to %s", month), true);
 
     wait.forElementVisible(signupBirthDay);
     signupBirthDay.click();
     signupBirthDay.sendKeys(day);
-    PageObjectLogging.logInfo("Set day value", String.format("value set to %s", day));
+    PageObjectLogging.log("Set day value", String.format("value set to %s", day), true);
 
     wait.forElementVisible(signupBirthYear);
     signupBirthYear.click();
     signupBirthYear.sendKeys(year);
-    PageObjectLogging.logInfo("Set year value", String.format("value set to %s", year));
+    PageObjectLogging.log("Set year value", String.format("value set to %s", year), true);
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -3,7 +3,6 @@ package com.wikia.webdriver.elements.mercury.old;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.elemnt.Wait;
-import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.core.url.UrlBuilder;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.elements.mercury.components.Navigation;
@@ -80,27 +79,22 @@ public class SignupPageObject {
     return this;
   }
 
+  private void safelySetValue(WebElement input, String value) {
+    wait.forElementVisible(input).click();
+    input.clear();
+    input.sendKeys(value);
+    PageObjectLogging.log("Set value",
+      String.format("value of input identified by: %s set to %s",
+        input.getCssValue("class"), value), true);
+  }
+
   private SignupPageObject typeBirthdate(String month, String day, String year) {
     wait.forElementVisible(signupBirthdate);
     signupBirthdate.click();
 
-    wait.forElementVisible(signupBirthMonth);
-    signupBirthMonth.click();
-    signupBirthMonth.clear();
-    signupBirthMonth.sendKeys(month);
-    PageObjectLogging.log("Set month value", String.format("value set to %s", month), true);
-
-    wait.forElementVisible(signupBirthDay);
-    signupBirthDay.click();
-    signupBirthDay.clear();
-    signupBirthDay.sendKeys(day);
-    PageObjectLogging.log("Set day value", String.format("value set to %s", day), true);
-
-    wait.forElementVisible(signupBirthYear);
-    signupBirthYear.click();
-    signupBirthYear.clear();
-    signupBirthYear.sendKeys(year);
-    PageObjectLogging.log("Set year value", String.format("value set to %s", year), true);
+    safelySetValue(signupBirthMonth, month);
+    safelySetValue(signupBirthDay, day);
+    safelySetValue(signupBirthYear, year);
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -62,21 +62,21 @@ public class SignupPageObject {
   }
 
   private SignupPageObject typeEmailAddress(String email) {
-    safelySetValue(signupEmail, email);
+    setValue(signupEmail, email);
     return this;
   }
 
   private SignupPageObject typeUsername(String username) {
-    safelySetValue(signupUsername, username);
+    setValue(signupUsername, username);
     return this;
   }
 
   private SignupPageObject typePassword(String password) {
-    safelySetValue(signupPassword, password);
+    setValue(signupPassword, password);
     return this;
   }
 
-  private void safelySetValue(WebElement input, String value) {
+  private void setValue(WebElement input, String value) {
     wait.forElementVisible(input).click();
     input.clear();
     input.sendKeys(value);
@@ -89,9 +89,9 @@ public class SignupPageObject {
     wait.forElementVisible(signupBirthdate);
     signupBirthdate.click();
 
-    safelySetValue(signupBirthMonth, month);
-    safelySetValue(signupBirthDay, day);
-    safelySetValue(signupBirthYear, year);
+    setValue(signupBirthMonth, month);
+    setValue(signupBirthDay, day);
+    setValue(signupBirthYear, year);
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -62,20 +62,17 @@ public class SignupPageObject {
   }
 
   private SignupPageObject typeEmailAddress(String email) {
-    wait.forElementVisible(signupEmail);
-    signupEmail.sendKeys(email);
+    safelySetValue(signupEmail, email);
     return this;
   }
 
   private SignupPageObject typeUsername(String username) {
-    wait.forElementVisible(signupUsername);
-    signupUsername.sendKeys(username);
+    safelySetValue(signupUsername, username);
     return this;
   }
 
   private SignupPageObject typePassword(String password) {
-    wait.forElementVisible(signupPassword);
-    signupPassword.sendKeys(password);
+    safelySetValue(signupPassword, password);
     return this;
   }
 

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -3,6 +3,7 @@ package com.wikia.webdriver.elements.mercury.old;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.elemnt.Wait;
+import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.core.url.UrlBuilder;
 import com.wikia.webdriver.common.logging.PageObjectLogging;
 import com.wikia.webdriver.elements.mercury.components.Navigation;
@@ -86,17 +87,17 @@ public class SignupPageObject {
     wait.forElementVisible(signupBirthMonth);
     signupBirthMonth.click();
     signupBirthMonth.sendKeys(month);
-    PageObjectLogging.logInfo(String.format("Set month value to %s", month));
+    PageObjectLogging.logInfo("Set month value", String.format("value set to %s", month));
 
     wait.forElementVisible(signupBirthDay);
     signupBirthDay.click();
     signupBirthDay.sendKeys(day);
-    PageObjectLogging.logInfo(String.format("Set day value to %s", month));
+    PageObjectLogging.logInfo("Set day value", String.format("value set to %s", day));
 
     wait.forElementVisible(signupBirthYear);
     signupBirthYear.click();
     signupBirthYear.sendKeys(year);
-    PageObjectLogging.logInfo(String.format("Set year value to %s", month));
+    PageObjectLogging.logInfo("Set year value", String.format("value set to %s", year));
 
     return this;
   }

--- a/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/old/SignupPageObject.java
@@ -86,16 +86,19 @@ public class SignupPageObject {
 
     wait.forElementVisible(signupBirthMonth);
     signupBirthMonth.click();
+    signupBirthMonth.clear();
     signupBirthMonth.sendKeys(month);
     PageObjectLogging.log("Set month value", String.format("value set to %s", month), true);
 
     wait.forElementVisible(signupBirthDay);
     signupBirthDay.click();
+    signupBirthDay.clear();
     signupBirthDay.sendKeys(day);
     PageObjectLogging.log("Set day value", String.format("value set to %s", day), true);
 
     wait.forElementVisible(signupBirthYear);
     signupBirthYear.click();
+    signupBirthYear.clear();
     signupBirthYear.sendKeys(year);
     PageObjectLogging.log("Set year value", String.format("value set to %s", year), true);
 


### PR DESCRIPTION
Apparently there's a race condition - webdriver sometimes fills the birthday input value before the focus is set to that input. Workaround: clear the field before setting its value