### PR TITLE
DE-5225 | muppet to sydneybuses

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
@@ -8,7 +8,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.analytics.AnalyticsPage
 
 import org.testng.annotations.Test;
 
-@Execute(onWikia = "muppet")
+@Execute(onWikia = "sydneybuses")
 @Test(groups = {"DataEngineering", "AnalyticsPageTests"})
 public class AnalyticsPageTests extends NewTestTemplate {
 


### PR DESCRIPTION
## Description
Tested wikia (muppets) was moved to UCP and it caused tests to fail. Now testing on sydneybuses.

## Ticket
https://wikia-inc.atlassian.net/browse/DE-5225