### PR TITLE
Update Infobox1 invocation with internal fandom.com link

### DIFF
--- a/src/test/resources/TextFiles/Infobox1_Invocation
+++ b/src/test/resources/TextFiles/Infobox1_Invocation
@@ -3,7 +3,7 @@
 1=[[File:default_Image009.jpg|thumb|QAWebdriverCaption1]]
 </tabber>Mężczyzna|Gatunek = ''Niedźwiedź'' [[Category:VEINFOBOX]]|Kolor Kostiumu = *BrązowyBrązowyBrązowy BrązowyBrązowyBrązowy BrązowyBrązowyBrązowy
 *Fiolet
-#Malina|Nowsza wersja = [[File:The Hobbit|thumb|330x330px]] [[Toy Freddy]]|Straty = [[Niektóre]] Fragmenty Ciała http://www.wikia.com/Fandom|Rola = <ref>This is first reference</ref>|Atrybut = *Czarny Cylinder i Mikrofon
+#Malina|Nowsza wersja = [[File:The Hobbit|thumb|330x330px]] [[Toy Freddy]]|Straty = [[Niektóre]] Fragmenty Ciała http://www.fandom.com|Rola = <ref>This is first reference</ref>|Atrybut = *Czarny Cylinder i Mikrofon
 *Truskawki
 
 #Ziemniak

--- a/src/test/resources/TextFiles/Infobox1_Invocation
+++ b/src/test/resources/TextFiles/Infobox1_Invocation
@@ -3,7 +3,7 @@
 1=[[File:default_Image009.jpg|thumb|QAWebdriverCaption1]]
 </tabber>Mężczyzna|Gatunek = ''Niedźwiedź'' [[Category:VEINFOBOX]]|Kolor Kostiumu = *BrązowyBrązowyBrązowy BrązowyBrązowyBrązowy BrązowyBrązowyBrązowy
 *Fiolet
-#Malina|Nowsza wersja = [[File:The Hobbit|thumb|330x330px]] [[Toy Freddy]]|Straty = [[Niektóre]] Fragmenty Ciała http://www.fandom.com|Rola = <ref>This is first reference</ref>|Atrybut = *Czarny Cylinder i Mikrofon
+#Malina|Nowsza wersja = [[File:The Hobbit|thumb|330x330px]] [[Toy Freddy]]|Straty = [[Niektóre]] Fragmenty Ciała https://www.fandom.com|Rola = <ref>This is first reference</ref>|Atrybut = *Czarny Cylinder i Mikrofon
 *Truskawki
 
 #Ziemniak


### PR DESCRIPTION
Since `www.wikia.com/Fandom` has been changed to `www.fandom.com` one PortableInfobox test is failing.

@Wikia/iwing