### PR TITLE
Fix selector for guidelines

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
@@ -40,7 +40,7 @@ public class GuidelinesPage extends BasePage {
   @FindBy(css = ".discussion-standalone-editor button[type='submit']")
   private WebElement saveButton;
 
-  @FindBy(css = ".editor-input-label-wrapper textarea")
+  @FindBy(css = ".guidelines-text")
   private WebElement guidelinesText;
 
   public GuidelinesPage open() {

--- a/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/pages/discussions/GuidelinesPage.java
@@ -28,8 +28,8 @@ public class GuidelinesPage extends BasePage {
   @FindBy(css = ".discussion-left-rail__header")
   private WebElement leftRailHeader;
 
-  @FindBy(css = ".guidelines-text")
-  private WebElement contentText;
+  @FindBy(css = ".editor-input-label-wrapper textarea")
+  private WebElement guidelinesEditorTextarea;
 
   @FindBy(css = ".guidelines-edit-button")
   private WebElement editButton;
@@ -92,8 +92,8 @@ public class GuidelinesPage extends BasePage {
   }
 
   private void addText(String text) {
-    this.guidelinesText.clear();
-    this.guidelinesText.sendKeys(text);
+    this.guidelinesEditorTextarea.clear();
+    this.guidelinesEditorTextarea.sendKeys(text);
     clickSaveButton();
     waitForLoadingSpinner();
   }
@@ -106,14 +106,14 @@ public class GuidelinesPage extends BasePage {
   }
 
   private void hasTextInGuidelines(String text) {
-    wait.forTextInElement(contentText, text);
-    contentText.isDisplayed();
+    wait.forTextInElement(guidelinesText, text);
+    guidelinesText.isDisplayed();
   }
 
   private void deleteTextFromGuidelines(String text) {
     clickEditGuidelines();
     addText(DEFAULT_GUIDELINES_TEXT);
-    wait.forTextNotInElement(contentText, text);
+    wait.forTextNotInElement(guidelinesText, text);
   }
 
   public boolean canUpdateGuidelinesContent() {
@@ -121,6 +121,6 @@ public class GuidelinesPage extends BasePage {
       hasTextInGuidelines(text);
       deleteTextFromGuidelines(text);
 
-      return DEFAULT_GUIDELINES_TEXT.equals(contentText.getText());
+      return DEFAULT_GUIDELINES_TEXT.equals(guidelinesText.getText());
   }
 }


### PR DESCRIPTION
https://github.com/Wikia/selenium-tests/commit/74c8f62cfdb5f1d21c3ac754c9d3ab8e0e4a991c was introduced as a fix, but actually broke `guidelinesIsNotEmptyOnNewCommunityDiscussionsPage`, so let's revert that first and fix that previously "fixed" test(s) in different way