### PR TITLE
Switch selenium tests to new staging url

### DIFF
--- a/config_default.yml
+++ b/config_default.yml
@@ -15,7 +15,7 @@ logEnabled: true
 takeScreenshots: true
 mockAds: false
 forceHttps: false
-newStagingUrlFormat: false
+newStagingUrlFormat: true
 disableCommunityPageSalesPitchDialog: true
 useMITM: false
 useZapProxy: false


### PR DESCRIPTION
To be merge today before cut off, it doesn't touch production so it can be merged to master to run selenium tests with new value right after the cut off.
... or to preview to avoid problems on sandboxes