### PR TITLE
IW-1934 | Get rid of SZL tests and annotations

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/desktop/anonymization/AnonymizationTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/anonymization/AnonymizationTests.java
@@ -34,12 +34,7 @@ public class AnonymizationTests extends NewTestTemplate {
       ERROR_MESSAGE
       = "We don't recognize these credentials. Try again or register a new account.";
 
-  private static final String
-      ERROR_MESSAGE_SZL
-      = "Nie rozpoznajemy tych danych uwierzytelniania. Spróbuj ponownie lub zarejestruj nowe konto.";
-
   @Test
-  @DontRun(language = "szl")
   public void anonymizedUserCannotLogin() {
     Credentials credentials = new Credentials();
     String timestamp = Long.toString(DateTime.now().getMillis());
@@ -63,32 +58,6 @@ public class AnonymizationTests extends NewTestTemplate {
     SignInPage signIn = new GlobalNavigation().clickOnSignIn();
     signIn.login(qanon, passw);
     Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE);
-  }
-  @Test
-  @RunOnly(language = "szl")
-  public void anonymizedUserCannotLoginSzl() {
-    Credentials credentials = new Credentials();
-    String timestamp = Long.toString(DateTime.now().getMillis());
-    String qanon = User.SUS_REGULAR_USER.getUserName() + timestamp;
-    String passw = User.SUS_REGULAR_USER.getPassword();
-    SignUpUser user = new SignUpUser(qanon,
-                                     credentials.emailAnonymousUserTestWikia,
-                                     passw,
-                                     LocalDate.of(1990, 3, 19)
-    );
-    UserRegistration.registerUserEmailConfirmed(user);
-
-    SpecialAnonymizationUserPage anonymizationPage = new SpecialAnonymizationUserPage().open();
-    anonymizationPage.loginAs(User.SUS_STAFF);
-    anonymizationPage.fillFutureAnon(qanon).submitAnonymization();
-
-    Assertion.assertStringContains(anonymizationPage.getAnonConfirmation(), qanon);
-
-    anonymizationPage.logOut();
-
-    SignInPage signIn = new GlobalNavigation().clickOnSignIn();
-    signIn.login(qanon, passw);
-    Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE_SZL);
   }
 
   @Test

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/articlecrudtests/ArticleActionsAdminTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/articlecrudtests/ArticleActionsAdminTests.java
@@ -3,9 +3,7 @@ package com.wikia.webdriver.testcases.desktop.articlecrudtests;
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.TestContext;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.driverprovider.UseUnstablePageLoadStrategy;
@@ -58,7 +56,6 @@ public class ArticleActionsAdminTests extends NewTestTemplate {
     article.verifyArticleTitle(articleTitle);
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"ArticleActionsAdmin_002"})
   @UseUnstablePageLoadStrategy
   @Execute(asUser = User.STAFF)

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/articlecrudtests/ArticleSourceModeTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/articlecrudtests/ArticleSourceModeTests.java
@@ -4,9 +4,7 @@ import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.contentpatterns.VideoContent;
 import com.wikia.webdriver.common.core.AlertHandler;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -78,7 +76,6 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     Assertion.assertEquals(source.getSourceContent(), "\n== Headline text ==\n");
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"RTE_extended_1", "RTE_extended_006"})
   public void RTE_006_EmbedFile() {
     String articleName = PageContent.ARTICLE_NAME_PREFIX + DateTime.now().getMillis();
@@ -135,7 +132,6 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     Assertion.assertEquals(source.getSourceContent(), "\n----\n");
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"RTE_extended_2", "RTE_extended_012"})
   public void RTE_012_Photo() {
     String articleName = PageContent.ARTICLE_NAME_PREFIX + DateTime.now().getMillis();
@@ -149,25 +145,6 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     Assertion.assertEquals(source.getSourceContent(),
                            String.format(PageContent.WIKI_TEXT_PHOTO.replace("%photoName%",
                                                                              photoName
-                           ), PageContent.CAPTION)
-    );
-  }
-
-  @Test(groups = {"RTE_extended_2", "RTE_extended_012A"})
-  @RunOnly(language = "szl")
-  @Execute(asUser = User.SUS_REGULAR_USER3, onWikia = "sustainingtest")
-  public void RTE_012A_PhotoSzl() {
-    String articleName = PageContent.ARTICLE_NAME_PREFIX + DateTime.now().getMillis();
-    SourceEditModePageObject source = new SourceEditModePageObject().openArticle(articleName);
-    PhotoAddComponentObject photoAddPhoto = source.clickAddPhoto();
-    PhotoOptionsComponentObject photoOptions = photoAddPhoto.addPhotoFromWiki("default_Image001.png");
-    photoOptions.setCaption(PageContent.CAPTION);
-    photoOptions.clickAddPhoto();
-    String photoName = photoAddPhoto.getPhotoName();
-
-    Assertion.assertEquals(source.getSourceContent(),
-                           String.format("[[Plik:%photoName%|thumb|%s]]".replace("%photoName%",
-                                                                                 photoName
                            ), PageContent.CAPTION)
     );
   }
