### PR TITLE
Changed TIMEOUT_PAGE_REGISTRATION as it is in seconds

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/BasePageObject.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 public class BasePageObject {
 
-  private static final int TIMEOUT_PAGE_REGISTRATION = 3000;
+  private static final int TIMEOUT_PAGE_REGISTRATION = 3;
   private static final String
       COMSCORE_PIXEL_URL
       = "script[src*='b.scorecardresearch.com/beacon.js']";


### PR DESCRIPTION
http://jenkins.wikia-prod:8080/view/Iris/view/discussions-sandbox/job/iris-discussions-promoting-sandbox/76/

Timeout was set to 3000 but it is in seconds so I don't think it was done on purpose.
```
private void waitForLinkOpenedInNewTab(WebElement link) {
    int initialTabsNumber = driver.getWindowHandles().size();
    link.click();
    new WebDriverWait(driver,
                      TIMEOUT_PAGE_REGISTRATION
    ).until((Function<WebDriver, Boolean>) input -> getTabsCount() > initialTabsNumber);
  }
```