### PR TITLE
ANIME tab is included in WAM tests

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/wampagetests/WamPageTests.java
@@ -38,10 +38,6 @@ public class WamPageTests extends NewTestTemplate {
     wam.verifyWamVerticalFilterOptions();
 
     for (WamTab tab : EnumSet.complementOf(EnumSet.of(WamTab.ALL))) {
-      // ignore ANIME vertical
-      // delete the line below when ANIME wertical will start to be filled withd data!
-      if (tab.getId() == 8)
-        continue;
       wam.selectTab(tab);
       wam.verifyIfVerticalIdSelectedInUrl(tab.getId());
       wam.verifyWamIndexIsNotEmpty();
@@ -107,16 +103,5 @@ public class WamPageTests extends NewTestTemplate {
         3 * wam.DEFAULT_WAM_INDEX_ROWS
     );
 
-  }
-
-  @Test
-  @RelatedIssue(issueID = "DE-4569", comment = "If fails, remove the tests and include ANIME vertical in test 002.")
-  /**
-   * The goal of this test is to alert the DE team when Anime verticall will start to be filled with data.
-   * If the test fails, we need to changge the tests to start monitoring if this vertical is filled with data.
-   */
-  public void wam_007_checkIfAnimeAlreadyIsFilled() {
-    wam.selectTab(WamTab.ANIME);
-    wam.verifyWamIndexIsEmpty();
   }
 }


### PR DESCRIPTION
Previously, WAM tab was discarded from the test as the data was empty (by design).
Now the tests check if the data is present in this tab as well