### PR TITLE
(PLATFORM-3465) Fix unpin button selector for non-English wikis

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/componentobject/lightbox/LightboxComponentObject.java
@@ -20,7 +20,7 @@ public class LightboxComponentObject extends WikiBasePageObject {
   private WebElement imageThumbnail;
   @FindBy(css = "#LightboxModal")
   private WebElement lightBoxModal;
-  @FindBy(css = "span[data-pinned-title='Unpin top and bottom bars']")
+  @FindBy(css = "span.pin")
   private WebElement pinButton;
   @FindBy(css = ".WikiaLightbox .share")
   private WebElement shareScreen;


### PR DESCRIPTION
Anons will see a wiki's i18n messages in the content language of the
wiki, so selecting based on the content of an attribute that uses an
i18n message won't work on a non-English wiki such as those in our
language path tests. Additionally, selecting based on a translation
string is brittle, so let's use a class selector here.

/cc @Wikia/core-platform-team 