### PR TITLE
Fix post image upload test

### DIFF
--- a/src/test/java/com/wikia/webdriver/elements/mercury/components/discussions/common/BasePostsCreator.java
+++ b/src/test/java/com/wikia/webdriver/elements/mercury/components/discussions/common/BasePostsCreator.java
@@ -178,4 +178,9 @@ public abstract class BasePostsCreator extends BasePageObject implements PostsCr
     return startPostCreationWith(String.format(" %s ", link.toString()));
   }
 
+  public BasePostsCreator waitForErrorMessageNotVisible() {
+    wait.forElementNotVisible(By.className("error"));
+
+    return this;
+  }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/UploadingImageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/UploadingImageTests.java
@@ -307,7 +307,7 @@ public class UploadingImageTests extends NewTestTemplate {
   private void addPostWithUnsupportedImage(BasePostsCreator postCreator) {
     String errorMsg = postCreator.uploadUnsupportedImage();
     Assertion.assertStringContains(errorMsg, UNSUPPORTED_IMAGE_MSG);
-    postCreator.clickSubmitButton();
+    postCreator.waitForErrorMessageNotVisible().clickSubmitButton();
   }
 
   private void addReplyWithUnsupportedImage(BaseReplyCreator replyCreator) {


### PR DESCRIPTION
`userCannotUploadUnsupportedImageToTheirPostOnMobile` was randomly failing because error message covered "submit" button for few seconds - we're now waiting for button to be clickable.