### PR TITLE
Restore selector for register button

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/Navigation.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/Navigation.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class Navigation extends WikiBasePageObject {
 
-  @FindBy(css = ".wikia-nav__avatar .wikia-nav--login")
+  @FindBy(css = ".wikia-nav__avatar .wds-icon")
   private WebElement signInRegisterButton;
 
   @FindBy(css = ".wikia-nav__back")


### PR DESCRIPTION
This actually reverts this commit https://github.com/Wikia/selenium-tests/commit/a009ad50b39845e8c1cea2a5d6f27b6e7f53a5c9 

Since `wikia-nav--login` is not present in mobile wiki, but is present in discussions, so almost all login/signup tests are failing.

 It'll be better and more consistent to add `wds-icon` class to dicsussions' nav.