### PR TITLE
DE-4387-WAM-tests-on-fandom

### DIFF
--- a/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
+++ b/src/test/java/com/wikia/webdriver/common/contentpatterns/URLsContent.java
@@ -86,7 +86,7 @@ public class URLsContent {
   public static final String ACTION_RAW = "action=raw";
 
   // WAM Scores page url
-  public static final String WAM_PAGE = "/WAM";
+  public static final String WAM_PAGE = "WAM";
 
   // replace %title% with new article name
   public static final String ADD_ARTICLE = "index.php?title=%title%&action=edit";

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -205,11 +205,14 @@ public class WamPageObject extends BasePageObject {
   }
 
   /**
-   * Checks if yesterday's or current day is selected by default in date picker Yesterday clause was
-   * added due to possible lags in bulkimporter (providing data for WAM API)
+   * Checks if yesterday's, day before yesterday, or current day is selected by default in date picker
+   * 3 days are checked due to lags in bulkimporter (providing data for WAM API)
    */
-  public void verifyYesterdaysOrCurrentDateInDatePicker() {
+  public void verifyDateInDatePicker() {
     String currentDate = datePickerInput.getAttribute("value");
+    String dayBeforeYesterday = DateTimeFormat.forPattern("MMMM d, yyyy")
+        .withLocale(Locale.ENGLISH)
+        .print(DateTime.now().minus(Period.days(2)).withZone(DateTimeZone.UTC));
     String yesterday = DateTimeFormat.forPattern("MMMM d, yyyy")
         .withLocale(Locale.ENGLISH)
         .print(DateTime.now().minus(Period.days(1)).withZone(DateTimeZone.UTC));
@@ -217,8 +220,8 @@ public class WamPageObject extends BasePageObject {
         .withLocale(Locale.ENGLISH)
         .print(DateTime.now().withZone(DateTimeZone.UTC));
     Assertion.assertTrue(
-        yesterday.equals(currentDate) || today.equals(currentDate),
-        "Default date does not match yesterday or today"
+        dayBeforeYesterday.equals(currentDate)|| yesterday.equals(currentDate) || today.equals(currentDate),
+        "Default date does not match day before yesterday, yesterday or today"
     );
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -105,8 +105,8 @@ public class WamPageObject extends BasePageObject {
 
   /**
    * @param expectedRowsNo the number of expecting table rows
-   * @desc Checks if there are as many rows in the WAM index table as we expect
-   * Adds +1 to expectedRowsNo to account for header of the table
+   * @desc Checks if there are as many rows in the WAM index table as we expect Adds +1 to
+   * expectedRowsNo to account for header of the table
    */
   public void verifyWamIndexHasExactRowsNo(int expectedRowsNo) {
     wait.forElementPresent(WAM_INDEX_TABLE);
@@ -205,8 +205,8 @@ public class WamPageObject extends BasePageObject {
   }
 
   /**
-   * Checks if yesterday's or current day is selected by default in date picker
-   * Yesterday clause was added due to possible lags in bulkimporter (providing data for WAM API)
+   * Checks if yesterday's or current day is selected by default in date picker Yesterday clause was
+   * added due to possible lags in bulkimporter (providing data for WAM API)
    */
   public void verifyYesterdaysOrCurrentDateInDatePicker() {
     String currentDate = datePickerInput.getAttribute("value");
@@ -225,7 +225,11 @@ public class WamPageObject extends BasePageObject {
   public void verifyDateInDatePicker(String date) {
     isLoaded();
     String currentDate = datePickerInput.getAttribute("value");
-    Assertion.assertEquals(date, currentDate, "Current date and entered manually date are not the same");
+    Assertion.assertEquals(
+        date,
+        currentDate,
+        "Current date and entered manually date are not the same"
+    );
   }
 
   public void typeDateInDatePicker(String date) {
@@ -233,5 +237,17 @@ public class WamPageObject extends BasePageObject {
     jsActions.execute("$(arguments[0])[0].value=''", datePickerInput);
     scrollAndClick(datePickerInput);
     new Actions(driver).sendKeys(datePickerInput, date).sendKeys(datePickerInput, "\n").perform();
+  }
+
+  public void verifyIfOnWamFandomPage() {
+    Assertion.assertTrue(this.isStringInURL("WAM"), "Not on WAM subpage (in URL");
+    Assertion.assertTrue(this.isStringInURL("fandom"), "Not on fandom (in URL");
+  }
+
+  public void verifyIfVerticalIdSelectedInUrl(int verticalId) {
+    Assertion.assertTrue(
+        this.isStringInURL("verticalId=" + verticalId),
+        "No VerticalId selection (in URL)"
+    );
   }
 }

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -53,10 +53,10 @@ public class WamPageObject extends BasePageObject {
   }
 
   /**
-   * @desc Opens "WAM Scores" page in example: www.wikia.com/WAM
+   * @desc Opens "WAM Scores" page: https://community.fandom.com/wiki/WAM
    */
   public void openWamPage(String wikiCorporateURL) {
-    getUrl(wikiCorporateURL + URLsContent.WAM_PAGE);
+    getUrl(urlBuilder.getUrlForWikiPage(URLsContent.WAM_PAGE));
     waitForPageLoad();
     Log.log("openWamPage", "WAM page opened", true);
   }
@@ -66,8 +66,9 @@ public class WamPageObject extends BasePageObject {
    * @desc Checks if given tab has an anchor with "selected" class
    */
   public void verifyTabIsSelected(WamTab tab) {
-    WebElement wamTab = driver.findElement(By.cssSelector(String.format(WAM_TAB_CSS_SELECTOR_FORMAT,
-                                                                        tab.getId()
+    WebElement wamTab = driver.findElement(By.cssSelector(String.format(
+        WAM_TAB_CSS_SELECTOR_FORMAT,
+        tab.getId()
     )));
     Log.log("verifyTabIsSelected", "tab with index " + tab.getId() + " exist", true);
 
@@ -92,9 +93,10 @@ public class WamPageObject extends BasePageObject {
     int rows = wamIndexRows.size();
 
     if (rows > 1) {
-      Log.log("verifyWamIndexIsNotEmpty",
-              "there are more rows in the table than just a head row (" + rows + ")",
-              true
+      Log.log(
+          "verifyWamIndexIsNotEmpty",
+          "there are more rows in the table than just a head row (" + rows + ")",
+          true
       );
     } else {
       Log.log("verifyTabIsSelected", "there is only the head row", false);
@@ -107,9 +109,10 @@ public class WamPageObject extends BasePageObject {
    */
   public void verifyWamIndexHasExactRowsNo(int expectedRowsNo) {
     wait.forElementPresent(WAM_INDEX_TABLE);
-    Assertion.assertNumber(wamIndexRows.size(),
-                           expectedRowsNo,
-                           "wam index rows equals " + expectedRowsNo
+    Assertion.assertNumber(
+        wamIndexRows.size(),
+        expectedRowsNo,
+        "wam index rows equals " + expectedRowsNo
     );
   }
 
@@ -130,14 +133,16 @@ public class WamPageObject extends BasePageObject {
     }
 
     if (result.equals(true)) {
-      Log.log("verifyWamVerticalFilterOptions",
-              "There are correct options in the vertical select box",
-              true
+      Log.log(
+          "verifyWamVerticalFilterOptions",
+          "There are correct options in the vertical select box",
+          true
       );
     } else {
-      Log.log("verifyWamVerticalFilterOptions",
-              "There is invalid option in the vertical select box",
-              false
+      Log.log(
+          "verifyWamVerticalFilterOptions",
+          "There is invalid option in the vertical select box",
+          false
       );
     }
   }
@@ -180,16 +185,18 @@ public class WamPageObject extends BasePageObject {
   }
 
   public void selectTab(WamTab tab) {
-    scrollAndClick(driver.findElement(By.cssSelector(String.format(WAM_TAB_CSS_SELECTOR_FORMAT,
-                                                                   tab.getId()
+    scrollAndClick(driver.findElement(By.cssSelector(String.format(
+        WAM_TAB_CSS_SELECTOR_FORMAT,
+        tab.getId()
     ))));
     isLoaded();
     verifyTabSelected(tab);
   }
 
   private void verifyTabSelected(WamTab tab) {
-    Assertion.assertTrue(driver.findElement(By.cssSelector(String.format(WAM_TAB_CSS_SELECTOR_FORMAT,
-                                                                         tab.getId()
+    Assertion.assertTrue(driver.findElement(By.cssSelector(String.format(
+        WAM_TAB_CSS_SELECTOR_FORMAT,
+        tab.getId()
     )))
                              .getAttribute("class")
                              .contains("icon-vertical-selected"));

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -22,7 +22,7 @@ import java.util.Locale;
 
 public class WamPageObject extends BasePageObject {
 
-  public static final int DEFAULT_WAM_INDEX_ROWS = 21;
+  public static final int DEFAULT_WAM_INDEX_ROWS = 20;
   private static final int FIRST_WAM_TAB_INDEX = 0;
   private static final By WAM_INDEX_TABLE = By.cssSelector("#wam-index table");
   private static final String WAM_TAB_CSS_SELECTOR_FORMAT = "a[data-vertical-id='%s']";
@@ -106,12 +106,13 @@ public class WamPageObject extends BasePageObject {
   /**
    * @param expectedRowsNo the number of expecting table rows
    * @desc Checks if there are as many rows in the WAM index table as we expect
+   * Adds +1 to expectedRowsNo to account for header of the table
    */
   public void verifyWamIndexHasExactRowsNo(int expectedRowsNo) {
     wait.forElementPresent(WAM_INDEX_TABLE);
     Assertion.assertNumber(
         wamIndexRows.size(),
-        expectedRowsNo,
+        expectedRowsNo + 1,
         "wam index rows equals " + expectedRowsNo
     );
   }
@@ -169,7 +170,7 @@ public class WamPageObject extends BasePageObject {
     return counter;
   }
 
-  public void verifyWamIndexPageFirstColumn(int startElement, int endElement) {
+  public void verifyWamIndexPageFirstColumnInOrder(int startElement, int endElement) {
     wait.forElementPresent(WAM_INDEX_TABLE);
     List<String> current = getCurrentIndexNo();
     for (int i = 0; i <= endElement - startElement; i++) {
@@ -203,24 +204,28 @@ public class WamPageObject extends BasePageObject {
     wait.forElementVisible(tabSelected);
   }
 
-  public void verifyLatestDateInDatePicker() {
+  /**
+   * Checks if yesterday's or current day is selected by default in date picker
+   * Yesterday clause was added due to possible lags in bulkimporter (providing data for WAM API)
+   */
+  public void verifyYesterdaysOrCurrentDateInDatePicker() {
     String currentDate = datePickerInput.getAttribute("value");
     String yesterday = DateTimeFormat.forPattern("MMMM d, yyyy")
         .withLocale(Locale.ENGLISH)
         .print(DateTime.now().minus(Period.days(1)).withZone(DateTimeZone.UTC));
-    String dayBeforeYesterday = DateTimeFormat.forPattern("MMMM d, yyyy")
+    String today = DateTimeFormat.forPattern("MMMM d, yyyy")
         .withLocale(Locale.ENGLISH)
-        .print(DateTime.now().minus(Period.days(2)).withZone(DateTimeZone.UTC));
+        .print(DateTime.now().withZone(DateTimeZone.UTC));
     Assertion.assertTrue(
-        yesterday.equals(currentDate) || dayBeforeYesterday.equals(currentDate),
-        "Current date does not match yesterday or the day before"
+        yesterday.equals(currentDate) || today.equals(currentDate),
+        "Default date does not match yesterday or today"
     );
   }
 
   public void verifyDateInDatePicker(String date) {
     isLoaded();
     String currentDate = datePickerInput.getAttribute("value");
-    Assertion.assertEquals(date, currentDate, "Current date and expected date are not the same");
+    Assertion.assertEquals(date, currentDate, "Current date and entered manually date are not the same");
   }
 
   public void typeDateInDatePicker(String date) {

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -41,8 +41,9 @@ public class WamPageTests extends NewTestTemplate {
     }
   }
 
-  @RelatedIssue(issueID = "CONCF-6", comment = "Test manually."
-                                               + " Test is failing because WAM page sometimes has wrong order due to duplicate WAM scores.")
+  @RelatedIssue(issueID = "DE-4379", comment = "If fails, notify DE team."
+                                               + "Test is failing because WAM page sometimes has wrong order due to duplicate WAM scores."
+                                               + "This is caused by remaining hive staging files during wam calculation ")
   @Test(groups = {"WamPage003", "WamPageTests", "Smoke5"})
   public void wam_003_verifyPaginationByNextButton() {
     wam.verifyWamIndexPageFirstColumn(1, 20);

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -61,6 +61,11 @@ public class WamPageTests extends NewTestTemplate {
         2 * wam.DEFAULT_WAM_INDEX_ROWS + 1,
         3 * wam.DEFAULT_WAM_INDEX_ROWS
     );
+    wam.clickNextPaginator();
+    wam.verifyWamIndexPageFirstColumnInOrder(
+        3 * wam.DEFAULT_WAM_INDEX_ROWS + 1,
+        4 * wam.DEFAULT_WAM_INDEX_ROWS
+    );
   }
 
   /**
@@ -68,12 +73,34 @@ public class WamPageTests extends NewTestTemplate {
    */
   @Test(groups = {"wamPage_005", "WamPageTests"})
   public void wam_005_testDatePicker() {
-    // test if today's or yesterday's date is set by default
-    wam.verifyYesterdaysOrCurrentDateInDatePicker();
+    wam.verifyDateInDatePicker();
     // test behaviour of selecting a date
     String date = "June 1, 2019";
     wam.typeDateInDatePicker(date);
     wam.verifyDateInDatePicker(date);
     wam.verifyWamIndexIsNotEmpty();
+  }
+
+  /**
+   * Tests order of ranks on date that was previously out of order
+   */
+  @Test(groups = {"wamPage_005", "WamPageTests"})
+  public void wam_006_testJune32019DataCorrectness() {
+    String date = "June 3, 2019";
+    wam.typeDateInDatePicker(date);
+    wam.verifyDateInDatePicker(date);
+
+    wam.verifyWamIndexPageFirstColumnInOrder(1, wam.DEFAULT_WAM_INDEX_ROWS);
+    wam.clickNextPaginator();
+    wam.verifyWamIndexPageFirstColumnInOrder(
+        wam.DEFAULT_WAM_INDEX_ROWS + 1,
+        2 * wam.DEFAULT_WAM_INDEX_ROWS
+    );
+    wam.clickNextPaginator();
+    wam.verifyWamIndexPageFirstColumnInOrder(
+        2 * wam.DEFAULT_WAM_INDEX_ROWS + 1,
+        3 * wam.DEFAULT_WAM_INDEX_ROWS
+    );
+
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -27,6 +27,7 @@ public class WamPageTests extends NewTestTemplate {
     wam.verifyTabIsSelected(WamTab.ALL);
     wam.verifyWamIndexIsNotEmpty();
     wam.verifyWamIndexHasExactRowsNo(wam.DEFAULT_WAM_INDEX_ROWS);
+    wam.verifyWamIndexPageFirstColumnInOrder(1, wam.DEFAULT_WAM_INDEX_ROWS);
   }
 
   @Test(groups = {"WamPage002", "WamPageTests"})
@@ -41,21 +42,30 @@ public class WamPageTests extends NewTestTemplate {
     }
   }
 
-  @RelatedIssue(issueID = "DE-4379", comment = "If fails, notify DE team."
-                                               + "Test is failing because WAM page sometimes has wrong order due to duplicate WAM scores."
-                                               + "This is caused by remaining hive staging files during wam calculation ")
+  /**
+   * Test pagination and if WAM ranks are displayed in order
+   */
+  @RelatedIssue(issueID = "DE-4379", comment = "If fails, notify DE team.")
   @Test(groups = {"WamPage003", "WamPageTests", "Smoke5"})
   public void wam_003_verifyPaginationByNextButton() {
-    wam.verifyWamIndexPageFirstColumn(1, 20);
+    wam.verifyWamIndexPageFirstColumnInOrder(1, wam.DEFAULT_WAM_INDEX_ROWS);
     wam.clickNextPaginator();
-    wam.verifyWamIndexPageFirstColumn(21, 40);
+    wam.verifyWamIndexPageFirstColumnInOrder(wam.DEFAULT_WAM_INDEX_ROWS + 1, 2 * wam.DEFAULT_WAM_INDEX_ROWS);
+    wam.clickNextPaginator();
+    wam.verifyWamIndexPageFirstColumnInOrder(2 * wam.DEFAULT_WAM_INDEX_ROWS + 1, 3 * wam.DEFAULT_WAM_INDEX_ROWS);
   }
 
+  /**
+   * Tests behaviour of date picker
+   */
   @Test(groups = {"wamPage_005", "WamPageTests"})
   public void wam_005_testDatePicker() {
-    wam.verifyLatestDateInDatePicker();
-    String date = "July 12, 2014";
+    // test if today's or yesterday's date is set by default
+    wam.verifyYesterdaysOrCurrentDateInDatePicker();
+    // test behaviour of selecting a date
+    String date = "June 1, 2019";
     wam.typeDateInDatePicker(date);
     wam.verifyDateInDatePicker(date);
+    wam.verifyWamIndexIsNotEmpty();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -1,5 +1,6 @@
 package com.wikia.webdriver.testcases.desktop.wampagetests;
 
+import com.wikia.webdriver.common.core.annotations.Execute;
 import com.wikia.webdriver.common.core.annotations.RelatedIssue;
 import com.wikia.webdriver.common.templates.NewTestTemplate;
 import com.wikia.webdriver.pageobjectsfactory.pageobject.wam.WamPageObject;
@@ -10,6 +11,7 @@ import org.testng.annotations.Test;
 
 import java.util.EnumSet;
 
+@Execute(onWikia = "community")
 public class WamPageTests extends NewTestTemplate {
 
   private WamPageObject wam;

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -20,6 +20,7 @@ public class WamPageTests extends NewTestTemplate {
   public void wam_000_setup() {
     wam = new WamPageObject(driver);
     wam.openWamPage(wikiCorporateURL);
+    wam.verifyIfOnWamFandomPage();
   }
 
   @Test(groups = {"WamPage001", "WamPageTests"})
@@ -37,6 +38,7 @@ public class WamPageTests extends NewTestTemplate {
 
     for (WamTab tab : EnumSet.complementOf(EnumSet.of(WamTab.ALL))) {
       wam.selectTab(tab);
+      wam.verifyIfVerticalIdSelectedInUrl(tab.getId());
       wam.verifyWamIndexIsNotEmpty();
       wam.verifyVerticalColumnValuesAreTheSame();
     }
@@ -50,9 +52,15 @@ public class WamPageTests extends NewTestTemplate {
   public void wam_003_verifyPaginationByNextButton() {
     wam.verifyWamIndexPageFirstColumnInOrder(1, wam.DEFAULT_WAM_INDEX_ROWS);
     wam.clickNextPaginator();
-    wam.verifyWamIndexPageFirstColumnInOrder(wam.DEFAULT_WAM_INDEX_ROWS + 1, 2 * wam.DEFAULT_WAM_INDEX_ROWS);
+    wam.verifyWamIndexPageFirstColumnInOrder(
+        wam.DEFAULT_WAM_INDEX_ROWS + 1,
+        2 * wam.DEFAULT_WAM_INDEX_ROWS
+    );
     wam.clickNextPaginator();
-    wam.verifyWamIndexPageFirstColumnInOrder(2 * wam.DEFAULT_WAM_INDEX_ROWS + 1, 3 * wam.DEFAULT_WAM_INDEX_ROWS);
+    wam.verifyWamIndexPageFirstColumnInOrder(
+        2 * wam.DEFAULT_WAM_INDEX_ROWS + 1,
+        3 * wam.DEFAULT_WAM_INDEX_ROWS
+    );
   }
 
   /**


### PR DESCRIPTION
Switches WAM tests to execute on fandom domain instead of wikia.org
Adds simple URL checks (fandom WAM, selected vertical)  and updates date picker test to take into account 0-3 bulkimporter lag.
Adds more checks for order of entries by rank (as it's failing on subpages), also on specific failing date.