### PR TITLE
PLATFORM-3678 | There are no GDPR cookies outside UE

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/desktop/adstests/TestAdsTrackingOptInRequestsOasis.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/adstests/TestAdsTrackingOptInRequestsOasis.java
@@ -349,11 +349,11 @@ public class TestAdsTrackingOptInRequestsOasis extends NewTestTemplate {
     modal.setGeoCookie(driver, "NA", "US");
     modal.getUrl(ADS_ARTICLE1_PAGE);
 
-    modal.verifyTrackingRequestsSend(urlPatterns, networkTrafficInterceptor);
+    modal.verifyTrackingRequestsSendOutsideEU(urlPatterns, networkTrafficInterceptor);
     // Check tracking pixels on consecutive page views
     for (String linkName : articles) {
       ads.clickOnArticleLink(linkName);
-      modal.verifyTrackingRequestsSend(urlPatterns, networkTrafficInterceptor);
+      modal.verifyTrackingRequestsSendOutsideEU(urlPatterns, networkTrafficInterceptor);
     }
   }
 
@@ -367,6 +367,6 @@ public class TestAdsTrackingOptInRequestsOasis extends NewTestTemplate {
     modal.setGeoCookie(driver, "NA", "US");
     modal.getUrl(ADS_HOME_PAGE);
 
-    modal.verifyTrackingRequestsSend(urlPatterns, networkTrafficInterceptor);
+    modal.verifyTrackingRequestsSendOutsideEU(urlPatterns, networkTrafficInterceptor);
   }
 }


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3678

For tests outside EU let's use a method dedicated for that case like we already do on mobile:
https://github.com/Wikia/selenium-tests/blob/7864af753dc819d7b493176a3baeafee4fa39502/src/test/java/com/wikia/webdriver/testcases/desktop/adstests/TestAdsTrackingOptInRequestsMobileWiki.java#L296

These two tests started failing after we stopped using in-app CMP and started using the one from tracking-opt-in lib: https://github.com/Wikia/app/pull/16060

@ludwikkazmierczak @Wikia/adeng 