### PR TITLE
Community should not be served from fandom domain

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/core/configuration/EnvType.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/EnvType.java
@@ -10,7 +10,6 @@ public enum EnvType {
   @Getter
   private final String wikiaDomain;
 
-  @Getter
   private final String fandomDomain;
 
   @Getter

--- a/src/test/java/com/wikia/webdriver/common/core/configuration/EnvType.java
+++ b/src/test/java/com/wikia/webdriver/common/core/configuration/EnvType.java
@@ -3,24 +3,26 @@ package com.wikia.webdriver.common.core.configuration;
 import lombok.Getter;
 
 public enum EnvType {
-	PROD("prod", "wikia.com", "fandom.com"),
-	SANDBOX("sandbox", "wikia.com", "fandom.com"),
-	DEV("dev", "wikia-dev.pl", "fandom-dev.pl");
+  PROD("prod", "wikia.com", "fandom.com"),
+  SANDBOX("sandbox", "wikia.com", "fandom.com"),
+  DEV("dev", "wikia-dev.pl", "fandom-dev.pl");
 
-	private final String wikiaDomain;
+  @Getter
+  private final String wikiaDomain;
 
-	private final String fandomDomain;
+  @Getter
+  private final String fandomDomain;
 
-	@Getter
-	private final String key;
+  @Getter
+  private final String key;
 
-	EnvType(String key, String wikiaDomain, String fandomDomain) {
-		this.key = key;
-		this.wikiaDomain = wikiaDomain;
-		this.fandomDomain = fandomDomain;
-	}
+  EnvType(String key, String wikiaDomain, String fandomDomain) {
+    this.key = key;
+    this.wikiaDomain = wikiaDomain;
+    this.fandomDomain = fandomDomain;
+  }
 
-	public String getDomain() {
-		return Configuration.getForceFandomDomain() ? fandomDomain : wikiaDomain;
-	}
+  public String getDomain() {
+    return Configuration.getForceFandomDomain() ? fandomDomain : wikiaDomain;
+  }
 }

--- a/src/test/java/com/wikia/webdriver/common/core/url/UrlBuilder.java
+++ b/src/test/java/com/wikia/webdriver/common/core/url/UrlBuilder.java
@@ -184,7 +184,7 @@ public class UrlBuilder extends BaseUrlBuilder {
     if (FANDOM_EXCULUDED_WIKIS.contains(wikiName)) {
       return envType.getWikiaDomain();
     } else {
-      return envType.getFandomDomain();
+      return envType.getDomain();
     }
   }
 }


### PR DESCRIPTION
When a wiki is on the `FANDOM_EXCULUDED_WIKIS` it should not add `suffix` to the name, or change a domain to `fandom.com`, it's mostly API calls to community.