@@ -243,7 +220,6 @@ public class ArticleSourceModeTests extends NewTestTemplate {
     );
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"RTE_extended_3", "RTE_extended_016", "Media"})
   public void RTE_016_Video() {
     String articleName = PageContent.ARTICLE_NAME_PREFIX + DateTime.now().getMillis();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/auth/ForcedLoginTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/auth/ForcedLoginTests.java
@@ -5,9 +5,7 @@ import static com.wikia.webdriver.common.core.Assertion.assertTrue;
 import com.wikia.webdriver.common.contentpatterns.MobileWikis;
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.logging.Log;
@@ -42,7 +40,6 @@ public class ForcedLoginTests extends NewTestTemplate {
     specialPage.verifyUserLoggedIn(user.getUserName());
   }
 
-  @DontRun(language = "szl")
   public void anonCanLogInViaUserLoginPage() {
     WikiBasePageObject base = new WikiBasePageObject().openSpecialUpload();
     base.clickLoginOnSpecialPage();
@@ -51,16 +48,6 @@ public class ForcedLoginTests extends NewTestTemplate {
     assertTrue(base.isStringInURL(URLsContent.SPECIAL_UPLOAD));
   }
 
-  @RunOnly(language = "szl")
-  public void anonCanLogInViaUserLoginPageSzl() {
-    WikiBasePageObject base = new WikiBasePageObject().openSpecialUpload();
-    base.clickLoginOnSpecialPage();
-    new AttachedSignInPage().login(user);
-    base.verifyUserLoggedIn(user.getUserName());
-    Assertion.assertStringContains(base.getUrl(),URLsContent.SPECIAL_UPLOAD_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void anonCanLogInOnSpecialWatchListPage() {
     WikiBasePageObject base = new WikiBasePageObject();
@@ -69,17 +56,6 @@ public class ForcedLoginTests extends NewTestTemplate {
     new AttachedSignInPage().login(user);
     base.verifyUserLoggedIn(user.getUserName());
     assertTrue(base.isStringInURL(URLsContent.SPECIAL_WATCHLIST));
-  }
-
-  @RunOnly(language = "szl")
-  @Test
-  public void anonCanLogInOnSpecialWatchListPageSzl() {
-    WikiBasePageObject base = new WikiBasePageObject();
-    base.openSpecialWatchListPage(wikiURL);
-    base.clickLoginOnSpecialPage();
-    new AttachedSignInPage().login(user);
-    base.verifyUserLoggedIn(user.getUserName());
-    assertTrue(base.isStringInURL(URLsContent.SPECIAL_WATCHLIST_SZL));
   }
 
   public void anonCanLogInViaAuthModalWhenAddingPhoto() {

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/auth/LoginTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/auth/LoginTests.java
@@ -4,10 +4,8 @@ import com.wikia.webdriver.common.contentpatterns.MobileSubpages;
 import com.wikia.webdriver.common.contentpatterns.MobileWikis;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.Helios;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.drivers.Browser;
 import com.wikia.webdriver.common.core.helpers.Emulator;
 import com.wikia.webdriver.common.core.helpers.User;
@@ -38,7 +36,6 @@ public class LoginTests extends NewTestTemplate {
 
   private static final String ERROR_MESSAGE =
     "We don't recognize these credentials. Try again or register a new account.";
-  private static final String ERROR_MESSAGE_SZL = "Nie rozpoznajemy tych danych uwierzytelniania. Spróbuj ponownie lub zarejestruj nowe konto.";
 
   private static final  String PASSWORD_FORM = "P@55_%s";
 
@@ -139,7 +136,6 @@ public class LoginTests extends NewTestTemplate {
     assertTrue(article.isUserLoggedOutMobile());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = DESKTOP)
   public void invalidPasswordErrorMessagesIsPresentedOnDesktop() {
     SignInPage signIn = openLoginPageFromGlobalnavOnDesktop();
@@ -148,16 +144,6 @@ public class LoginTests extends NewTestTemplate {
     Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = DESKTOP)
-  public void invalidPasswordErrorMessagesIsPresentedOnDesktopSzl() {
-    SignInPage signIn = openLoginPageFromGlobalnavOnDesktop();
-    String invalidPassword = String.format(PASSWORD_FORM, Instant.now().getEpochSecond());
-    signIn.login(USER.getUserName(), invalidPassword);
-    Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = MOBILE)
   @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
   public void invalidPasswordErrorMessagesIsPresentedOnMobile() {
@@ -166,17 +152,6 @@ public class LoginTests extends NewTestTemplate {
     String invalidPassword = String.format(PASSWORD_FORM, Instant.now().getEpochSecond());
     signIn.login(USER.getUserName(), invalidPassword);
     Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE);
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = MOBILE)
-  @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
-  public void invalidPasswordErrorMessagesIsPresentedOnMobileSzl() {
-    openArticleOnMobile();
-    SignInPage signIn = navigateToSignInOnMobile();
-    String invalidPassword = String.format(PASSWORD_FORM, Instant.now().getEpochSecond());
-    signIn.login(USER.getUserName(), invalidPassword);
-    Assertion.assertEquals(signIn.getError(), ERROR_MESSAGE_SZL);
   }
 
   /**

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/auth/SignupTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/auth/SignupTests.java
@@ -28,13 +28,9 @@ import static org.testng.Assert.assertTrue;
 public class SignupTests extends NewTestTemplate {
 
   private static final String USERNAME_TAKEN_MSG = "Username is taken";
-  private static final String USERNAME_TAKEN_MSG_SZL = "Nazwa użytkownika jest już wykorzystywana";
   private static final String PASSWORD_MATCHING_USERNAME_MSG = "Password and username cannot match";
-  private static final String PASSWORD_MATCHING_USERNAME_MSG_SZL = "Hasło i nazwa użytkownika nie mogą być takie same";
   private static final String GENERIC_ERROR_MSG =
     "We cannot complete your registration at this time";
-  private static final String GENERIC_ERROR_MSG_SZL =
-      "Nie możemy w tej chwili ukończyć rejestracji";
 
   private static final String DESKTOP = "auth-signup-desktop";
   private static final String MOBILE = "auth-signup-mobile";
@@ -67,21 +63,12 @@ public class SignupTests extends NewTestTemplate {
     performSignUpOnMobileAs(createUserWithExistingEmail());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = DESKTOP)
   public void userCannotSignUpWithExistingUsernameDesktop() {
     RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createUserWithExistingUsername());
     assertEquals(form.getError(), USERNAME_TAKEN_MSG);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = DESKTOP)
-  public void userCannotSignUpWithExistingUsernameDesktopSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createUserWithExistingUsername());
-    assertEquals(form.getError(), USERNAME_TAKEN_MSG_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = MOBILE)
   @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
   public void userCannotSignUpWithExistingUsernameMobile() {
@@ -89,29 +76,12 @@ public class SignupTests extends NewTestTemplate {
     assertEquals(form.getError(), USERNAME_TAKEN_MSG);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = MOBILE)
-  @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
-  public void userCannotSignUpWithExistingUsernameMobileSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnMobileAs(createUserWithExistingUsername());
-    assertEquals(form.getError(), USERNAME_TAKEN_MSG_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = DESKTOP)
   public void userCannotSignUpWithPasswordMatchingUsernameDesktop() {
     RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createUserWithPasswordMatchingUsername());
     assertEquals(form.getError(), PASSWORD_MATCHING_USERNAME_MSG);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = DESKTOP)
-  public void userCannotSignUpWithPasswordMatchingUsernameDesktopSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createUserWithPasswordMatchingUsername());
-    assertEquals(form.getError(), PASSWORD_MATCHING_USERNAME_MSG_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = MOBILE)
   @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
   public void userCannotSignUpWithPasswordMatchingUsernameMobile() {
@@ -119,42 +89,17 @@ public class SignupTests extends NewTestTemplate {
     assertEquals(form.getError(), PASSWORD_MATCHING_USERNAME_MSG);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = MOBILE)
-  @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
-  public void userCannotSignUpWithPasswordMatchingUsernameMobileSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnMobileAs(createUserWithPasswordMatchingUsername());
-    assertEquals(form.getError(), PASSWORD_MATCHING_USERNAME_MSG_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = DESKTOP)
   public void userCannotSignUpWhenTooYoungDesktop() {
     RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createTooYoungUser());
     assertEquals(form.getError(), GENERIC_ERROR_MSG);
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = DESKTOP)
-  public void userCannotSignUpWhenTooYoungDesktopSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnDesktopAs(createTooYoungUser());
-    assertEquals(form.getError(), GENERIC_ERROR_MSG_SZL);
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = MOBILE)
   @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
   public void userCannotSignUpWhenTooYoungMobile() {
     RegisterPage form = performSignUpExpectingFailureOnMobileAs(createTooYoungUser());
     assertEquals(form.getError(), GENERIC_ERROR_MSG);
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = MOBILE)
-  @InBrowser(browser = Browser.CHROME, emulator = Emulator.GOOGLE_NEXUS_5)
-  public void userCannotSignUpWhenTooYoungMobileSzl() {
-    RegisterPage form = performSignUpExpectingFailureOnMobileAs(createTooYoungUser());
-    assertEquals(form.getError(), GENERIC_ERROR_MSG_SZL);
   }
 
   @Test(groups = DESKTOP)

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/commentstests/ArticleCommentsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/commentstests/ArticleCommentsTests.java
@@ -2,7 +2,6 @@ package com.wikia.webdriver.testcases.desktop.commentstests;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.api.ArticleContent;
 import com.wikia.webdriver.common.core.helpers.User;
@@ -61,7 +60,6 @@ public class ArticleCommentsTests extends NewTestTemplate {
     article.verifyReplyCreator(User.COMMENTS_REGULAR_USER.getUserName());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = "ArticleComments_003")
   public void AnonCanReplyToAComment() {
     new ArticleContent(User.COMMENTS_REGULAR_USER).push(PageContent.ARTICLE_TEXT);

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/commentstests/BlogCommentsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/commentstests/BlogCommentsTests.java
@@ -2,7 +2,6 @@ package com.wikia.webdriver.testcases.desktop.commentstests;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
@@ -25,7 +24,6 @@ public class BlogCommentsTests extends NewTestTemplate {
 
   Credentials credentials = Configuration.getCredentials();
 
-  @DontRun(language = "szl")
   @Test(groups = "BlogComments_001")
   public void AnonCanCommentAReply() {
     WikiBasePageObject base = new WikiBasePageObject();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/discussions/CommunityHeaderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/discussions/CommunityHeaderTests.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 @InBrowser(emulator = Emulator.DESKTOP_BREAKPOINT_BIG)
 public class CommunityHeaderTests extends NewTestTemplate {
 
-  @DontRun(language = "szl")
   @Test(groups = {"discussions-CommunityHeaderTests"})
   public void wordmarkShouldLinkToMainPage() {
     new PostsListPage().open();
@@ -42,7 +41,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertEquals(userPage.getUserName(), username);
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"discussions-CommunityHeaderTests"})
   public void testExploreMenuLinks() {
     new PostsListPage().open();
@@ -62,41 +60,5 @@ public class CommunityHeaderTests extends NewTestTemplate {
     communityHeader.openExploreMenu().clickExploreRandomLink();
     Assertion.assertTrue(driver.getCurrentUrl()
                              .matches(".*.fandom.com/de/wiki/(?!Spezial:Bilder).*"));
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = {"discussions-CommunityHeaderTests"})
-  public void testExploreMenuLinksSzl() {
-    new PostsListPage().open();
-    CommunityHeaderDesktop communityHeader = new CommunityHeaderDesktop();
-
-    communityHeader.openExploreMenu().clickExploreWikiActivityLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Aktywno%C5%9B%C4%87_na_wiki");
-
-    new PostsListPage().open();
-
-    communityHeader.openExploreMenu().clickExploreCommunityLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Spo%C5%82eczno%C5%9B%C4%87");
-
-    new PostsListPage().open();
-
-    communityHeader.openExploreMenu().clickExploreVideosLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Filmy");
-
-    new PostsListPage().open();
-
-    communityHeader.openExploreMenu().clickExploreImagesLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Obrazy");
-
-    new PostsListPage().open();
-
-    communityHeader.openExploreMenu().clickExploreRandomLink();
-
-    Assertion.assertTrue(driver.getCurrentUrl()
-                             .matches(".*\\.wikia\\.com/szl/wiki/(?!Specjalna:Obrazy).*"));
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumBoardTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/forumtests/ForumBoardTests.java
@@ -1,9 +1,7 @@
 package com.wikia.webdriver.testcases.desktop.forumtests;
 
 import com.wikia.webdriver.common.contentpatterns.PageContent;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.forumpageobject.ForumBoardPage;
@@ -30,7 +28,6 @@ public class ForumBoardTests extends NewTestTemplate {
   }
 
   @Test(groups = {"ForumBoardTests_002"})
-  @DontRun(language = "szl")
   public void anonymousUserCanStartDiscussionWithoutTitleOnForum() {
     String message = String.format(PageContent.FORUM_MESSAGE, DateTime.now().getMillis());
 
@@ -39,18 +36,6 @@ public class ForumBoardTests extends NewTestTemplate {
     ForumThreadPageObject forumThread = forumBoard.startDiscussionWithoutTitle(message);
     // "Message from" default title appears after posting message without title
     forumThread.verifyDiscussionTitleAndMessage("Message from", message);
-  }
-
-  @Test(groups = {"ForumBoardTests_002"})
-  @RunOnly(language = "szl")
-  public void anonymousUserCanStartDiscussionWithoutTitleOnForumSzl() {
-    String message = String.format(PageContent.FORUM_MESSAGE, DateTime.now().getMillis());
-
-    ForumBoardPage forumBoard = new ForumBoardPage();
-    forumBoard.open(forumBoard.createNew(User.SUS_ADMIN));
-    ForumThreadPageObject forumThread = forumBoard.startDiscussionWithoutTitle(message);
-    // "Message from" default title appears after posting message without title
-    forumThread.verifyDiscussionTitleAndMessage("Wiadomość od", message);
   }
 
   @Test(groups = {"ForumBoardTests_003"})

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/globalshortcuts/KeyboardShortcutsTest.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/globalshortcuts/KeyboardShortcutsTest.java
@@ -28,15 +28,8 @@ public class KeyboardShortcutsTest extends NewTestTemplate {
   }
 
   @Test(groups = "globalShortcuts_keyboardShortcuts_navigateToInsightsByShortcut")
-  @DontRun(language = "szl")
   public void globalShortcuts_keyboardShortcuts_navigateToInsightsByShortcut() {
     new HomePage().open().getKeyboardShortcuts().useShortcut("?").useShortcut("gi");
-  }
-
-  @Test(groups = "globalShortcuts_keyboardShortcuts_navigateToInsightsByShortcut")
-  @RunOnly(language = "szl")
-  public void globalShortcuts_keyboardShortcuts_navigateToInsightsByShortcutSzl() {
-    new HomePage().open().getKeyboardShortcuts().useShortcutSzl("?").useShortcutSzl("gi");
   }
 
   @Test(groups = "globalShortcuts_keyboardShortcuts_focusGlobalNavigationSearchByShortcut")

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/mcfootertests/EnAnonMixedContentFooterTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/mcfootertests/EnAnonMixedContentFooterTests.java
@@ -1,7 +1,6 @@
 package com.wikia.webdriver.testcases.desktop.mcfootertests;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -17,7 +16,6 @@ import org.testng.annotations.Test;
 @Execute(onWikia = "mediawiki119", asUser = User.ANONYMOUS)
 public class EnAnonMixedContentFooterTests extends NewTestTemplate {
 
-  @DontRun( language = "szl")
   @Test
   public void mcFooterIsPresentOnENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -25,7 +23,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isMCFooterPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void exploreWikisCardIsPresentOnENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -33,7 +30,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isExploreWikisCardPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void discussionsCardIsPresentOnENwikiWithDiscussions() {
     DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
@@ -43,7 +39,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isDiscussionsCardPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   @Execute(onWikia = "enwikiwithemptydiscussions")
   public void discussionsCardIsPresentOnENwikiWithEmptyDiscussions() {
@@ -54,7 +49,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isDiscussionsCardPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   @Execute(onWikia = "sydneybuses")
   //SHOULD BE RUN AT enwikiwithoutdiscussions.wikia.com ONCE MCF with 'More of..' will appear on this wiki
@@ -65,7 +59,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isDiscussionsCardNotPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void moreOfWikiArticlesCardIsPresentOnENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -73,7 +66,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isMoreOfWikiArticlesCardPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void countNoOfArticlesInMCFooterWithDiscussionsAndWithMoreOfWikiArticles() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -81,7 +73,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 17);
   }
 
-  @DontRun( language = "szl")
   @Test
   @Execute(onWikia = "sydneybuses")
   //SHOULD BE RUN AT enwikiwithoutdiscussions.wikia.com ONCE MCF with 'More of..' will appear on this wiki
@@ -91,7 +82,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 19);
   }
 
-  @DontRun( language = "szl")
   @Test
   @Execute(onWikia = "enwikiwithemptydiscussions")
   public void countNoOfArticlesInMCFooterWithDiscussionsAndWithoutMoreOfWikiArticles() {
@@ -100,7 +90,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 18);
   }
 
-  @DontRun( language = "szl")
   @Test
   public void countNoOfArticlesInExploreCard() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -108,7 +97,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticlesInExploreCard(), 3);
   }
 
-  @DontRun( language = "szl")
   @Test
   public void userIsTakenToDiscussionsAfterClickOnViewAll() {
     DiscussionsPage discussions = new MixedContentFooter().openWikiMainPage()
@@ -119,7 +107,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussions.isDiscussionsPresent());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void userIsTakenToUserProfileAfterClickOnAvatar() {
     DiscussionCard discussions = new MixedContentFooter().openWikiMainPage()
@@ -133,7 +120,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(profilePage.getUserName(), username);
   }
 
-  @DontRun( language = "szl")
   @Test
   public void userIsTakenToDiscussionsPostViewAfterClickOnPost() {
     new MixedContentFooter().openWikiMainPage()
@@ -145,7 +131,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(url.matches(".*\\.(wikia|fandom)\\.com/d/.*"));
   }
 
-  @DontRun( language = "szl")
   @Test
   @Execute(onWikia = "enwikiwithemptydiscussions")
   public void zeroStateAppearsInDiscussionsWithoutPosts() {
@@ -156,7 +141,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isZeroState());
   }
 
-  @DontRun( language = "szl")
   @Test
   public void userIsTakenToFandomPageAfterClickOnFandomArticleCard() {
     new MixedContentFooter().openWikiMainPage()
@@ -168,7 +152,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(url.matches(".*\\.(fandom|fandom.wikia)\\.com/articles/.*"));
   }
 
-  @DontRun( language = "szl")
   @Test
   public void userIsTakenToWikiArticleAfterClickOnWikiArticleCard() {
     MixedContentFooter mcf = new MixedContentFooter().openWikiMainPage();
@@ -187,7 +170,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
    * Fandom or Wiki article and they are randomly failing
    */
 
-  @DontRun( language = "szl")
   @Test(enabled = false)
   public void userIsTakenToFandomArticleWithVideoAfterClickOnFandomVideoCard() {
     FandomPageObject fandomPage = new MixedContentFooter().openWikiMainPage()
@@ -202,7 +184,6 @@ public class EnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(fandomPage.isFeaturedVideo());
   }
 
-  @DontRun( language = "szl")
   @Test(enabled = false)
   public void userIsTakenToWikiArticleWithVideoAfterClickOnWikiVideoCard() {
     MixedContentFooter mcf = new MixedContentFooter().openWikiMainPage();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/mcfootertests/NonEnAnonMixedContentFooterTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/mcfootertests/NonEnAnonMixedContentFooterTests.java
@@ -1,9 +1,7 @@
 package com.wikia.webdriver.testcases.desktop.mcfootertests;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.elements.communities.mobile.pages.discussions.DiscussionsPage;
@@ -18,7 +16,6 @@ import org.testng.annotations.Test;
 @Execute(onWikia = "elderscrolls", language = "de", asUser = User.ANONYMOUS)
 public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
 
-  @DontRun(language = "szl")
   @Test
   public void isMCFooterPresentOnNonENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -26,16 +23,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isMCFooterPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void isMCFooterPresentOnNonENwikiSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertTrue(mcFooter.isMCFooterPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void exploreWikisCardIsPresentOnNonENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -43,16 +30,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isExploreWikisCardPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void exploreWikisCardIsPresentOnNonENwikiSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertTrue(mcFooter.isExploreWikisCardPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void discussionsCardIsPresentOnNonENwiki() {
     DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
@@ -62,18 +39,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isDiscussionsCardPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void discussionsCardIsPresentOnNonENwikiSzl() {
-    DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard();
-
-    Assertion.assertTrue(discussionCard.isDiscussionsCardPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "nonenwikiwithemptydiscussions", language = "es")
   public void discussionsCardIsPresentOnNonENwikiWithEmptyDiscussions() {
@@ -84,18 +49,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionsCard.isDiscussionsCardPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Test
-  @Execute(onWikia = "qatestdiscussionsnoforum")
-  public void discussionsCardIsPresentOnNonENwikiWithEmptyDiscussionsSzl() {
-    DiscussionCard discussionsCard = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard();
-
-    Assertion.assertTrue(discussionsCard.isDiscussionsCardPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "nonenwikiwithoutdiscussions", language = "es")
   public void discussionsCardIsNotPresentOnNonENwikiWithoutDiscussions() {
@@ -106,18 +59,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isDiscussionsCardNotPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Test
-  @Execute(onWikia = "qatestnodiscussionsnoforum")
-  public void discussionsCardIsNotPresentOnNonENwikiWithoutDiscussionsSzl() {
-    DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard();
-
-    Assertion.assertTrue(discussionCard.isDiscussionsCardNotPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void moreOfWikiArticlesCardIsPresentOnNonENwiki() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -125,7 +66,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(mcFooter.isMoreOfWikiArticlesCardPresent());
   }
 
-  @DontRun(language = "szl")
   @Test
   public void countNoOfArticlesInMCFooterWithDiscussionsAndWithMoreOfWikiArticles() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -133,16 +73,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 11);
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void countNoOfArticlesInMCFooterWithDiscussionsAndWithMoreOfWikiArticlesSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertEquals(mcFooter.countArticleCards(), 12);
-  }
-
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "gta", language = "es")
   public void countNoOfArticlesInMCFooterWithoutDiscussionsAndWithMoreOfWikiArticles() {
@@ -151,16 +81,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 13);
   }
 
-  @RunOnly(language = "szl")
-  @Test
-  @Execute(onWikia = "qatestnodiscussionsnoforum")
-  public void countNoOfArticlesInMCFooterWithoutDiscussionsAndWithMoreOfWikiArticlesSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertEquals(mcFooter.countArticleCards(), 14);
-  }
-
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "nonenwikiwithemptydiscussions", language = "es")
   public void countNoOfArticlesInMCFooterWithDiscussionsAndWithoutMoreOfWikiArticles() {
@@ -169,16 +89,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticleCards(), 12);
   }
 
-  @RunOnly(language = "szl")
-  @Test
-  @Execute(onWikia = "mediawiki119")
-  public void countNoOfArticlesInMCFooterWithDiscussionsAndWithoutMoreOfWikiArticlesSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertEquals(mcFooter.countArticleCards(), 12);
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void countNoOfArticlesInExploreCard() {
     MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
@@ -186,16 +96,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(mcFooter.countArticlesInExploreCard(), 3);
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void countNoOfArticlesInExploreCardSzl() {
-    MixedContentFooter mcFooter = new MixedContentFooter().openWikiMainPage().scrollToMCFooter();
-
-    Assertion.assertEquals(mcFooter.countArticlesInExploreCard(), 3);
-  }
-
-  @DontRun(language = "szl")
   @Test
   void isUserTakenToDiscussionsAfterClickOnViewAll() {
     DiscussionsPage discussions = new MixedContentFooter().openWikiMainPage()
@@ -207,19 +107,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussions.isDiscussionsPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Test
-  void isUserTakenToDiscussionsAfterClickOnViewAllSzl() {
-    DiscussionsPage discussions = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard()
-        .scrollToDiscussions()
-        .clickOnViewAllLinkInDiscussions();
-
-    Assertion.assertTrue(discussions.isDiscussionsPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void userIsTakenToUserProfileAfterClickOnAvatar() {
     DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
@@ -234,23 +121,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertEquals(userProfilePage.getUserName(), username);
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void userIsTakenToUserProfileAfterClickOnAvatarSzl() {
-    DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard()
-        .scrollToDiscussions();
-
-    String username = discussionCard.getUsername().replaceAll(" •.*$", "");
-
-    UserProfilePage userProfilePage = discussionCard.clickUserAvatar();
-
-    Assertion.assertEquals(userProfilePage.getUserName(), username);
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void userIsTakenToDiscussionsPostViewAfterClickOnPost() {
     new MixedContentFooter().openWikiMainPage()
@@ -263,20 +133,6 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(url.contains(".wikia.com/d/"));
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void userIsTakenToDiscussionsPostViewAfterClickOnPostSzl() {
-    new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard()
-        .scrollToDiscussions()
-        .clickDiscussionsPost();
-
-    Assertion.assertTrue(driver.getCurrentUrl().contains(".wikia.com/szl/d/"));
-  }
-
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "enwikiwithemptydiscussions")
   public void zeroStateAppearsInDiscussionsWithoutPosts() {
@@ -287,37 +143,8 @@ public class NonEnAnonMixedContentFooterTests extends NewTestTemplate {
     Assertion.assertTrue(discussionCard.isZeroState());
   }
 
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "qatestdiscussionsnoforum")
-  @Test
-  public void zeroStateAppearsInDiscussionsWithoutPostsSzl() {
-    DiscussionCard discussionCard = new MixedContentFooter().openWikiMainPage()
-        .scrollToMCFooter()
-        .getDiscussionsCard();
-
-    Assertion.assertTrue(discussionCard.isZeroState());
-  }
-
-  @DontRun(language = "szl")
   @Test
   public void userIsTakenToWikiArticleAfterClickOnWikiArticleCard() {
-    MixedContentFooter mcf = new MixedContentFooter().openWikiMainPage();
-
-    String urlMainPage = driver.getCurrentUrl();
-
-    ArticlePageObject article = mcf.scrollToMCFooter().clickWikiArticlecard();
-
-    article.waitForPageLoad();
-
-    String urlArticlePage = mcf.getCurrentUrl();
-
-    Assertion.assertNotEquals(urlMainPage, urlArticlePage);
-  }
-
-  @RunOnly(language = "szl")
-  @Execute(onWikia = "mediawiki119")
-  @Test
-  public void userIsTakenToWikiArticleAfterClickOnWikiArticleCardSzl() {
     MixedContentFooter mcf = new MixedContentFooter().openWikiMainPage();
 
     String urlMainPage = driver.getCurrentUrl();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationLayout.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationLayout.java
@@ -1,9 +1,7 @@
 package com.wikia.webdriver.testcases.desktop.navigation.global;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.HomePage;
@@ -22,7 +20,6 @@ public class GlobalNavigationLayout extends NewTestTemplate {
     wikiActivity.verifyGlobalNavigation();
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"globalNavigationBarLayoutForEnglishAnon"})
   public void testLayoutForEnglishAnon() {
     GlobalNavigation globalNavigation = new HomePage().getGlobalNavigation();
@@ -57,7 +54,6 @@ public class GlobalNavigationLayout extends NewTestTemplate {
     Assertion.assertTrue(globalNavigation.isStartWikiButtonVisible());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"globalNavigationBarLayoutForDeAnon"})
   @Execute(onWikia = "gta", language = "de")
   public void testLayoutForDeAnon() {
@@ -77,48 +73,9 @@ public class GlobalNavigationLayout extends NewTestTemplate {
     Assertion.assertFalse(globalNavigation.isNotificationsIconVisible());
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"globalNavigationBarLayoutForDeAnon"})
-  public void testLayoutForAnonSzl() {
-    GlobalNavigation globalNavigation = new HomePage().open().getGlobalNavigation();
-
-    Assertion.assertTrue(globalNavigation.isFandomLogoVisible());
-    Assertion.assertTrue(globalNavigation.isSearchInputVisible());
-    Assertion.assertTrue(globalNavigation.isStartWikiButtonVisible());
-    Assertion.assertTrue(globalNavigation.isGryHubVisible());
-    Assertion.assertTrue(globalNavigation.isFilmyHubVisible());
-    Assertion.assertTrue(globalNavigation.isTVDEHubVisible());
-    Assertion.assertTrue(globalNavigation.isWikisMenuVisible());
-
-    Assertion.assertFalse(globalNavigation.isVideoHubVisible());
-    Assertion.assertFalse(globalNavigation.isUserAvatarVisible());
-    Assertion.assertFalse(globalNavigation.isNotificationsIconVisible());
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"globalNavigationBarLayoutForDeLoggedIn"})
   @Execute(onWikia = "harrypotter", language = "de", asUser = User.USER_GERMAN)
   public void testLayoutForDeLoggedIn() {
-    GlobalNavigation globalNavigation = new HomePage().getGlobalNavigation();
-
-    Assertion.assertTrue(globalNavigation.isFandomLogoVisible());
-    Assertion.assertTrue(globalNavigation.isSearchInputVisible());
-    Assertion.assertTrue(globalNavigation.isStartWikiButtonVisible());
-    Assertion.assertTrue(globalNavigation.isPartnerSlotLinkVisible());
-    Assertion.assertTrue(globalNavigation.isVideospieleHubVisible());
-    Assertion.assertTrue(globalNavigation.isFilmeHubVisible());
-    Assertion.assertTrue(globalNavigation.isTVDEHubVisible());
-    Assertion.assertTrue(globalNavigation.isWikisMenuVisible());
-    Assertion.assertTrue(globalNavigation.isUserAvatarVisible());
-    Assertion.assertTrue(globalNavigation.isNotificationsIconVisible());
-
-    Assertion.assertFalse(globalNavigation.isVideoHubVisible());
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = {"globalNavigationBarLayoutForDeLoggedIn"})
-  @Execute(asUser = User.USER_GERMAN)
-  public void testLayoutForLoggedInSzl() {
     GlobalNavigation globalNavigation = new HomePage().getGlobalNavigation();
 
     Assertion.assertTrue(globalNavigation.isFandomLogoVisible());

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationNavigating.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationNavigating.java
@@ -2,9 +2,7 @@ package com.wikia.webdriver.testcases.desktop.navigation.global;
 
 import com.wikia.webdriver.common.contentpatterns.URLsContent;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.url.UrlBuilder;
 import com.wikia.webdriver.common.core.url.UrlChecker;
@@ -20,7 +18,6 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
 
   UrlChecker urlChecker = new UrlChecker();
 
-  @DontRun(language = "szl")
   @Test(groups = {"fandomLogoClickOnEnCommunityOpensFandomWikia"})
   public void logoClickOnEnglishCommunityOpensFandom() {
     new HomePage().getGlobalNavigation().clickFandomLogo();
@@ -29,10 +26,8 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
             urlChecker.getProtocolRelativeURL(driver.getCurrentUrl()),
             urlChecker.getProtocolRelativeURL(fandomUrlBuilder.getFandomUrl(new Configuration().getEnvType()))
     );
-
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"gamesHubLinkClickOnEnCommunityOpensGamesHub"})
   public void testGamesHubLink() {
     new HomePage().getGlobalNavigation().clickGamesHubLink();
@@ -44,19 +39,6 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
     );
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"gamesHubLinkClickOnEnCommunityOpensGamesHub"})
-  public void testGamesHubLinkSzl() {
-    new HomePage().getGlobalNavigation().clickGamesHubLink();
-
-    Assertion.assertEquals(
-            urlChecker.getProtocolRelativeURL(driver.getCurrentUrl()),
-            urlChecker.getProtocolRelativeURL(
-                    fandomUrlBuilder.getFandomUrl(new Configuration().getEnvType()) + HUBS_SZL + "#Gry")
-    );
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"moviesHubLinkClickOnEnCommunityOpensMoviesHub"})
   public void testMoviesHubLink() {
     new HomePage().getGlobalNavigation().clickMoviesHubLink();
@@ -68,19 +50,6 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
     );
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"moviesHubLinkClickOnEnCommunityOpensMoviesHub"})
-  public void testMoviesHubLinkSzl() {
-    new HomePage().getGlobalNavigation().clickMoviesHubLink();
-
-    Assertion.assertEquals(
-            urlChecker.getProtocolRelativeURL(driver.getCurrentUrl()),
-            urlChecker.getProtocolRelativeURL(
-                    fandomUrlBuilder.getFandomUrl(new Configuration().getEnvType()) + HUBS_SZL + "#Filmy")
-    );
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"tvHubLinkClickOnEnCommunityOpensTvHub"})
   public void testTVHubLink() {
     new HomePage().getGlobalNavigation().clickTVHubLink();
@@ -92,20 +61,7 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
     );
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"tvHubLinkClickOnEnCommunityOpensTvHub"})
-  public void testTVHubLinkSzl() {
-    new HomePage().getGlobalNavigation().clickTVHubLink();
-
-    Assertion.assertEquals(
-            urlChecker.getProtocolRelativeURL(driver.getCurrentUrl()),
-            urlChecker.getProtocolRelativeURL(
-                    fandomUrlBuilder.getFandomUrl(new Configuration().getEnvType()) + HUBS_SZL + "#TV")
-    );
-  }
-
   @RelatedIssue(issueID = "IW-1607")
-  @DontRun(language = "szl")
   @Test(groups = {"exploreWikisLinkClickOnEnCommunityOpensExplorePage"}, enabled = false)
   public void testExploreWikisLink() {
     new HomePage().getGlobalNavigation().openWikisMenu().clickExploreWikisLink();
@@ -117,19 +73,6 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
     );
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"exploreWikisLinkClickOnEnCommunityOpensExplorePage"})
-  public void testExploreWikisLinkSzl() {
-    new HomePage().getGlobalNavigation().openWikisMenu().clickExploreWikisLink();
-
-    Assertion.assertEquals(
-            urlChecker.getProtocolRelativeURL(driver.getCurrentUrl()),
-            urlChecker.getProtocolRelativeURL(
-                    fandomUrlBuilder.getFandomUrl(new Configuration().getEnvType()) + HUBS_SZL)
-    );
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"communityCentralLinkClickOnEnCommunityOpensEnCommunityCentral"})
   public void testCommunityCentralLink() {
     new HomePage().getGlobalNavigation().openWikisMenu().clickCommunityCentralLink();
@@ -138,18 +81,6 @@ public class GlobalNavigationNavigating extends NewTestTemplate {
                            UrlBuilder.createUrlBuilderForWikiAndLang(COMMUNITY_WIKI,
                                                                      DEFAULT_LANGUAGE
                            ).getUrlForWikiPage(URLsContent.COMMUNITY_CENTRAL)
-    );
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = {"communityCentralLinkClickOnEnCommunityOpensEnCommunityCentral"})
-  public void testCommunityCentralLinkSzl() {
-    new HomePage().getGlobalNavigation().openWikisMenu().clickCommunityCentralLink();
-
-    Assertion.assertEquals(driver.getCurrentUrl(),
-                           UrlBuilder.createUrlBuilderForWikiAndLang(COMMUNITY_WIKI_SZL,
-                                                                     DEFAULT_LANGUAGE
-                           ).getUrlForWikiPage(URLsContent.COMMUNITY_CENTRAL_SZL)
     );
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationSearching.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/global/GlobalNavigationSearching.java
@@ -1,9 +1,7 @@
 package com.wikia.webdriver.testcases.desktop.navigation.global;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.core.url.UrlBuilder;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -24,14 +22,6 @@ public class GlobalNavigationSearching extends NewTestTemplate {
                           {"mediawiki119", "szl", "Mix", "Specjalna:Szukaj"}};
   }
 
-  // TODO: Remove SZL DataProvider & SZL tests when not needed
-  @DataProvider
-  public Object[][] getDataForGlobalSearchSzl() {
-    return new Object[][]{{"muppet", "en", "kermit", "Special:Search"},
-                          {"mediawiki119", "szl", "Mix", "Specjalna:Szukaj"}};
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"serachGlobalNavigationBarAsAnon"}, dataProvider = "getDataForGlobalSearch")
   public void searchGlobalNavigationBarAsAnon(
       String wikiName, String wikiLanguage, String query, String expectedSpecialPage
@@ -44,37 +34,9 @@ public class GlobalNavigationSearching extends NewTestTemplate {
     Assertion.assertTrue(search.isResultPresent());
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"serachGlobalNavigationBarAsAnon"}, dataProvider = "getDataForGlobalSearchSzl")
-  public void searchGlobalNavigationBarAsAnonSzl(
-      String wikiName, String wikiLanguage, String query, String expectedSpecialPage
-  ) {
-    HomePage homePage = new HomePage();
-    homePage.getUrl(UrlBuilder.createUrlBuilderForWikiAndLang(wikiName, wikiLanguage).getUrl());
-    SearchPageObject search = homePage.getGlobalNavigation().search(query);
-
-    Assertion.assertStringContains(driver.getCurrentUrl(), expectedSpecialPage);
-    Assertion.assertTrue(search.isResultPresent());
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"serachGlobalNavigationBarAsLoggedIn"}, dataProvider = "getDataForGlobalSearch")
   @Execute(asUser = User.USER)
   public void searchGlobalNavigationBarAsLoggedIn(
-      String wikiName, String wikiLanguage, String query, String expectedSpecialPage
-  ) {
-    HomePage homePage = new HomePage();
-    homePage.getUrl(UrlBuilder.createUrlBuilderForWikiAndLang(wikiName, wikiLanguage).getUrl());
-    SearchPageObject search = homePage.getGlobalNavigation().search(query);
-
-    Assertion.assertStringContains(driver.getCurrentUrl(), expectedSpecialPage);
-    Assertion.assertTrue(search.isResultPresent());
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = {"serachGlobalNavigationBarAsLoggedIn"}, dataProvider = "getDataForGlobalSearchSzl")
-  @Execute(asUser = User.USER)
-  public void searchGlobalNavigationBarAsLoggedInSzl(
       String wikiName, String wikiLanguage, String query, String expectedSpecialPage
   ) {
     HomePage homePage = new HomePage();

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/local/CommunityHeaderTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/navigation/local/CommunityHeaderTests.java
@@ -2,9 +2,7 @@ package com.wikia.webdriver.testcases.desktop.navigation.local;
 
 import com.wikia.webdriver.common.contentpatterns.MobileWikis;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
-import com.wikia.webdriver.common.core.annotations.RunOnly;
 import com.wikia.webdriver.common.core.configuration.Configuration;
 import com.wikia.webdriver.common.core.helpers.User;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
@@ -32,7 +30,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertTrue(mainPage.isMainPage());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(onWikia = MobileWikis.DE_WIKI)
   public void wikiNameOnNonEnglishWikiShouldLinkToMainPage() {
@@ -49,7 +46,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertTrue(modal.isCreateNewArticleModalVisible());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(asUser = User.USER)
   public void testLoggedInWikiButtons() {
@@ -80,38 +76,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertTrue(actionExplorerModal.isVisible());
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"CommunityHeaderTests"})
-  @Execute(asUser = User.USER)
-  public void testLoggedInWikiButtonsSzl() {
-    CommunityHeaderDesktop communityHeader = new CommunityHeaderDesktop();
-
-    communityHeader.clickWikiActivity();
-    Assertion.assertStringContains(driver.getCurrentUrl(), "Specjalna:Aktywno%C5%9B%C4%87_na_wiki");
-
-    CreateArticleModalComponentObject addNewPageModal = communityHeader.clickAddNewPage();
-    Assertion.assertTrue(addNewPageModal.isCreateNewArticleModalVisible());
-    addNewPageModal.close();
-
-    communityHeader.openMoreToolsDropdown().clickMoreAddImageLink();
-    Assertion.assertStringContains(driver.getCurrentUrl(), "Specjalna:Prze%C5%9Blij");
-
-    AddMediaModalComponentObject addVideoModal = communityHeader.openMoreToolsDropdown()
-        .clickMoreAddVideoLink();
-    Assertion.assertStringContains(driver.getCurrentUrl(), "Specjalna:Filmy");
-    Assertion.assertTrue(addVideoModal.isVideoModalVisible());
-
-    addVideoModal.closeAddVideoModal();
-
-    communityHeader.openMoreToolsDropdown().clickMoreRecentChanges();
-    Assertion.assertStringContains(driver.getCurrentUrl(), "Specjalna:Ostatnie_zmiany");
-
-    ActionExplorerModal actionExplorerModal = communityHeader.openMoreToolsDropdown()
-        .clickMoreAllShortcuts();
-    Assertion.assertTrue(actionExplorerModal.isVisible());
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(asUser = User.MW119_ADMINISTRATOR)
   public void testAdminWikiButtons() {
@@ -145,7 +109,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertTrue(actionExplorerModal.isVisible());
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   public void testExploreMenuLinks() {
     CommunityHeaderDesktop communityHeader = new CommunityHeaderDesktop();
@@ -172,34 +135,6 @@ public class CommunityHeaderTests extends NewTestTemplate {
                              .matches(".*\\.(wikia|fandom)\\.com/wiki/(?!Special:Images).*"));
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"CommunityHeaderTests"})
-  public void testExploreMenuLinksSzl() {
-    CommunityHeaderDesktop communityHeader = new CommunityHeaderDesktop();
-
-    communityHeader.openExploreMenu().clickExploreWikiActivityLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Aktywno%C5%9B%C4%87_na_wiki");
-
-    communityHeader.openExploreMenu().clickExploreCommunityLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Spo%C5%82eczno%C5%9B%C4%87");
-
-    communityHeader.openExploreMenu().clickExploreVideosLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Filmy");
-
-    communityHeader.openExploreMenu().clickExploreImagesLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Obrazy");
-
-    communityHeader.openExploreMenu().clickExploreRandomLink();
-
-    Assertion.assertTrue(driver.getCurrentUrl()
-        .matches(".*\\.wikia\\.com/szl/wiki/(?!Specjalna:Obrazy).*"));
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(onWikia = "qatestdiscussionsnoforum")
   public void testDiscussLinkOnWikiWithDiscussionsWithoutForum() {
@@ -208,19 +143,9 @@ public class CommunityHeaderTests extends NewTestTemplate {
     Assertion.assertTrue(driver.getCurrentUrl().matches(".*(wikia|fandom).com/d/f"));
   }
 
-  @RunOnly(language = "szl")
-  @Test(groups = {"CommunityHeaderTests"})
-  @Execute(onWikia = "qatestdiscussionsnoforum")
-  public void testDiscussLinkOnWikiWithDiscussionsWithoutForumSzl() {
-    new CommunityHeaderDesktop().clickDiscussLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"wikia.com/szl/d/f");
-  }
-
   /**
    * @prerequisites use wiki with enabled forum and discussions
    */
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(onWikia = "qatestdiscussiosandforum")
   public void testDiscussLinkOnWikiWithDiscussionsAndForum() {
@@ -236,35 +161,13 @@ public class CommunityHeaderTests extends NewTestTemplate {
   /**
    * @prerequisites use wiki with enabled forum and discussions
    */
-  @RunOnly(language = "szl")
-  @Test(groups = {"CommunityHeaderTests"})
-  @Execute(onWikia = "qatestdiscussiosandforum")
-  public void testDiscussLinkOnWikiWithDiscussionsAndForumSzl() {
-    CommunityHeaderDesktop communityHeader = new CommunityHeaderDesktop();
 
-    communityHeader.openExploreMenu().clickExploreForumLink();
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Forum");
-
-    communityHeader.clickDiscussLink();
-    Assertion.assertStringContains(driver.getCurrentUrl(),String.format("%s/d/f", Configuration.getEnvType().getDomain()));
-  }
-
-  @DontRun(language = "szl")
   @Test(groups = {"CommunityHeaderTests"})
   @Execute(onWikia = "qatestforumnodiscussions")
   public void testDiscussLinkOnWikiWithNoDiscussionsAndWithForum() {
     new CommunityHeaderDesktop().clickDiscussLink();
 
     Assertion.assertStringContains(driver.getCurrentUrl(),"Special:Forum");
-  }
-
-  @RunOnly(language = "szl")
-  @Test(groups = {"CommunityHeaderTests"})
-  @Execute(onWikia = "qatestforumnodiscussions")
-  public void testDiscussLinkOnWikiWithNoDiscussionsAndWithForumSzl() {
-    new CommunityHeaderDesktop().clickDiscussLink();
-
-    Assertion.assertStringContains(driver.getCurrentUrl(),"Specjalna:Forum");
   }
 
   @Test(groups = {"CommunityHeaderTests"})

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/renametool/RenameToolTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/renametool/RenameToolTests.java
@@ -1,7 +1,6 @@
 package com.wikia.webdriver.testcases.desktop.renametool;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.api.ArticleContent;
@@ -27,7 +26,6 @@ import org.testng.annotations.Test;
 public class RenameToolTests extends NewTestTemplate {
 
   @Test
-  @DontRun(language = "szl")
   @Execute(asUser = User.QARENAME)
   public void userProvidesCorrectNewNameDoesntClickUnderstandCheckbox() {
     SpecialRenameUserPage renameUserPage = new SpecialRenameUserPage().open()
@@ -41,7 +39,6 @@ public class RenameToolTests extends NewTestTemplate {
   }
 
   @Test
-  @DontRun(language = "szl")
   @Execute(asUser = User.QARENAME)
   public void userProvidesInCorrectNewNameDoesClickUnderstandCheckbox() {
     SpecialRenameUserPage renameUserPage = new SpecialRenameUserPage().open()
@@ -55,7 +52,6 @@ public class RenameToolTests extends NewTestTemplate {
   }
 
   @Test
-  @DontRun(language = "szl")
   @Execute(asUser = User.QARENAME)
   public void userProvidesNoNewUserNameErrorIsShown() {
     SpecialRenameUserPage renameUserPage = new SpecialRenameUserPage().open()
@@ -76,7 +72,6 @@ public class RenameToolTests extends NewTestTemplate {
   }
 
   @Test
-  @DontRun(language = "szl")
   @Execute(asUser = User.QARENAME)
   public void goToHelpPage() {
     SpecialRenameUserPage renameUserPage = new SpecialRenameUserPage().open();
@@ -98,7 +93,6 @@ public class RenameToolTests extends NewTestTemplate {
   }
 
   @Test
-  @DontRun(language = "szl")
   public void newUserCreateAndRenameDone() {
     Credentials credentials = new Credentials();
     String timestamp = Long.toString(DateTime.now().getMillis());
@@ -124,7 +118,6 @@ public class RenameToolTests extends NewTestTemplate {
   }
 
   @Test
-  @DontRun(language = "szl")
   @Execute(onWikia = "communitytest")
   public void newUserCreateEditProfileAndRenameDone() {
     Credentials credentials = new Credentials();

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/CommentsTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/CommentsTests.java
@@ -3,7 +3,6 @@ package com.wikia.webdriver.testcases.mobile;
 import com.wikia.webdriver.common.contentpatterns.MobileSubpages;
 import com.wikia.webdriver.common.contentpatterns.MobileWikis;
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
@@ -140,7 +139,6 @@ public class CommentsTests extends NewTestTemplate {
   }
 
   @Test(groups = "mercury_comments_tapOnUsernameRedirectsToUserPage", enabled = false)
-  @DontRun(language = "szl")
   @RelatedIssue(issueID = "XW-5188")
   public void mercury_comments_tapOnUsernameRedirectsToUserPage() {
     this.comments = new CommentsPageObject(driver);
@@ -157,7 +155,6 @@ public class CommentsTests extends NewTestTemplate {
             "does not match pattern /wiki/User:", result);
   }
 
-  @DontRun(language = "szl")
   @Test(groups = "mercury_comments_imagesAndVideosAreDisplayedCorrectly")
   public void mercury_comments_imagesAndVideosAreDisplayedCorrectly() {
     this.comments = new CommentsPageObject(driver);

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/HTMLTitleTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/HTMLTitleTests.java
@@ -1,7 +1,6 @@
 package com.wikia.webdriver.testcases.mobile;
 
 import com.wikia.webdriver.common.core.Assertion;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.configuration.Configuration;
@@ -59,7 +58,6 @@ public class HTMLTitleTests extends NewTestTemplate {
     this.navigate = new Navigate();
   }
 
-  @DontRun(language = "szl")
   @Test(groups = {"mercury_htmlTitleSet", "Mercury_htmlTitleSet"})
   public void mercury_htmlTitleSet() {
     for (String[] testCase : testCases) {

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/curatedcontenttests/NavigationTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/curatedcontenttests/NavigationTests.java
@@ -5,7 +5,6 @@ import com.wikia.webdriver.common.contentpatterns.MobileWikis;
 import com.wikia.webdriver.common.contentpatterns.WikiTextContent;
 import com.wikia.webdriver.common.core.Assertion;
 import com.wikia.webdriver.common.core.TestContext;
-import com.wikia.webdriver.common.core.annotations.DontRun;
 import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.InBrowser;
 import com.wikia.webdriver.common.core.api.ArticleContent;
@@ -37,7 +36,6 @@ public class NavigationTests extends NewTestTemplate {
   }
 
   @Test(groups = "MercuryCuratedNavigationTest_001")
-  @DontRun(language = "szl")
   public void mercuryCuratedNavigationTest_001_navigateThroughCategory() {
     init();
 

--- a/src/test/java/com/wikia/webdriver/testcases/mobile/navigation/globalnav/GlobalNavigationMobileWikiTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/mobile/navigation/globalnav/GlobalNavigationMobileWikiTests.java
@@ -78,7 +78,6 @@ public class GlobalNavigationMobileWikiTests extends NewTestTemplate {
     Assertion.assertTrue(globalNavigationMobile.isSearchComponentPresent());
   }
 
-  @DontRun(language = "szl")
   @Test
   public void hubsLinksOnEnWiki() {
     GlobalNavigationMobile globalNavigationMobile =
@@ -92,24 +91,9 @@ public class GlobalNavigationMobileWikiTests extends NewTestTemplate {
     Assertion.assertTrue(globalNavigationMobile.isVideoHubLinkVisible());
   }
 
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = "dman", language = "de")
   public void hubsLinksOnNonEnWiki() {
-    GlobalNavigationMobile globalNavigationMobile =
-        new ArticlePage()
-            .open(MobileSubpages.MAIN_PAGE)
-            .getGlobalNavigationMobile();
-
-    globalNavigationMobile.openSearch();
-
-    Assertion.assertTrue(globalNavigationMobile.areInterntionalHubLinksVisible());
-    Assertion.assertFalse(globalNavigationMobile.isVideoHubLinkVisible());
-  }
-
-  @RunOnly(language = "szl")
-  @Test
-  public void hubsLinksOnNonEnWikiSzl() {
     GlobalNavigationMobile globalNavigationMobile =
         new ArticlePage()
             .open(MobileSubpages.MAIN_PAGE)
@@ -136,7 +120,6 @@ public class GlobalNavigationMobileWikiTests extends NewTestTemplate {
 
   }
 
-  @DontRun(language = "szl")
   @Test
   public void trendingArticlesModuleOpensUnderMobileSearchOnEnWikis() {
     GlobalNavigationMobile globalNavigationMobile =
@@ -151,25 +134,9 @@ public class GlobalNavigationMobileWikiTests extends NewTestTemplate {
     Assertion.assertTrue(trendingArticles.isTrendingArticlesModuleVisible());
   }
 
-  @DontRun(language = "szl")
   @Test
   @Execute(onWikia = MobileWikis.DE_WIKI_2)
   public void trendingArticlesModuleDoesNotOpenUnderMobileSearchOnNonEnWikis() {
-    GlobalNavigationMobile globalNavigationMobile =
-        new ArticlePage()
-            .openDefault()
-            .getGlobalNavigationMobile();
-
-    globalNavigationMobile.openSearch();
-
-    ContentRecommendationsMobile trendingArticles = new ContentRecommendationsMobile();
-
-    Assertion.assertTrue(trendingArticles.isTrendingArticlesModuleNotVisible());
-  }
-
-  @RunOnly(language = "szl")
-  @Test
-  public void trendingArticlesModuleDoesNotOpenUnderMobileSearchOnNonEnWikisSzl() {
     GlobalNavigationMobile globalNavigationMobile =
         new ArticlePage()
             .openDefault()


### PR DESCRIPTION
- Deleted tests for `language = 'szl'`
- Deleted RunOnly & DontRun annotation 