### PR TITLE
Tracking Opt In in Discussions

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
@@ -82,8 +82,7 @@ public class TrackingOptInDataProvider {
   };
 
   private static final String GOOGLE_ANALYTICS_ANONYMIZED_USER =
-          "https?://.*google-analytics\\.com/analytics\\.r/collect*&aip=1.*";
-
+          "https?://.*google-analytics\\.com/collect\\?.*aip=1.*";
 
   @DataProvider
   public static Object[][] GDPRcountries() {

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
@@ -81,7 +81,7 @@ public class TrackingOptInDataProvider {
       "wgAdDriverA9VideoBidderCountries"
   };
 
-  private static final String DISCUSSION_GOOGLE_ANONYMIZED =
+  private static final String GOOGLE_ANALYTICS_ANONYMIZED_USER =
           "https?://.*google-analytics\\.com/analytics\\.r/collect*&aip=1.*";
 
 
@@ -315,11 +315,11 @@ public class TrackingOptInDataProvider {
   }
 
   @DataProvider
-  public static Object[][] discussionsGoogleAnalyticAnonymized() {
+  public static Object[][] googleAnalyticAnonymizedUser() {
     return new Object[][]{
             {
               Arrays.asList(
-                      DISCUSSION_GOOGLE_ANONYMIZED
+                      GOOGLE_ANALYTICS_ANONYMIZED_USER
               )
             }
     };

--- a/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
+++ b/src/test/java/com/wikia/webdriver/common/dataprovider/TrackingOptInDataProvider.java
@@ -35,8 +35,6 @@ public class TrackingOptInDataProvider {
   private static final String ADS_VAST_NPA_SECOND_PARAMETER_PATTERN =
           "https?://.*pubads\\.g\\.doubleclick\\.net/gampad/ads.*output=xml_vast.*npa=1.*";
 
-
-
   private static final String[] ADS_KIKIMORA_INSTANT_GLOBALS = {
           "wgAdDriverKikimoraTrackingCountries",
           "wgAdDriverKikimoraViewabilityTrackingCountries",
@@ -70,6 +68,10 @@ public class TrackingOptInDataProvider {
           "wgAdDriverA9BidderCountries",
           "wgAdDriverA9VideoBidderCountries"
   };
+
+  private static final String DISCUSSION_GOOGLE_ANONYMIZED =
+          "https?://.*google-analytics\\.com/analytics\\.r/collect*&aip=1.*";
+
 
   @DataProvider
   public static Object[][] GDPRcountries() {
@@ -280,6 +282,17 @@ public class TrackingOptInDataProvider {
                     Arrays.asList(
                             ADS_QUALAROO_ANALITYCS_PATERN
                     )
+            }
+    };
+  }
+
+  @DataProvider
+  public static Object[][] discussionsGoogleAnalyticAnonymized() {
+    return new Object[][]{
+            {
+              Arrays.asList(
+                      DISCUSSION_GOOGLE_ANONYMIZED
+              )
             }
     };
   }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
@@ -169,4 +169,8 @@ public class TrackingOptInModal extends BasePageObject {
         return urlBuilder.appendQueryStringToURL(urlWithInstantGlobals, MODAL_INSTANT_GLOBAL);
     }
 
+    public void logTrackingCookieValue() {
+        PageObjectLogging.logInfo("Geo cookie: ", driver.manage().getCookieNamed("Geo").getValue());
+    }
+
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
@@ -144,6 +144,12 @@ public class TrackingOptInModal extends BasePageObject {
         }
     }
 
+    public void isOnlyExpectedTrackingRequestSend(List<String> elementsList,
+                                                  NetworkTrafficInterceptor networkTrafficInterceptor) {
+        for(int i=0; i<elementsList.size(); i++) {
+        }
+    }
+
     private boolean isSuccessfulResponseByUrlPattern(final NetworkTrafficInterceptor trafficInterceptor,
                                                     final String pattern) {
         try {

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/TrackingOptInModal.java
@@ -144,10 +144,19 @@ public class TrackingOptInModal extends BasePageObject {
         }
     }
 
-    public void isOnlyExpectedTrackingRequestSend(List<String> elementsList,
-                                                  NetworkTrafficInterceptor networkTrafficInterceptor) {
-        for(int i=0; i<elementsList.size(); i++) {
+    public boolean areResponsesByUrlPatternSuccessful(List<String> elementsList,
+                                      NetworkTrafficInterceptor networkTrafficInterceptor) {
+        boolean result = true;
+        for(int i=0; i<elementsList.size(); i++){
+            try {
+                wait.forSuccessfulResponseByUrlPattern(networkTrafficInterceptor,elementsList.get(i));
+            } catch (Exception e) {
+                PageObjectLogging.log("Did not get successfull response with element: " + elementsList.get(i),
+                        e, false);
+                result = false;
+            }
         }
+        return result;
     }
 
     private boolean isSuccessfulResponseByUrlPattern(final NetworkTrafficInterceptor trafficInterceptor,

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -1,0 +1,132 @@
+package com.wikia.webdriver.testcases.discussions;
+
+import com.wikia.webdriver.common.core.Assertion;
+import com.wikia.webdriver.common.core.annotations.Execute;
+import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.drivers.Browser;
+import com.wikia.webdriver.common.core.helpers.Emulator;
+import com.wikia.webdriver.common.core.helpers.User;
+import com.wikia.webdriver.common.dataprovider.TrackingOptInDataProvider;
+import com.wikia.webdriver.common.templates.NewTestTemplate;
+import com.wikia.webdriver.elements.mercury.pages.discussions.PostsListPage;
+import com.wikia.webdriver.pageobjectsfactory.componentobject.TrackingOptInModal;
+import org.testng.annotations.Test;
+
+@Test(groups = {"discussions-tracking-opt-in"})
+public class TrackingOptIn extends NewTestTemplate {
+
+    private TrackingOptInModal setGeoCookieToGermanyAndNavigate() {
+        TrackingOptInModal trackingModal = new TrackingOptInModal();
+        trackingModal.setGeoCookie(driver, "EU", "DE");
+        new PostsListPage().open();
+        trackingModal.logTrackingCookieValue();
+
+        return trackingModal;
+    }
+
+    private TrackingOptInModal setGeoCookieAndNavigate(String continent, String country) {
+        TrackingOptInModal trackingModal = new TrackingOptInModal();
+        trackingModal.setGeoCookie(driver, continent, country);
+        new PostsListPage().open();
+        trackingModal.logTrackingCookieValue();
+
+        return trackingModal;
+    }
+
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
+    @Test(dataProviderClass = TrackingOptInDataProvider.class, dataProvider = "GDPRcountries",
+            groups = {"discussions-tracking-opt-in-desktop"})
+    public void testModalVisibilityForAnonOnDesktop(String continent, String country, boolean shouldGetModal) {
+        TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
+        Assertion.assertEquals(trackingModal.isVisible(), shouldGetModal);
+    }
+
+    @Execute(asUser = User.USER, trackingOptIn = false)
+    @Test(dataProviderClass = TrackingOptInDataProvider.class, dataProvider = "GDPRcountries",
+            groups = {"discussions-tracking-opt-in-desktop"})
+    public void testModalVisibilityForLoggedInWhoNeverOptedInOnDesktop(String continent, String country,
+                                                              boolean shouldGetModal) {
+        TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
+        Assertion.assertEquals(trackingModal.isVisible(), shouldGetModal);
+    }
+
+    @Test(groups = {"discussions-tracking-opt-in-desktop"})
+    @Execute(asUser = User.USER)
+    public void loggedInUserInEUShouldNotGetModalIfOptedInOnDesktop() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @Test(groups = {"discussions-tracking-opt-in-desktop"})
+    @Execute(asUser = User.ANONYMOUS)
+    public void AnonUserInEUShouldNotGetModalIfOptedInOnDesktop() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @Test(groups = {"discussions-tracking-opt-in-desktop"})
+    @Execute(asUser = User.USER, trackingOptIn = false, trackingOptOut = true)
+    public void loggedInUserInEUShouldNotGetModalIfOptedOutOnDesktop() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @Test(groups = {"discussions-tracking-opt-in-desktop"})
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false, trackingOptOut = true)
+    public void AnonUserInEUShouldNotGetModalIfOptedOutOnDesktop() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
+    @Test(dataProviderClass = TrackingOptInDataProvider.class, dataProvider = "GDPRcountries",
+            groups = {"discussions-tracking-opt-in-mobile"})
+    public void testModalVisibilityForAnonOnMobile(String continent, String country, boolean shouldGetModal) {
+        TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
+        Assertion.assertEquals(new TrackingOptInModal().isVisible(), shouldGetModal);
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Execute(asUser = User.USER, trackingOptIn = false)
+    @Test(dataProviderClass = TrackingOptInDataProvider.class, dataProvider = "GDPRcountries",
+            groups = {"discussions-tracking-opt-in-mobile"})
+    public void testModalVisibilityForLoggedInWhoNeverOptedInOnMobile(String continent, String country,
+                                                              boolean shouldGetModal) {
+        TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
+        Assertion.assertEquals(new TrackingOptInModal().isVisible(), shouldGetModal);
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Test(groups = {"discussions-tracking-opt-in-mobile"})
+    @Execute(asUser = User.USER)
+    public void loggedInUserInEUShouldNotGetModalIfOptedInOnMobile() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Test(groups = {"discussions-tracking-opt-in-mobile"})
+    @Execute(asUser = User.ANONYMOUS)
+    public void AnonUserInEUShouldNotGetModalIfOptedInOnMobile() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Test(groups = {"discussions-tracking-opt-in-mobile"})
+    @Execute(asUser = User.USER, trackingOptIn = false, trackingOptOut = true)
+    public void loggedInUserInEUShouldNotGetModalIfOptedOutOnMobile() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
+    @Test(groups = {"discussions-tracking-opt-in-mobile"})
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false, trackingOptOut = true)
+    public void AnonUserInEUShouldNotGetModalIfOptedOutOnMobile() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+}

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -15,23 +15,9 @@ import org.testng.annotations.Test;
 @Test(groups = {"discussions-tracking-opt-in"})
 public class TrackingOptIn extends NewTestTemplate {
 
-    private TrackingOptInModal setGeoCookieToGermanyAndNavigate() {
-        TrackingOptInModal trackingModal = new TrackingOptInModal();
-        trackingModal.setGeoCookie(driver, "EU", "DE");
-        new PostsListPage().open();
-        trackingModal.logTrackingCookieValue();
-
-        return trackingModal;
-    }
-
-    private TrackingOptInModal setGeoCookieAndNavigate(String continent, String country) {
-        TrackingOptInModal trackingModal = new TrackingOptInModal();
-        trackingModal.setGeoCookie(driver, continent, country);
-        new PostsListPage().open();
-        trackingModal.logTrackingCookieValue();
-
-        return trackingModal;
-    }
+    /*
+        DESKTOP TESTS
+    */
 
     @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
     @Test(dataProviderClass = TrackingOptInDataProvider.class, dataProvider = "GDPRcountries",
@@ -52,31 +38,35 @@ public class TrackingOptIn extends NewTestTemplate {
 
     @Test(groups = {"discussions-tracking-opt-in-desktop"})
     @Execute(asUser = User.USER)
-    public void loggedInUserInEUShouldNotGetModalIfOptedInOnDesktop() {
+    public void loggedInEUShouldNotGetModalIfOptedInOnDesktop() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
 
     @Test(groups = {"discussions-tracking-opt-in-desktop"})
     @Execute(asUser = User.ANONYMOUS)
-    public void AnonUserInEUShouldNotGetModalIfOptedInOnDesktop() {
+    public void AnonInEUShouldNotGetModalIfOptedInOnDesktop() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
 
     @Test(groups = {"discussions-tracking-opt-in-desktop"})
     @Execute(asUser = User.USER, trackingOptIn = false, trackingOptOut = true)
-    public void loggedInUserInEUShouldNotGetModalIfOptedOutOnDesktop() {
+    public void loggedInEUShouldNotGetModalIfOptedOutOnDesktop() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
 
     @Test(groups = {"discussions-tracking-opt-in-desktop"})
     @Execute(asUser = User.ANONYMOUS, trackingOptIn = false, trackingOptOut = true)
-    public void AnonUserInEUShouldNotGetModalIfOptedOutOnDesktop() {
+    public void AnonInEUShouldNotGetModalIfOptedOutOnDesktop() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
+
+    /*
+        MOBILE TESTS
+    */
 
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
     @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
@@ -84,7 +74,7 @@ public class TrackingOptIn extends NewTestTemplate {
             groups = {"discussions-tracking-opt-in-mobile"})
     public void testModalVisibilityForAnonOnMobile(String continent, String country, boolean shouldGetModal) {
         TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
-        Assertion.assertEquals(new TrackingOptInModal().isVisible(), shouldGetModal);
+        Assertion.assertEquals(trackingModal.isVisible(), shouldGetModal);
     }
 
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
@@ -94,13 +84,13 @@ public class TrackingOptIn extends NewTestTemplate {
     public void testModalVisibilityForLoggedInWhoNeverOptedInOnMobile(String continent, String country,
                                                               boolean shouldGetModal) {
         TrackingOptInModal trackingModal = setGeoCookieAndNavigate(continent, country);
-        Assertion.assertEquals(new TrackingOptInModal().isVisible(), shouldGetModal);
+        Assertion.assertEquals(trackingModal.isVisible(), shouldGetModal);
     }
 
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
     @Test(groups = {"discussions-tracking-opt-in-mobile"})
     @Execute(asUser = User.USER)
-    public void loggedInUserInEUShouldNotGetModalIfOptedInOnMobile() {
+    public void loggedInEUShouldNotGetModalIfOptedInOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
@@ -108,7 +98,7 @@ public class TrackingOptIn extends NewTestTemplate {
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
     @Test(groups = {"discussions-tracking-opt-in-mobile"})
     @Execute(asUser = User.ANONYMOUS)
-    public void AnonUserInEUShouldNotGetModalIfOptedInOnMobile() {
+    public void AnonInEUShouldNotGetModalIfOptedInOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
@@ -116,7 +106,7 @@ public class TrackingOptIn extends NewTestTemplate {
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
     @Test(groups = {"discussions-tracking-opt-in-mobile"})
     @Execute(asUser = User.USER, trackingOptIn = false, trackingOptOut = true)
-    public void loggedInUserInEUShouldNotGetModalIfOptedOutOnMobile() {
+    public void loggedInEUShouldNotGetModalIfOptedOutOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
     }
@@ -124,9 +114,31 @@ public class TrackingOptIn extends NewTestTemplate {
     @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
     @Test(groups = {"discussions-tracking-opt-in-mobile"})
     @Execute(asUser = User.ANONYMOUS, trackingOptIn = false, trackingOptOut = true)
-    public void AnonUserInEUShouldNotGetModalIfOptedOutOnMobile() {
+    public void AnonInEUShouldNotGetModalIfOptedOutOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    /*
+        HELPERS
+    */
+
+    private TrackingOptInModal setGeoCookieToGermanyAndNavigate() {
+        TrackingOptInModal trackingModal = new TrackingOptInModal();
+        trackingModal.setGeoCookie(driver, "EU", "DE");
+        new PostsListPage().open();
+        trackingModal.logTrackingCookieValue();
+
+        return trackingModal;
+    }
+
+    private TrackingOptInModal setGeoCookieAndNavigate(String continent, String country) {
+        TrackingOptInModal trackingModal = new TrackingOptInModal();
+        trackingModal.setGeoCookie(driver, continent, country);
+        new PostsListPage().open();
+        trackingModal.logTrackingCookieValue();
+
+        return trackingModal;
     }
 
 }

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -70,7 +70,7 @@ public class TrackingOptIn extends NewTestTemplate {
     @NetworkTrafficDump(useMITM = true)
     @Test(groups = {"discussions-tracking-opt-in-desktop"},
             dataProviderClass = TrackingOptInDataProvider.class,
-            dataProvider = "discussionsGoogleAnalyticAnonymized")
+            dataProvider = "googleAnalyticAnonymizedUser")
     @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
     public void anonInEUOnRejectShouldGetAnonymizedGoogleTracking(List<String> urlPatterns) {
         networkTrafficInterceptor.startIntercepting();

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -3,6 +3,7 @@ package com.wikia.webdriver.testcases.discussions;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
+import com.wikia.webdriver.common.core.annotations.NetworkTrafficDump;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
@@ -117,6 +118,18 @@ public class TrackingOptIn extends NewTestTemplate {
     public void AnonInEUShouldNotGetModalIfOptedOutOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
+    }
+
+    @Test
+    @NetworkTrafficDump(useMITM = true)
+    @Execute(trackingOptIn = false)
+    public void testRequest() {
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertTrue(trackingModal.isVisible());
+        networkTrafficInterceptor.startIntercepting();
+        trackingModal.clickRejectButton();
+
+        networkTrafficInterceptor.stop();
     }
 
     /*

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -77,7 +77,6 @@ public class TrackingOptIn extends NewTestTemplate {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertTrue(trackingModal.isVisible());
         trackingModal.clickRejectButton();
-        networkTrafficInterceptor.stop();
 
         Assertion.assertTrue(trackingModal.areResponsesByUrlPatternSuccessful(urlPatterns, networkTrafficInterceptor));
     }

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -13,6 +13,8 @@ import com.wikia.webdriver.elements.mercury.pages.discussions.PostsListPage;
 import com.wikia.webdriver.pageobjectsfactory.componentobject.TrackingOptInModal;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 @Test(groups = {"discussions-tracking-opt-in"})
 public class TrackingOptIn extends NewTestTemplate {
 
@@ -120,16 +122,19 @@ public class TrackingOptIn extends NewTestTemplate {
         Assertion.assertFalse(trackingModal.isVisible());
     }
 
-    @Test
     @NetworkTrafficDump(useMITM = true)
-    @Execute(trackingOptIn = false)
-    public void testRequest() {
+    @Test(groups = {"discussions-tracking-opt-in-desktop"},
+            dataProviderClass = TrackingOptInDataProvider.class,
+            dataProvider = "discussionsGoogleAnalyticAnonymized")
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
+    public void anonInEUOnRejectShouldGetAnonymizedGoogleTracking(List<String> urlPatterns) {
+        networkTrafficInterceptor.startIntercepting();
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertTrue(trackingModal.isVisible());
-        networkTrafficInterceptor.startIntercepting();
         trackingModal.clickRejectButton();
-
         networkTrafficInterceptor.stop();
+
+        Assertion.assertTrue(trackingModal.areResponsesByUrlPatternSuccessful(urlPatterns, networkTrafficInterceptor));
     }
 
     /*

--- a/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
+++ b/src/test/java/com/wikia/webdriver/testcases/discussions/TrackingOptIn.java
@@ -67,6 +67,21 @@ public class TrackingOptIn extends NewTestTemplate {
         Assertion.assertFalse(trackingModal.isVisible());
     }
 
+    @NetworkTrafficDump(useMITM = true)
+    @Test(groups = {"discussions-tracking-opt-in-desktop"},
+            dataProviderClass = TrackingOptInDataProvider.class,
+            dataProvider = "discussionsGoogleAnalyticAnonymized")
+    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
+    public void anonInEUOnRejectShouldGetAnonymizedGoogleTracking(List<String> urlPatterns) {
+        networkTrafficInterceptor.startIntercepting();
+        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
+        Assertion.assertTrue(trackingModal.isVisible());
+        trackingModal.clickRejectButton();
+        networkTrafficInterceptor.stop();
+
+        Assertion.assertTrue(trackingModal.areResponsesByUrlPatternSuccessful(urlPatterns, networkTrafficInterceptor));
+    }
+
     /*
         MOBILE TESTS
     */
@@ -120,21 +135,6 @@ public class TrackingOptIn extends NewTestTemplate {
     public void AnonInEUShouldNotGetModalIfOptedOutOnMobile() {
         TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
         Assertion.assertFalse(trackingModal.isVisible());
-    }
-
-    @NetworkTrafficDump(useMITM = true)
-    @Test(groups = {"discussions-tracking-opt-in-desktop"},
-            dataProviderClass = TrackingOptInDataProvider.class,
-            dataProvider = "discussionsGoogleAnalyticAnonymized")
-    @Execute(asUser = User.ANONYMOUS, trackingOptIn = false)
-    public void anonInEUOnRejectShouldGetAnonymizedGoogleTracking(List<String> urlPatterns) {
-        networkTrafficInterceptor.startIntercepting();
-        TrackingOptInModal trackingModal = setGeoCookieToGermanyAndNavigate();
-        Assertion.assertTrue(trackingModal.isVisible());
-        trackingModal.clickRejectButton();
-        networkTrafficInterceptor.stop();
-
-        Assertion.assertTrue(trackingModal.areResponsesByUrlPatternSuccessful(urlPatterns, networkTrafficInterceptor));
     }
 
     /*

--- a/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
+++ b/src/test/java/com/wikia/webdriver/testsuites/testSuite.xml
@@ -119,6 +119,7 @@
             <class name="com.wikia.webdriver.testcases.discussions.ReportingPostTests"/>
             <class name="com.wikia.webdriver.testcases.discussions.SharingTests"/>
             <class name="com.wikia.webdriver.testcases.discussions.SortingTests"/>
+            <class name="com.wikia.webdriver.testcases.discussions.TrackingOptIn"/>
             <class name="com.wikia.webdriver.testcases.discussions.UploadingImageTests"/>
             <class name="com.wikia.webdriver.testcases.discussions.UpvotingTests"/>
             <class name="com.wikia.webdriver.testcases.discussions.ZeroErrorStateTests"/>


### PR DESCRIPTION
Use already implemented TrackingOptInModal page object and mobile-wiki tests cases in Discussions. Add check for anonymized request to Google Analytics.

@Wikia/iris @ludwikkazmierczak  @bulaszenko @chessky 