### PR TITLE
Fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,6 +378,7 @@ test {
         testLogging.showStandardStreams = true
         testLogging.showStackTraces = true
         testLogging.exceptionFormat = TestExceptionFormat.FULL
+        configFailurePolicy = 'continue'
     }
 
     outputs.upToDateWhen { false }
@@ -403,7 +404,7 @@ dependencies {
     testCompile 'org.seleniumhq.selenium:jetty-repacked:7.6.1'
     testCompile 'commons-lang:commons-lang:2.4'
     testCompile 'com.github.detro.ghostdriver:phantomjsdriver:1.1.0'
-    testCompile 'org.testng:testng:6.9.6'
+    testCompile 'org.testng:testng:6.14.3'
     testCompile 'org.jsoup:jsoup:1.8.3'
     testCompile 'com.google.guava:guava:18.0'
     testCompile 'org.yaml:snakeyaml:1.8'

--- a/src/test/java/com/wikia/webdriver/common/templates/NewTestTemplate.java
+++ b/src/test/java/com/wikia/webdriver/common/templates/NewTestTemplate.java
@@ -18,10 +18,6 @@ public class NewTestTemplate extends CoreTestTemplate {
   protected String wikiCorporateURL;
   protected String wikiCorpSetupURL;
 
-  @BeforeMethod(alwaysRun = true)
-  public void start(Method method, Object[] data) {
-  }
-
   protected void loadFirstPage() {
     driver.get(urlBuilder.getUrlForWikiPage(URLsContent.SPECIAL_VERSION) + "?noexternals=1");
   }

--- a/src/test/java/com/wikia/webdriver/common/testnglisteners/BrowserAndTestEventListener.java
+++ b/src/test/java/com/wikia/webdriver/common/testnglisteners/BrowserAndTestEventListener.java
@@ -61,13 +61,13 @@ public class BrowserAndTestEventListener extends AbstractWebDriverEventListener
       if (url.equals(driver.getCurrentUrl())) {
         Log.ok(command, VelocityWrapper.fillLink(driver.getCurrentUrl(), driver.getCurrentUrl()));
       } else {
+        // A fast lane to stop executing any test on "not a valid community" page
+        if(driver.getCurrentUrl().contains(URLsContent.NOT_A_VALID_COMMUNITY)){
+          throw new SkipException(String.format("Wrong redirect to: %s", driver.getCurrentUrl()));
+        }
         if (driver.getCurrentUrl().contains("data:text/html,chromewebdata ")) {
           driver.get(url);
           Log.warning(command, driver.getCurrentUrl());
-        } else if (driver.getCurrentUrl().contains(URLsContent.NOT_A_VALID_COMMUNITY)) {
-          Log.warning(command, driver.getCurrentUrl());
-          driver.get("http://seleniumworkaround");
-          Log.log("Workaround", "Dummy redirect", true);
         } else {
           Log.warning(command, driver.getCurrentUrl());
         }
@@ -221,7 +221,9 @@ public class BrowserAndTestEventListener extends AbstractWebDriverEventListener
       onTestSuccess(result);
     } else {
       result.setStatus(ITestResult.FAILURE);
-      result.setThrowable(new SkipException("TEST SKIPPED"));
+      if(result.getThrowable() == null) {
+        result.setThrowable(new SkipException("TEST SKIPPED"));
+      }
       onTestFailure(result);
     }
     if (Log.isTestStarted()) {

--- a/src/test/java/com/wikia/webdriver/common/testnglisteners/InvokeMethodAdapter.java
+++ b/src/test/java/com/wikia/webdriver/common/testnglisteners/InvokeMethodAdapter.java
@@ -32,6 +32,10 @@ public class InvokeMethodAdapter implements IInvokedMethodListener {
           result.setThrowable((Throwable) failure);
         }
       }
+    }else {
+      if(result.getStatus() == ITestResult.FAILURE){
+        Log.logError("TEST CONFIGURATION FAILED", result.getThrowable());
+      }
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsAmazonObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/adsbase/AdsAmazonObject.java
@@ -1,8 +1,8 @@
 package com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase;
 
 import com.wikia.webdriver.common.contentpatterns.AdsContent;
-import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
 
 public class AdsAmazonObject extends AdsBaseObject {
   private static final String QS_TURN_ON_A9 = "InstantGlobals.wgAdDriverA9BidderCountries=[XX]";

--- a/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsAbcdProductsPriority.java
+++ b/src/test/java/com/wikia/webdriver/testcases/adstests/TestAdsAbcdProductsPriority.java
@@ -6,7 +6,8 @@ import com.wikia.webdriver.common.core.url.Page;
 import com.wikia.webdriver.common.dataprovider.ads.AdsDataProvider;
 import com.wikia.webdriver.common.templates.TemplateNoFirstLoad;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.adsbase.AdsBaseObject;
-import org.junit.Assert;
+
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestAdsAbcdProductsPriority extends TemplateNoFirstLoad {
@@ -52,8 +53,8 @@ public class TestAdsAbcdProductsPriority extends TemplateNoFirstLoad {
   }
 
   private void verifyNoUAPSizesInSlot(AdsBaseObject ads, String slot) {
-    Assert.assertFalse(String.format("Slot %s has UAP supported 2x2 size", slot), ads.slotHasSize(slot, 2, 2));
-    Assert.assertFalse(String.format("Slot %s has UAP supported 3x3 size", slot), ads.slotHasSize(slot, 3, 3));
+    Assert.assertFalse(ads.slotHasSize(slot, 2, 2), String.format("Slot %s has UAP supported 2x2 size", slot));
+    Assert.assertFalse(ads.slotHasSize(slot, 3, 3), String.format("Slot %s has UAP supported 3x3 size", slot));
   }
 
   private void verifyOutstreamAdIsDisplayed(AdsBaseObject ads){


### PR DESCRIPTION
An actual fix for the issue. Setting `configFailurePolicy = 'continue'` is essential, since if runtime error is thrown in config method (ex. `initTestContext`) then method coming right after is skipped, but child methods from the group are being executed. If we set policy to `'skip'` (which is a default), then all the tests in the group are skipped if configuration fails even once.

Changes in method adapter are there to log both, the configuration `Throwable`, which is the caus e of the skip, and Test skipped exception. Otherwise, just a skip exception will be logged, and we will not know the root cause
 