### PR TITLE
Remove title checks for Discussions

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/mobilewikitests/HTMLTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobilewikitests/HTMLTitleTests.java
@@ -90,21 +90,6 @@ public class HTMLTitleTests extends NewTestTemplate {
           "Droid starfighter | Wookieepedia | FANDOM powered by Wikia"
       },
       {
-          "mediawiki119",
-          "/d/f/203236/latest",
-          "Discussions | Mediawiki 1.19 test Wiki | FANDOM powered by Wikia"
-      },
-      {
-          "mediawiki119",
-          "/d/p/2706859396041803285",
-          "Discussions | Mediawiki 1.19 test Wiki | FANDOM powered by Wikia"
-      },
-      {
-          "mediawiki119",
-          "/d/u/27334045",
-          "Discussions | Mediawiki 1.19 test Wiki | FANDOM powered by Wikia"
-      },
-      {
           "dnd4",
           "/wiki/Dungeons_&_Dragons",
           "Dungeons & Dragons | D&D4 Wiki | FANDOM powered by Wikia"


### PR DESCRIPTION
These pages aren't in mobile-wiki nor the values are up to date, so the test fails (http://jenkins:8080/view/X-Wing/view/mobile-wiki-sandbox/job/xwing-mobile-wiki-htmlTitleSet-sandbox/). We already test tiles in https://github.com/Wikia/seo-tests/blob/master/iris-test/testsIrisHtmlTitle.py

/cc @nikodamn @qaga 