### PR TITLE
Change the way video wiki text is compared in RTE tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/VideoContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/VideoContent.java
@@ -5,7 +5,7 @@ public class VideoContent {
   public static final String YOUTUBE_VIDEO_URL = "https://www.youtube.com/watch?v=QE32HghV8-I";
   public static final String
       YOUTUBE_VIDEO_WIKITEXT =
-      "File:WikiEvolution - Poznańska Wiki-1354533479|thumb|right|335 px|";
+      "File:WikiEvolution - Poznańska Wiki|thumb|right|335 px|";
 
   public static final String YOUTUBE_VIDEO_URL2_FILENAME = "How_to_make_the_Monstre_Verte_cocktail";
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -105,13 +105,8 @@ public class SourceEditModePageObject extends EditMode {
   }
 
   public void checkSourceVideoContent(String desiredContent) {
-    int fileNameLength = 38;
-    int fileParametersBeginIndex = 48;
     Assertion.assertEquals(
-        getSourceContent().substring(1, fileNameLength)
-            + getSourceContent().substring(fileParametersBeginIndex),
-        desiredContent.substring(1, fileNameLength)
-            + desiredContent.substring(fileParametersBeginIndex));
+        getSourceContent().replaceAll("(-\\d+)\\|","|"), desiredContent.replaceAll("(-\\d+)\\|","|"));
   }
 
   public void clickBold() {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/article/editmode/SourceEditModePageObject.java
@@ -105,8 +105,7 @@ public class SourceEditModePageObject extends EditMode {
   }
 
   public void checkSourceVideoContent(String desiredContent) {
-    Assertion.assertEquals(
-        getSourceContent().replaceAll("(-\\d+)\\|","|"), desiredContent.replaceAll("(-\\d+)\\|","|"));
+    Assertion.assertEquals(getSourceContent().replaceAll("(-\\d+)\\|","|"), desiredContent);
   }
 
   public void clickBold() {


### PR DESCRIPTION
It's all about comparing video wiki text, e.g. [[File:WikiEvolution - Poznańska Wiki-1354533479|thumb|right|335 px|TestDataCaption1]] ignoring the 1354533479 number.
http://jenkins.wikia-prod:8080/view/Staging/view/core-dashboard/job/staging-core-rte-3/17/