### PR TITLE
DE-5334 | SpecialAnalytics tests are failing

### DIFF
--- a/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
@@ -8,7 +8,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.analytics.AnalyticsPage
 
 import org.testng.annotations.Test;
 
-@Execute(onWikia = "nonenwikiwithemptydiscussions")
+@Execute(onWikia = "community")
 @Test(groups = {"DataEngineering", "AnalyticsPageTests"})
 public class AnalyticsPageTests extends NewTestTemplate {
 

--- a/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
+++ b/src/test/java/com/wikia/webdriver/testcases/desktop/analyticstests/AnalyticsPageTests.java
@@ -8,7 +8,7 @@ import com.wikia.webdriver.pageobjectsfactory.pageobject.analytics.AnalyticsPage
 
 import org.testng.annotations.Test;
 
-@Execute(onWikia = "sydneybuses")
+@Execute(onWikia = "nonenwikiwithemptydiscussions")
 @Test(groups = {"DataEngineering", "AnalyticsPageTests"})
 public class AnalyticsPageTests extends NewTestTemplate {
 


### PR DESCRIPTION
## Ticket
https://wikia-inc.atlassian.net/browse/DE-5334

## Description
SpecialAnalytics page tests are failing because `sydneybuses` wiki was moved to UCP. Changed to `community`.