### PR TITLE
Ignoring ANIME vertical in WAM tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -125,8 +125,8 @@ public class WamPageObject extends BasePageObject {
 
     for (WebElement e : wamTabs) {
       String optionValue = e.getAttribute("data-vertical-id");
-
-      if (!WamTab.contains(optionValue)) {
+      // ANIME value "8" corresponds to Anime. To be removed once we will decide to start testing anime tab as well
+      if (!WamTab.contains(optionValue) && !optionValue.toLowerCase().trim().equals("8")) {
         // once an option is not in our ENUM the test is failed
         result = false;
         break;

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamPageObject.java
@@ -99,7 +99,25 @@ public class WamPageObject extends BasePageObject {
           true
       );
     } else {
-      Log.log("verifyTabIsSelected", "there is only the head row", false);
+      Log.log("verifyWamIndexIsNotEmpty", "there is only the head row", false);
+    }
+  }
+
+  /**
+   * @desc Checks if the table for the vertical tab is empty. Needed to monitor data in ANIME vertical
+   */
+  public void verifyWamIndexIsEmpty() {
+    wait.forElementPresent(WAM_INDEX_TABLE);
+    int rows = wamIndexRows.size();
+    if (rows == 2 && wamIndexRows.get(1).getText().startsWith("The wiki you searched for is not in the top 5000")) {
+      Log.log(
+          "verifyWamIndexIsEmpty",
+          "WamTab for this vertical is empty, as it should be",
+          true
+      );
+    } else {
+      Log.log("verifyWamIndexIsEmpty",
+              "Rows in this tab started to appear! ANIME vertical is probably filled with data!", false);
     }
   }
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamTab.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamTab.java
@@ -8,8 +8,9 @@ public enum WamTab {
   COMICS(4, "COMICS"),
   LIFESTYLE(5, "LIFESTYLE"),
   MUSIC(6, "MUSIC"),
-  MOVIES(7, "MOVIES"),
-  ANIME(8, "ANIME");
+  MOVIES(7, "MOVIES");
+  // ANIME the line below should be uncommented somewhere in 2020 when Anime data will start to appear
+  //ANIME(8, "ANIME");
 
   private final int verticalId;
 

--- a/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamTab.java
+++ b/src/test/java/com/wikia/webdriver/pageobjectsfactory/pageobject/wam/WamTab.java
@@ -8,9 +8,8 @@ public enum WamTab {
   COMICS(4, "COMICS"),
   LIFESTYLE(5, "LIFESTYLE"),
   MUSIC(6, "MUSIC"),
-  MOVIES(7, "MOVIES");
-  // ANIME the line below should be uncommented somewhere in 2020 when Anime data will start to appear
-  //ANIME(8, "ANIME");
+  MOVIES(7, "MOVIES"),
+  ANIME(8, "ANIME");
 
   private final int verticalId;
 

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -34,13 +34,14 @@ public class WamPageTests extends NewTestTemplate {
 
   @Test
   public void wam_002_verifyFilteringByVertical() {
-    // WARNING! There are some hardcoded instructions which aim was to make sure that the test will not fail on Anime tab
-    // when the Anime tab will start to be filled with data, we should remove those fragments
-    // Seek for "Anime" in the tests to find those instructions
     wam.verifyWamIndexIsNotEmpty();
     wam.verifyWamVerticalFilterOptions();
 
     for (WamTab tab : EnumSet.complementOf(EnumSet.of(WamTab.ALL))) {
+      // ignore ANIME vertical
+      // delete the line below when ANIME wertical will start to be filled withd data!
+      if (tab.getId() == 8)
+        continue;
       wam.selectTab(tab);
       wam.verifyIfVerticalIdSelectedInUrl(tab.getId());
       wam.verifyWamIndexIsNotEmpty();
@@ -106,5 +107,16 @@ public class WamPageTests extends NewTestTemplate {
         3 * wam.DEFAULT_WAM_INDEX_ROWS
     );
 
+  }
+
+  @Test
+  @RelatedIssue(issueID = "DE-4569", comment = "If fails, remove the tests and include ANIME vertical in test 002.")
+  /**
+   * The goal of this test is to alert the DE team when Anime verticall will start to be filled with data.
+   * If the test fails, we need to changge the tests to start monitoring if this vertical is filled with data.
+   */
+  public void wam_007_checkIfAnimeAlreadyIsFilled() {
+    wam.selectTab(WamTab.ANIME);
+    wam.verifyWamIndexIsEmpty();
   }
 }

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -34,6 +34,9 @@ public class WamPageTests extends NewTestTemplate {
 
   @Test
   public void wam_002_verifyFilteringByVertical() {
+    // WARNING! There are some hardcoded instructions which aim was to make sure that the test will not fail on Anime tab
+    // when the Anime tab will start to be filled with data, we should remove those fragments
+    // Seek for "Anime" in the tests to find those instructions
     wam.verifyWamIndexIsNotEmpty();
     wam.verifyWamVerticalFilterOptions();
 


### PR DESCRIPTION
Anime vertical in WAM is not yet filled with data and that's by design.
Still, tests failed due to lack of data in this vertical.
In this commit we make sure that tests ignore Anime vertical.