### PR TITLE
IW-1372 | Remove Forum highlights feature from tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumBoardPage.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/forumpageobject/ForumBoardPage.java
@@ -33,8 +33,6 @@ public class ForumBoardPage extends BasePageObject {
   private List<WebElement> postedImageList;
   @FindBys(@FindBy(css = "li.thread div.thread-left h4 a"))
   private List<WebElement> threadTitlesList;
-  @FindBy(css = ".notify-everyone")
-  private WebElement highlight;
   @FindBy(css = "#cke_WikiaEditor-0")
   private WebElement wikiaEditorTextArea;
 
@@ -68,14 +66,7 @@ public class ForumBoardPage extends BasePageObject {
     return boardName;
   }
 
-  private void checkHighlightCheckbox(boolean isHighLighted) {
-    if (isHighLighted) {
-      highlight.click();
-      Log.log("checkHighlightCheckbox", "highlight checkbox clicked", true, driver);
-    }
-  }
-
-  public ForumThreadPageObject startDiscussion(String title, String message, boolean highlight) {
+  public ForumThreadPageObject startDiscussion(String title, String message) {
     wait.forElementVisible(discussionTitleArea);
     jsActions.focus(discussionTitleArea);
     discussionTitleArea.sendKeys(title);
@@ -84,7 +75,6 @@ public class ForumBoardPage extends BasePageObject {
     driver.switchTo().frame(miniEditor.miniEditorIframe);
     miniEditor.writeMiniEditor(message);
     driver.switchTo().defaultContent();
-    checkHighlightCheckbox(highlight);
     clickPostButton();
     Log.log(
         "startDiscussion",

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumAnonTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumAnonTests.java
@@ -21,7 +21,7 @@ public class ForumAnonTests extends NewTestTemplate {
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
 
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
   }
 
@@ -31,7 +31,7 @@ public class ForumAnonTests extends NewTestTemplate {
     String message = String.format(PageContent.FORUM_MESSAGE, DateTime.now().getMillis());
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     forumThread.reply(message);
     forumThread.verifyReplyMessage(1, message);

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumBoardTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumBoardTests.java
@@ -25,7 +25,7 @@ public class ForumBoardTests extends NewTestTemplate {
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
 
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
   }
 
@@ -97,7 +97,7 @@ public class ForumBoardTests extends NewTestTemplate {
 
     forumBoard.open(boardTitle);
 
-    ForumThreadPageObject thread = forumBoard.startDiscussion("A nice discussion", "A nice Message", false);
+    ForumThreadPageObject thread = forumBoard.startDiscussion("A nice discussion", "A nice Message");
     thread.verifyDiscussionTitleAndMessage("A nice discussion", "A nice Message");
 
     forumBoard.open(boardTitle);

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumThreadTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumThreadTests.java
@@ -27,7 +27,7 @@ public class ForumThreadTests extends NewTestTemplate {
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
 
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     forumThread.reply(message);
     forumThread.verifyReplyMessage(1, message);
@@ -41,7 +41,7 @@ public class ForumThreadTests extends NewTestTemplate {
 
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     forumThread.removeThread("QA reason");
     forumThread.verifyThreadRemoved();
@@ -58,7 +58,7 @@ public class ForumThreadTests extends NewTestTemplate {
 
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     forumThread.verifyParentBoard(forumThread.moveThread());
   }
@@ -71,7 +71,7 @@ public class ForumThreadTests extends NewTestTemplate {
 
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     ForumHistoryPageObject forumHistory = forumThread.openHistory();
     forumHistory.verifyImportandPageElements();
@@ -86,7 +86,7 @@ public class ForumThreadTests extends NewTestTemplate {
 
     ForumBoardPage forumBoard = new ForumBoardPage();
     forumBoard.open(forumBoard.createNew(User.SUS_STAFF2));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
     forumThread.closeThread(PageContent.CLOSE_REASON);
     forumThread.verifyThreadClosed();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/notificationstests/ForumNotificationsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/notificationstests/ForumNotificationsTests.java
@@ -36,7 +36,7 @@ public class ForumNotificationsTests extends NewTestTemplate {
     forumMainPage.openForumMainPage(wikiURL);
     ForumBoardPage forumBoard = forumMainPage.openForumBoard();
     forumBoardTitle = forumBoard.getTitle();
-    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message, false);
+    ForumThreadPageObject forumThread = forumBoard.startDiscussion(title, message);
     forumThread.verifyDiscussionTitleAndMessage(title, message);
   }
 


### PR DESCRIPTION
Remove Forum highlights support from tests. The feature is due to be sunset in https://github.com/Wikia/app/pull/16455 and it's not actually used in any tests.